### PR TITLE
fix: path encoding mismatch with Claude Code project dirs

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -14,6 +14,7 @@ _CCS_HOME_ENCODED=$(echo "$HOME" | sed 's/\//-/g')
 #   _ccs_conversation_md    — filtered conversation pairs as markdown
 #   _ccs_recent_files_md    — recent file operations from JSONL
 #   _ccs_todos_md           — TodoWrite items from JSONL
+#   _ccs_find_project_dir    — find encoded project dir from filesystem path
 #   _ccs_resolve_project_path — resolve JSONL dir name → filesystem path
 #   _ccs_get_boot_epoch     — system boot time as epoch
 #   _ccs_detect_crash       — detect crash-interrupted sessions
@@ -158,9 +159,8 @@ _ccs_resolve_jsonl() {
       search_dir="$projects_dir"
     else
       local encoded_dir
-      encoded_dir=$(pwd | sed 's|/|-|g')
+      encoded_dir=$(_ccs_find_project_dir "$(pwd)") || return 1
       search_dir="$projects_dir/$encoded_dir"
-      [ ! -d "$search_dir" ] && return 1
     fi
     find "$search_dir" -maxdepth 2 -name "*.jsonl" ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
       | sort -rn | head -1 | cut -f2
@@ -711,6 +711,44 @@ _ccs_detect_crash() {
       _crash_out["$sid"]="high:non-reboot-idle"
     fi
   done
+}
+
+# ── Helper: find encoded project dir from filesystem path ──
+# Given an absolute filesystem path, find the matching directory in ~/.claude/projects/.
+# Claude Code's encoding is not a simple sed — underscores, dots, etc. get transformed.
+# Strategy: normalize both sides (replace /._  with -, collapse runs, strip leading -)
+# and compare. Returns the actual directory name (not full path).
+_ccs_find_project_dir() {
+  local target="$1"
+  local projects_dir="$HOME/.claude/projects"
+  [ -z "$target" ] && return 1
+
+  # 1. Try exact match (naive slash-to-dash)
+  local exact
+  exact=$(printf '%s' "$target" | sed 's|/|-|g')
+  [ -d "$projects_dir/$exact" ] && {
+    echo "$exact"
+    return 0
+  }
+
+  # 2. Fuzzy match: normalize both sides (replace /._  with -, collapse, strip leading -)
+  local norm_target
+  norm_target=$(printf '%s' "$target" \
+    | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+
+  local d name norm_name
+  for d in "$projects_dir"/*/; do
+    [ -d "$d" ] || continue
+    name="${d%/}"
+    name="${name##*/}"
+    norm_name=$(printf '%s' "$name" \
+      | sed 's/--*/-/g; s/^-//')
+    [ "$norm_name" = "$norm_target" ] && {
+      echo "$name"
+      return 0
+    }
+  done
+  return 1
 }
 
 # ── Helper: resolve JSONL directory name → actual filesystem path ──

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -40,15 +40,13 @@ HELP
   local handoff_dir="$HOME/docs/tmp/handoff"
   mkdir -p "$handoff_dir"
 
-  # Find matching project dir in .claude/projects
+  # Find matching project dir in .claude/projects (fuzzy match)
   local encoded_dir
-  encoded_dir=$(echo "$project_dir" | sed 's|/|-|g')
-  local session_dir="$projects_dir/$encoded_dir"
-
-  if [ ! -d "$session_dir" ]; then
+  encoded_dir=$(_ccs_find_project_dir "$project_dir") || {
     echo "No Claude sessions found for: $project_dir"
     return 1
-  fi
+  }
+  local session_dir="$projects_dir/$encoded_dir"
 
   # Collect open (non-archived) sessions from last 7 days, sorted by recency
   local open_sessions=()
@@ -278,7 +276,7 @@ HELP
   project=$(echo "$dir" | sed "s/^${_CCS_HOME_ENCODED}-*//; s/-/\//g")
   [ -z "$project" ] && project="~(home)"
   # Reconstruct project_dir from encoded dir name
-  project_dir=$(echo "$dir" | sed 's/-/\//g')
+  project_dir=$(_ccs_resolve_project_path "$dir" 2>/dev/null)
   [ ! -d "$project_dir" ] && project_dir=""
 
   # ── Git context (if project dir exists) ──


### PR DESCRIPTION
## Summary

- 新增 `_ccs_find_project_dir` helper（exact match 優先，fuzzy match fallback）
- 修正 `ccs-handoff`、`ccs-resume-prompt`、`_ccs_resolve_jsonl` 不再用 naive `sed 's|/|-|g'`
- 含底線或隱藏目錄（如 `.worktrees`）的路徑現在能正確找到 session

Closes #25

## Test plan

- [x] 正常路徑（無底線）→ exact match
- [x] 含底線路徑 vs 含連字號路徑 → 各自 exact match，不碰撞
- [x] 含底線 + 隱藏目錄的 worktree 路徑 → fuzzy match 成功（issue #25 案例）
- [x] 使用者手動確認所有專案都能正常解析

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)