### PR TITLE
fix: resolve 3 ccs-recap bugs (ref #4)

### DIFF
--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -3273,9 +3273,9 @@ _ccs_recap_collect() {
           pending)      (( td_pending++ )); pending_items+=("$t_content") ;;
           in_progress)  (( td_ip++ )); pending_items+=("$t_content") ;;
         esac
-      done < <(jq -r 'select(.type == "assistant") | .message.content[]? |
+      done < <(jq -s -r '[.[] | select(.type == "assistant") | .message.content[]? |
         select(.type == "tool_use" and .name == "TodoWrite") |
-        .input.todos[]? | [.status, .content] | @tsv' "$jsonl" 2>/dev/null | tail -20)
+        .input.todos] | last // [] | .[]? | [.status, .content] | @tsv' "$jsonl" 2>/dev/null)
 
       # Last exchange preview
       local preview=""
@@ -3394,7 +3394,7 @@ _ccs_recap_collect() {
       topic=$(_ccs_topic_from_jsonl "$jsonl")
       dl_text=$(jq -r 'select(.type == "user" and .isMeta != true) |
         .message.content | if type == "string" then . else "" end' "$jsonl" 2>/dev/null |
-        grep -iE '(deadline|before|週|月底|by |due|urgent|ASAP|趕|今天|明天|後天)' |
+        grep -iE '(deadline|due|urgent|ASAP|月底|趕|今天|明天|後天|這週|下週|本週|by (monday|tuesday|wednesday|thursday|friday|tomorrow|end of))' |
         head -1 | sed 's/^[[:space:]]*//' | cut -c1-80)
       if [ -n "$dl_text" ]; then
         deadlines_json=$(echo "$deadlines_json" | jq \
@@ -3527,7 +3527,7 @@ _ccs_recap_terminal() {
 
   # Git
   printf "\n${C_BOLD}── Git Activity ──${C_RESET}\n"
-  echo "$json" | jq -r '.projects[] |
+  echo "$json" | jq -r '.projects[] | select(.git.branch != null) |
     "  " + .name + " (" + .git.branch + ")  " +
     (.git.commits_in_period|tostring) + " commits, " +
     (.git.uncommitted|tostring) + " uncommitted" +
@@ -3613,7 +3613,7 @@ _ccs_recap_md() {
   # Git
   echo "## Git Activity"
   echo ""
-  echo "$json" | jq -r '.projects[] |
+  echo "$json" | jq -r '.projects[] | select(.git.branch != null) |
     "- **" + .name + "** (" + .git.branch + ") — " +
     (.git.commits_in_period|tostring) + " commits, " +
     (.git.uncommitted|tostring) + " uncommitted" +


### PR DESCRIPTION
## Summary

- **Todos 重複**: 改用 `jq -s` slurp + `last` 只取最後一次 TodoWrite snapshot，避免多次呼叫產生重複 pending items
- **Git null 顯示**: 非 git 專案加 `select(.git.branch != null)` 過濾，terminal/md 不再顯示 `null commits`
- **Deadlines false positive**: 移除過廣的 `before`、`by `、`週`，改用限定性更強的組合 pattern

ref #4

## Review Report

### Changes Analysis

| File | Lines Changed | Impact |
|------|:---:|--------|
| ccs-dashboard.sh | +5 / -5 | \`_ccs_recap_collect\`, \`_ccs_recap_terminal\`, \`_ccs_recap_md\` |

### Bug 1 — Todos 重複 (L3276-3278)

**Root cause**: jq 逐行處理 JSONL，所有 TodoWrite 呼叫的 todos 混合後 `tail -20` 無法去重。TodoWrite 每次呼叫都是完整 snapshot，多次呼叫 = 重複累積。

**Fix**: `jq -s` slurp 整個 JSONL → 收集所有 TodoWrite 的 `.input.todos` 成陣列 → `last` 取最後一次 → 展開。

**Trade-off**: `-s` 讀入整個檔案到記憶體。JSONL 檔案通常 < 10MB，可接受。若日後遇到超大 session 可改用 `tac | jq` 反向讀取。

**Verification**: 模擬 2 次 TodoWrite（第一次 2 items、第二次 3 items），確認只輸出最後一次的 3 items。

### Bug 2 — Git null 顯示 (L3530, L3616)

**Root cause**: 非 git 專案 `git_json='{}'`，jq 存取 `.git.branch` 等欄位得到 null，terminal 顯示 `null commits`。

**Fix**: terminal 和 md 兩處 jq filter 都加 `select(.git.branch != null)`。

**Verification**: 模擬含 git 和非 git 兩個專案的 JSON，確認非 git 專案被過濾。

### Bug 3 — Deadlines false positive (L3397)

**Root cause**: `before`、`by `、`週` 等 keyword 太廣泛，正常技術討論（"before running the test"、"by using this method"）會觸發。

**Fix**:
- 移除：`before`、`by `（後面無限定）、`週`（匹配「上週」等回顧語）
- 保留：`deadline`、`due`、`urgent`、`ASAP`、`月底`、`趕`、`今天`、`明天`、`後天`
- 新增：`這週|下週|本週`、`by (weekday|tomorrow|end of)`

**Verification**: 8 行測試句中正確匹配 5 行，3 行 false positive 不再觸發。

### Risk Assessment

- **Low risk**: 所有修改都在 recap 輸出路徑，不影響 ccs-dashboard 核心功能
- **Backward compatible**: JSON schema 不變，只影響數據收集邏輯和顯示過濾

## Test plan

- [x] `bash -n` 語法檢查通過
- [x] Bug 1: 模擬多次 TodoWrite，確認只取最後 snapshot
- [x] Bug 2: 模擬 git/非 git 混合 JSON，確認過濾正確
- [x] Bug 3: 模擬 8 種 deadline 句型，確認 false positive 消除
- [ ] 實際執行 `ccs-recap` 觀察輸出正確性

🤖 Generated with [Claude Code](https://claude.ai/code)