### PR TITLE
feat: add ccs-project per-project insight report

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ccs-dashboard has two layers:
 | `ccs-dispatch` | Dispatch a task to a new Claude Code session (async or sync) |
 | `ccs-jobs` | View dispatch job history and results |
 | `ccs-review` | Session review report — stats, conversation, LLM summary (md/html/pdf) |
+| `ccs-project` | Per-project insight report — cost, features, rhythm, code changes (md/html) |
 
 All commands support both **Terminal ANSI** and **Markdown** (`--md`) output modes.
 
@@ -205,8 +206,9 @@ ccs-ops.sh         # ccs-crash, ccs-recap, ccs-checkpoint
 ccs-health.sh      # Session health scoring
 ccs-dispatch.sh    # ccs-dispatch, ccs-jobs
 ccs-review.sh      # ccs-review — session review report
+ccs-project.sh     # ccs-project — per-project insight report
 install.sh         # Installer (deps check + bashrc + skill symlink)
-templates/         # Jinja2 HTML templates for ccs-review
+templates/         # Jinja2 HTML templates for ccs-review, ccs-project
 skills/            # Claude Code skill — primary interface
 docs/              # CLI command reference + archived design docs
 ```

--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -26,6 +26,7 @@ source "${BASH_SOURCE[0]%/*}/ccs-feature.sh"
 source "${BASH_SOURCE[0]%/*}/ccs-ops.sh"
 source "${BASH_SOURCE[0]%/*}/ccs-dispatch.sh"
 source "${BASH_SOURCE[0]%/*}/ccs-review.sh"
+source "${BASH_SOURCE[0]%/*}/ccs-project.sh"
 
 # ── ccs-status (ccs) — unified session dashboard ──
 ccs-status() {

--- a/ccs-project-render.py
+++ b/ccs-project-render.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""ccs-project-render.py — Render project report JSON to HTML via Jinja2.
+
+Usage: echo '<project-json>' | python3 ccs-project-render.py
+
+Reads JSON from stdin, outputs HTML to stdout.
+"""
+import sys
+import json
+from pathlib import Path
+
+try:
+    from jinja2 import Environment, FileSystemLoader
+except ImportError:
+    print("Error: jinja2 not installed. Run: pip3 install jinja2", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    script_dir = Path(__file__).parent
+    template_dir = script_dir / "templates"
+
+    env = Environment(
+        loader=FileSystemLoader(str(template_dir)),
+        autoescape=True,
+    )
+
+    data = json.load(sys.stdin)
+    template = env.get_template("project.html")
+    html = template.render(**data)
+
+    sys.stdout.write(html)
+
+
+if __name__ == "__main__":
+    main()

--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -485,3 +485,218 @@ _ccs_project_json() {
       sessions: $sessions
     }'
 }
+
+# ── Helper: render project JSON as markdown ──
+# Reads JSON from stdin
+_ccs_project_md() {
+  local json
+  json=$(cat)
+
+  local project_name period_from period_to total_days active_days session_count
+  project_name=$(echo "$json" | jq -r '.project_name')
+  period_from=$(echo "$json" | jq -r '.period.from')
+  period_to=$(echo "$json" | jq -r '.period.to')
+  total_days=$(echo "$json" | jq '.period.total_days')
+  active_days=$(echo "$json" | jq '.period.active_days')
+  session_count=$(echo "$json" | jq '.period.session_count')
+
+  local truncated truncated_msg=""
+  truncated=$(echo "$json" | jq '.period.truncated')
+  if [ "$truncated" = "true" ]; then
+    local truncated_total
+    truncated_total=$(echo "$json" | jq '.period.truncated_total')
+    truncated_msg=" _(顯示最近 ${session_count} 個，共 ${truncated_total} 個)_"
+  fi
+
+  local est_hours avg_turns total_rounds
+  est_hours=$(echo "$json" | jq '.cost.estimated_hours')
+  avg_turns=$(echo "$json" | jq '.cost.avg_turns_per_session')
+  total_rounds=$(echo "$json" | jq '.cost.total_rounds')
+
+  echo "# Project Report: ${project_name}"
+  echo ""
+  echo "**期間：** ${period_from} ~ ${period_to}（${total_days} 天）"
+  echo "**Session 數：** ${session_count}${truncated_msg} | **活躍天：** ${active_days} | **估算工時：** ${est_hours}h"
+  echo ""
+
+  # Features
+  local feat_count
+  feat_count=$(echo "$json" | jq '.features | length')
+  if [ "$feat_count" -gt 0 ]; then
+    echo "## 功能進度"
+    echo ""
+    echo "$json" | jq -r '.features[] |
+      (if .status == "completed" then "✅"
+       elif .status == "in_progress" then "🔵"
+       elif .status == "stale" then "🟡"
+       else "⚪" end) as $icon |
+      "\($icon) \(.branch // .id) — \(.label) (\(.todos_done)/\(.todos_total) todos)"'
+    echo ""
+  fi
+
+  # Cost
+  echo "## 投入成本"
+  echo ""
+  echo "- 總 turns: ${total_rounds}（平均 ${avg_turns}/session）"
+  echo "- 估算工時: ${est_hours}h（${session_count} sessions）"
+  echo ""
+
+  # Rhythm
+  local longest_streak longest_gap avg_per_day
+  longest_streak=$(echo "$json" | jq '.rhythm.longest_streak')
+  longest_gap=$(echo "$json" | jq '.rhythm.longest_gap')
+  avg_per_day=$(echo "$json" | jq '.rhythm.avg_sessions_per_day')
+
+  echo "## 開發節奏"
+  echo ""
+  echo "- 最長連續: ${longest_streak} 天 | 最長中斷: ${longest_gap} 天"
+  echo "- 平均: ${avg_per_day} sessions/天"
+  echo ""
+
+  # Code changes
+  local lines_added lines_deleted
+  lines_added=$(echo "$json" | jq '.code_changes.lines_added')
+  lines_deleted=$(echo "$json" | jq '.code_changes.lines_deleted')
+
+  echo "## 程式碼變動"
+  echo ""
+  echo "- +${lines_added} / -${lines_deleted} 行"
+  echo ""
+
+  local branch_count
+  branch_count=$(echo "$json" | jq '.code_changes.by_branch | length')
+  if [ "$branch_count" -gt 0 ]; then
+    echo "$json" | jq -r '.code_changes.by_branch[] |
+      "- \(.branch) (\(.commits) commits): \(.summary)"'
+    echo ""
+  fi
+
+  local top_count
+  top_count=$(echo "$json" | jq '.code_changes.top_files | length')
+  if [ "$top_count" -gt 0 ]; then
+    echo "**修改最多的檔案：**"
+    echo "$json" | jq -r '.code_changes.top_files[:10][] | "- \(.path) (\(.changes)x)"'
+    echo ""
+  fi
+
+  # Insights
+  local has_insights
+  has_insights=$(echo "$json" | jq '.insights != null')
+  if [ "$has_insights" = "true" ]; then
+    echo "## 洞察"
+    echo ""
+    echo "$json" | jq -r '.insights.health_summary // empty'
+    echo ""
+    local issues_count
+    issues_count=$(echo "$json" | jq '.insights.recurring_issues | length // 0')
+    if [ "$issues_count" -gt 0 ]; then
+      echo "**重複問題：**"
+      echo "$json" | jq -r '.insights.recurring_issues[]? | "- \(.)"'
+      echo ""
+    fi
+    local suggestions_count
+    suggestions_count=$(echo "$json" | jq '.insights.suggestions | length // 0')
+    if [ "$suggestions_count" -gt 0 ]; then
+      echo "**建議：**"
+      echo "$json" | jq -r '.insights.suggestions[]? | "- \(.)"'
+      echo ""
+    fi
+  fi
+
+  # Session list
+  echo "## Session 列表"
+  echo ""
+  echo "$json" | jq -r '.sessions[] |
+    "- [\(.sid)] \(.date) — \(.topic) (\(.turns) turns, \(.duration_min)min)"'
+}
+
+# ── CLI entry point ──
+ccs-project() {
+  if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    cat <<'HELP'
+ccs-project — per-project insight report
+[personal tool, not official Claude Code]
+
+Usage:
+  ccs-project                         Report for current directory's project
+  ccs-project /path/to/repo           Report for specified project
+  ccs-project --since 2026-03-01      Limit time range
+  ccs-project --format html -o ./     Output as HTML
+
+Options:
+  --project PATH        Explicit project path (alternative to positional arg)
+  --since DATE          Start date (YYYY-MM-DD)
+  --until DATE          End date (YYYY-MM-DD, default: today)
+  --format md|html|json Output format (default: md)
+  -o, --output DIR      Output directory for html
+  --no-insights         Skip LLM insights cache lookup
+
+Auto-truncation: max 50 sessions or 90 days (whichever is stricter).
+HELP
+    return 0
+  fi
+
+  local project_path="" format="md" output_dir="" since="" until_date=""
+  local no_insights=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project) project_path="$2"; shift 2 ;;
+      --since) since="$2"; shift 2 ;;
+      --until) until_date="$2"; shift 2 ;;
+      --format) format="$2"; shift 2 ;;
+      -o|--output) output_dir="$2"; shift 2 ;;
+      --no-insights) no_insights=true; shift ;;
+      -*) echo "ccs-project: unknown option: $1" >&2; return 1 ;;
+      *) project_path="$1"; shift ;;
+    esac
+  done
+
+  # Resolve project path → encoded dir name
+  if [ -z "$project_path" ]; then
+    project_path=$(pwd)
+  fi
+  project_path=$(realpath "$project_path" 2>/dev/null || echo "$project_path")
+
+  local encoded_dir
+  encoded_dir=$(_ccs_find_project_dir "$project_path")
+  if [ -z "$encoded_dir" ]; then
+    echo "ccs-project: no sessions found for $project_path" >&2
+    return 1
+  fi
+
+  # Build JSON
+  local project_json
+  project_json=$(_ccs_project_json "$encoded_dir" "$since" "$until_date")
+
+  if $no_insights; then
+    project_json=$(echo "$project_json" | jq '.insights = null')
+  fi
+
+  case "$format" in
+    json)
+      echo "$project_json"
+      ;;
+    md)
+      echo "$project_json" | _ccs_project_md
+      ;;
+    html)
+      local script_dir="${BASH_SOURCE[0]%/*}"
+      local html
+      html=$(echo "$project_json" | python3 "$script_dir/ccs-project-render.py")
+      if [ -n "$output_dir" ]; then
+        local project_name
+        project_name=$(echo "$project_json" | jq -r '.project_name')
+        local outfile="${output_dir}/${project_name}-project-report.html"
+        echo "$html" > "$outfile"
+        echo "ccs-project: written to $outfile"
+      else
+        echo "$html"
+      fi
+      ;;
+    *)
+      echo "ccs-project: unknown format: $format" >&2
+      return 1
+      ;;
+  esac
+}

--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -1,0 +1,487 @@
+#!/usr/bin/env bash
+# ccs-project.sh — Per-project insight report
+# Part of ccs-dashboard. Sourced by ccs-dashboard.sh automatically.
+#
+# Functions:
+#   _ccs_project_collect     — collect session JSONLs for a project
+#   _ccs_project_path_to_dir — resolve filesystem path -> encoded dir name
+#   _ccs_project_json        — build project report JSON
+#   _ccs_project_md          — render project JSON as markdown
+#   ccs-project              — CLI entry point
+#
+# Depends on ccs-core.sh:
+#   _ccs_find_project_dir, _ccs_resolve_project_path,
+#   _ccs_session_stats, _ccs_topic_from_jsonl, _ccs_data_dir
+# Depends on ccs-feature.sh:
+#   features.jsonl (read only)
+
+# ── Constants ──
+_CCS_PROJECT_MAX_SESSIONS=50
+_CCS_PROJECT_MAX_DAYS=90
+
+# ── Helper: collect session JSONLs for a project ──
+# Args: encoded_dir_name [since_date] [until_date]
+# Output: one JSONL path per line, sorted by mtime descending, auto-truncated
+_ccs_project_collect() {
+  local encoded_dir="$1"
+  local since="${2:-}"
+  local until_date="${3:-}"
+  local projects_dir="${CCS_PROJECTS_DIR:-$HOME/.claude/projects}"
+  local target_dir="$projects_dir/$encoded_dir"
+
+  [ -d "$target_dir" ] || return 1
+
+  # Collect all JSONLs, sorted by mtime descending
+  local -a all_files=()
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    all_files+=("${line#*$'\t'}")
+  done < <(find "$target_dir" -maxdepth 1 -name "*.jsonl" \
+    ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
+    | sort -rn)
+
+  [ ${#all_files[@]} -eq 0 ] && return 0
+
+  # Apply date filters
+  local since_epoch=0 until_epoch=999999999999
+  if [ -n "$since" ]; then
+    since_epoch=$(date -d "$since" +%s 2>/dev/null || echo 0)
+  fi
+  if [ -n "$until_date" ]; then
+    until_epoch=$(date -d "$until_date 23:59:59" +%s 2>/dev/null || echo 999999999999)
+  fi
+
+  # Auto-truncation: max days (from now)
+  local max_days_epoch
+  max_days_epoch=$(date -d "$_CCS_PROJECT_MAX_DAYS days ago" +%s 2>/dev/null)
+
+  # Use the stricter of since_epoch and max_days_epoch
+  if [ "$max_days_epoch" -gt "$since_epoch" ] && [ -z "$since" ]; then
+    since_epoch=$max_days_epoch
+  fi
+
+  local -a filtered=()
+  local f mtime
+  for f in "${all_files[@]}"; do
+    mtime=$(stat -c "%Y" "$f" 2>/dev/null || echo 0)
+    if [ "$mtime" -ge "$since_epoch" ] && [ "$mtime" -le "$until_epoch" ]; then
+      filtered+=("$f")
+    fi
+    # Auto-truncation: max sessions
+    [ ${#filtered[@]} -ge $_CCS_PROJECT_MAX_SESSIONS ] && break
+  done
+
+  printf '%s\n' "${filtered[@]}"
+}
+
+# ── Helper: aggregate cost stats from file list on stdin ──
+# Input: one JSONL path per line on stdin
+# Output: JSON with session_count, total_rounds, total_duration_min, estimated_hours, avg_turns_per_session
+_ccs_project_cost_from_files() {
+  local total_rounds=0 total_duration=0 total_chars=0 total_tokens=0
+  local session_count=0
+  local -a active_dates=()
+
+  while IFS= read -r jsonl_file; do
+    [ -z "$jsonl_file" ] && continue
+    session_count=$((session_count + 1))
+
+    local stats
+    stats=$(_ccs_session_stats "$jsonl_file")
+
+    total_rounds=$(( total_rounds + $(echo "$stats" | jq '.rounds') ))
+    total_duration=$(( total_duration + $(echo "$stats" | jq '.time_range.duration_min') ))
+    total_chars=$(( total_chars + $(echo "$stats" | jq '.char_count') ))
+    total_tokens=$(( total_tokens + $(echo "$stats" | jq '.token_estimate') ))
+
+    local session_date
+    session_date=$(echo "$stats" | jq -r '.time_range.start' | cut -c1-10)
+    [ -n "$session_date" ] && [ "$session_date" != "null" ] && active_dates+=("$session_date")
+  done
+
+  local estimated_hours
+  estimated_hours=$(awk "BEGIN {printf \"%.1f\", $total_duration / 60}")
+
+  local avg_turns=0
+  [ "$session_count" -gt 0 ] && avg_turns=$(awk "BEGIN {printf \"%.1f\", $total_rounds / $session_count}")
+
+  local unique_days=0
+  [ ${#active_dates[@]} -gt 0 ] && unique_days=$(printf '%s\n' "${active_dates[@]}" | sort -u | wc -l)
+
+  jq -n \
+    --argjson session_count "$session_count" \
+    --argjson total_rounds "$total_rounds" \
+    --argjson total_duration "$total_duration" \
+    --arg estimated_hours "$estimated_hours" \
+    --arg avg_turns "$avg_turns" \
+    --argjson total_chars "$total_chars" \
+    --argjson total_tokens "$total_tokens" \
+    --argjson active_days "$unique_days" \
+    '{
+      session_count: $session_count,
+      total_rounds: $total_rounds,
+      total_duration_min: $total_duration,
+      estimated_hours: ($estimated_hours | tonumber),
+      avg_turns_per_session: ($avg_turns | tonumber),
+      total_char_count: $total_chars,
+      total_token_estimate: $total_tokens,
+      active_days: $active_days
+    }'
+}
+
+# ── Helper: aggregate cost stats for a project (convenience wrapper) ──
+# Args: encoded_dir_name [since] [until]
+_ccs_project_cost() {
+  local encoded_dir="$1" since="${2:-}" until_date="${3:-}"
+  _ccs_project_collect "$encoded_dir" "$since" "$until_date" | _ccs_project_cost_from_files
+}
+
+# ── Helper: analyze development rhythm from file list on stdin ──
+# Input: one JSONL path per line on stdin
+# Output: JSON with heatmap, longest_streak, longest_gap, avg_sessions_per_day
+_ccs_project_rhythm_from_files() {
+  local -A date_counts=()
+  while IFS= read -r jsonl_file; do
+    [ -z "$jsonl_file" ] && continue
+    local session_date
+    session_date=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl_file" 2>/dev/null \
+      | head -1 | cut -c1-10)
+    [ -z "$session_date" ] || [ "$session_date" = "null" ] && continue
+    date_counts[$session_date]=$(( ${date_counts[$session_date]:-0} + 1 ))
+  done
+
+  [ ${#date_counts[@]} -eq 0 ] && {
+    echo '{"heatmap":[],"longest_streak":0,"longest_gap":0,"avg_sessions_per_day":0}'
+    return 0
+  }
+
+  local -a sorted_dates=()
+  local heatmap_json="["
+  local first=true
+  while IFS= read -r d; do
+    sorted_dates+=("$d")
+    $first || heatmap_json+=","
+    first=false
+    heatmap_json+="{\"date\":\"$d\",\"sessions\":${date_counts[$d]}}"
+  done < <(printf '%s\n' "${!date_counts[@]}" | sort)
+  heatmap_json+="]"
+
+  local longest_streak=1 current_streak=1
+  local longest_gap=0
+  local i prev_epoch curr_epoch diff_days
+  for ((i = 1; i < ${#sorted_dates[@]}; i++)); do
+    prev_epoch=$(date -d "${sorted_dates[$((i-1))]}" +%s 2>/dev/null)
+    curr_epoch=$(date -d "${sorted_dates[$i]}" +%s 2>/dev/null)
+    diff_days=$(( (curr_epoch - prev_epoch) / 86400 ))
+
+    if [ "$diff_days" -eq 1 ]; then
+      current_streak=$((current_streak + 1))
+      [ "$current_streak" -gt "$longest_streak" ] && longest_streak=$current_streak
+    else
+      current_streak=1
+      local gap=$((diff_days - 1))
+      [ "$gap" -gt "$longest_gap" ] && longest_gap=$gap
+    fi
+  done
+
+  local total_sessions=0
+  for d in "${!date_counts[@]}"; do
+    total_sessions=$((total_sessions + date_counts[$d]))
+  done
+  local avg_per_day
+  avg_per_day=$(awk "BEGIN {printf \"%.1f\", $total_sessions / ${#sorted_dates[@]}}")
+
+  jq -n \
+    --argjson heatmap "$heatmap_json" \
+    --argjson longest_streak "$longest_streak" \
+    --argjson longest_gap "$longest_gap" \
+    --arg avg "$avg_per_day" \
+    '{
+      heatmap: $heatmap,
+      longest_streak: $longest_streak,
+      longest_gap: $longest_gap,
+      avg_sessions_per_day: ($avg | tonumber)
+    }'
+}
+
+# ── Helper: analyze development rhythm (convenience wrapper) ──
+# Args: encoded_dir_name [since] [until]
+_ccs_project_rhythm() {
+  local encoded_dir="$1" since="${2:-}" until_date="${3:-}"
+  _ccs_project_collect "$encoded_dir" "$since" "$until_date" | _ccs_project_rhythm_from_files
+}
+
+# ── Helper: filter features.jsonl for a specific project ──
+# Args: project_path (resolved filesystem path)
+# Output: JSON array of feature objects for this project
+_ccs_project_features() {
+  local project_path="$1"
+  local data_dir="${CCS_DATA_DIR:-$(_ccs_data_dir)}"
+  local features_file="$data_dir/features.jsonl"
+
+  if [ ! -f "$features_file" ]; then
+    echo "[]"
+    return 0
+  fi
+
+  jq -sc --arg proj "$project_path" '
+    [.[] | select(.project == $proj and .id != "_ungrouped")]
+  ' "$features_file" 2>/dev/null || echo "[]"
+}
+
+# ── Helper: analyze code changes from git ──
+# Args: project_path max_days
+# Output: JSON with by_branch, top_files, lines_added, lines_deleted
+_ccs_project_code_changes() {
+  local project_path="$1" max_days="${2:-90}"
+
+  if [ ! -d "$project_path/.git" ]; then
+    echo '{"by_branch":[],"top_files":[],"lines_added":0,"lines_deleted":0}'
+    return 0
+  fi
+
+  local since_date
+  since_date=$(date -d "$max_days days ago" +%Y-%m-%d 2>/dev/null)
+
+  # Per-branch analysis (variable-based, no temp files)
+  local by_branch="[]"
+
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    branch="${branch#  }"
+    branch="${branch#\* }"
+
+    local commit_count
+    commit_count=$(git -C "$project_path" log "$branch" --since="$since_date" \
+      --oneline 2>/dev/null | wc -l)
+    [ "$commit_count" -eq 0 ] && continue
+
+    local summary
+    summary=$(git -C "$project_path" log "$branch" --since="$since_date" \
+      --oneline 2>/dev/null | head -3 | paste -sd '; ')
+
+    local entry
+    entry=$(jq -n \
+      --arg branch "$branch" \
+      --argjson commits "$commit_count" \
+      --arg summary "$summary" \
+      '{branch: $branch, commits: $commits, summary: $summary}')
+    by_branch=$(echo "$by_branch" | jq --argjson entry "$entry" '. + [$entry]')
+  done < <(git -C "$project_path" branch 2>/dev/null)
+
+  # Top modified files
+  local top_files
+  top_files=$(git -C "$project_path" log --all --since="$since_date" \
+    --pretty=format: --name-only 2>/dev/null \
+    | grep -v '^$' | sort | uniq -c | sort -rn | head -10 \
+    | awk '{print "{\"path\":\""$2"\",\"changes\":"$1"}"}' \
+    | jq -s '.' 2>/dev/null || echo "[]")
+
+  # Total lines added/deleted
+  local diffstat
+  diffstat=$(git -C "$project_path" log --all --since="$since_date" \
+    --pretty=format: --numstat 2>/dev/null \
+    | awk '{a+=$1; d+=$2} END {print a+0, d+0}')
+  local lines_added lines_deleted
+  lines_added=$(echo "$diffstat" | cut -d' ' -f1)
+  lines_deleted=$(echo "$diffstat" | cut -d' ' -f2)
+
+  jq -n \
+    --argjson by_branch "$by_branch" \
+    --argjson top_files "$top_files" \
+    --argjson lines_added "$lines_added" \
+    --argjson lines_deleted "$lines_deleted" \
+    '{
+      by_branch: $by_branch,
+      top_files: $top_files,
+      lines_added: $lines_added,
+      lines_deleted: $lines_deleted
+    }'
+}
+
+# ── Helper: build complete project report JSON ──
+# Args: encoded_dir_name [since] [until]
+_ccs_project_json() {
+  local encoded_dir="$1" since="${2:-}" until_date="${3:-}"
+
+  local project_path
+  project_path=$(_ccs_resolve_project_path "$encoded_dir" 2>/dev/null || echo "")
+  local project_name
+  project_name=$(basename "$project_path" 2>/dev/null || echo "$encoded_dir")
+
+  # Collect sessions
+  local -a session_files=()
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    session_files+=("$f")
+  done < <(_ccs_project_collect "$encoded_dir" "$since" "$until_date")
+
+  local session_count=${#session_files[@]}
+
+  # Total count for truncation indicator
+  local projects_dir="${CCS_PROJECTS_DIR:-$HOME/.claude/projects}"
+  local total_count
+  total_count=$(find "$projects_dir/$encoded_dir" -maxdepth 1 -name "*.jsonl" \
+    ! -path "*/subagents/*" 2>/dev/null | wc -l)
+
+  local truncated=false truncated_total=null
+  if [ "$total_count" -gt "$session_count" ]; then
+    truncated=true
+    truncated_total=$total_count
+  fi
+
+  # Period from/to dates
+  local period_from="" period_to=""
+  if [ "$session_count" -gt 0 ]; then
+    period_from=$(jq -r 'select(.timestamp) | .timestamp' "${session_files[-1]}" 2>/dev/null \
+      | head -1 | cut -c1-10)
+    period_to=$(jq -r 'select(.timestamp) | .timestamp' "${session_files[0]}" 2>/dev/null \
+      | head -1 | cut -c1-10)
+  fi
+
+  local total_days=0
+  if [ -n "$period_from" ] && [ -n "$period_to" ] \
+     && [ "$period_from" != "null" ] && [ "$period_to" != "null" ]; then
+    local from_epoch to_epoch
+    from_epoch=$(date -d "$period_from" +%s 2>/dev/null || echo 0)
+    to_epoch=$(date -d "$period_to" +%s 2>/dev/null || echo 0)
+    total_days=$(( (to_epoch - from_epoch) / 86400 + 1 ))
+  fi
+
+  # Single-pass: compute cost + session list + rhythm dates simultaneously
+  # (avoids triple collection and double parsing of _ccs_session_stats)
+  local total_rounds=0 total_duration=0 total_chars=0 total_tokens=0
+  local -a active_dates=()
+  local -a sess_jsons=()
+
+  if [ "$session_count" -gt 0 ]; then
+    local f
+    for f in "${session_files[@]}"; do
+      local sid topic sstats turns duration_min session_date
+      sid=$(basename "$f" .jsonl | cut -c1-8)
+      topic=$(_ccs_topic_from_jsonl "$f")
+      sstats=$(_ccs_session_stats "$f")
+      turns=$(echo "$sstats" | jq '.rounds')
+      duration_min=$(echo "$sstats" | jq '.time_range.duration_min')
+      session_date=$(echo "$sstats" | jq -r '.time_range.start' | cut -c1-10)
+
+      # Accumulate cost stats
+      total_rounds=$(( total_rounds + turns ))
+      total_duration=$(( total_duration + duration_min ))
+      total_chars=$(( total_chars + $(echo "$sstats" | jq '.char_count') ))
+      total_tokens=$(( total_tokens + $(echo "$sstats" | jq '.token_estimate') ))
+      [ -n "$session_date" ] && [ "$session_date" != "null" ] && active_dates+=("$session_date")
+
+      # Build session list entry
+      sess_jsons+=("$(jq -n \
+        --arg sid "$sid" \
+        --arg date "$session_date" \
+        --arg topic "$topic" \
+        --argjson turns "$turns" \
+        --argjson duration_min "$duration_min" \
+        '{sid: $sid, date: $date, topic: $topic, turns: $turns, duration_min: $duration_min}')")
+    done
+  fi
+
+  local sessions_array="[]"
+  [ ${#sess_jsons[@]} -gt 0 ] && sessions_array=$(printf '%s\n' "${sess_jsons[@]}" | jq -s '.')
+
+  # Build cost JSON from accumulated stats
+  local estimated_hours avg_turns unique_days
+  estimated_hours=$(awk "BEGIN {printf \"%.1f\", $total_duration / 60}")
+  avg_turns=0
+  [ "$session_count" -gt 0 ] && avg_turns=$(awk "BEGIN {printf \"%.1f\", $total_rounds / $session_count}")
+  unique_days=0
+  [ ${#active_dates[@]} -gt 0 ] && unique_days=$(printf '%s\n' "${active_dates[@]}" | sort -u | wc -l)
+
+  local cost_json
+  cost_json=$(jq -n \
+    --argjson session_count "$session_count" \
+    --argjson total_rounds "$total_rounds" \
+    --argjson total_duration "$total_duration" \
+    --arg estimated_hours "$estimated_hours" \
+    --arg avg_turns "$avg_turns" \
+    --argjson total_chars "$total_chars" \
+    --argjson total_tokens "$total_tokens" \
+    --argjson active_days "$unique_days" \
+    '{
+      session_count: $session_count,
+      total_rounds: $total_rounds,
+      total_duration_min: $total_duration,
+      estimated_hours: ($estimated_hours | tonumber),
+      avg_turns_per_session: ($avg_turns | tonumber),
+      total_char_count: $total_chars,
+      total_token_estimate: $total_tokens,
+      active_days: $active_days
+    }')
+  local active_days_count="$unique_days"
+
+  # Rhythm: compute from collected dates (no re-collection)
+  local rhythm_json
+  rhythm_json=$(printf '%s\n' "${session_files[@]}" | _ccs_project_rhythm_from_files)
+
+  # Features
+  local features_json
+  features_json=$(_ccs_project_features "$project_path")
+
+  # Code changes
+  local max_days=$_CCS_PROJECT_MAX_DAYS
+  if [ -n "$since" ]; then
+    local since_epoch now_epoch
+    since_epoch=$(date -d "$since" +%s 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    max_days=$(( (now_epoch - since_epoch) / 86400 + 1 ))
+  fi
+  local code_json
+  code_json=$(_ccs_project_code_changes "$project_path" "$max_days")
+
+  # Insights cache
+  local insights="null"
+  local data_dir
+  data_dir="${CCS_DATA_DIR:-$(_ccs_data_dir)}"
+  local cache_file="$data_dir/project-cache/${encoded_dir}.insights.json"
+  if [ -f "$cache_file" ]; then
+    local cache_age
+    cache_age=$(( ($(date +%s) - $(stat -c "%Y" "$cache_file")) / 3600 ))
+    if [ "$cache_age" -lt 24 ]; then
+      insights=$(cat "$cache_file")
+    fi
+  fi
+
+  # Assemble
+  jq -n \
+    --arg project "$project_path" \
+    --arg project_name "$project_name" \
+    --arg period_from "$period_from" \
+    --arg period_to "$period_to" \
+    --argjson total_days "$total_days" \
+    --argjson active_days "$active_days_count" \
+    --argjson session_count "$session_count" \
+    --argjson truncated "$truncated" \
+    --argjson truncated_total "$truncated_total" \
+    --argjson cost "$cost_json" \
+    --argjson features "$features_json" \
+    --argjson rhythm "$rhythm_json" \
+    --argjson code_changes "$code_json" \
+    --argjson insights "$insights" \
+    --argjson sessions "$sessions_array" \
+    '{
+      project: $project,
+      project_name: $project_name,
+      period: {
+        from: $period_from,
+        to: $period_to,
+        total_days: $total_days,
+        active_days: $active_days,
+        session_count: $session_count,
+        truncated: $truncated,
+        truncated_total: $truncated_total
+      },
+      cost: $cost,
+      features: $features,
+      rhythm: $rhythm,
+      code_changes: $code_changes,
+      insights: $insights,
+      sessions: $sessions
+    }'
+}

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -118,6 +118,7 @@ ccs-dashboard 分兩層：
 | `ccs-dispatch` | 派發任務到新的 Claude Code session（async 或 sync） |
 | `ccs-jobs` | 查看 dispatch 任務歷史與結果 |
 | `ccs-review` | Session 回顧報告 — 統計、對話、LLM 摘要（md/html/pdf） |
+| `ccs-project` | 專案層級洞察報告 — 成本、進度、節奏、程式碼變動（md/html） |
 
 所有指令支援 **Terminal ANSI** 和 **Markdown** (`--md`) 兩種輸出模式。
 
@@ -205,8 +206,9 @@ ccs-ops.sh         # ccs-crash, ccs-recap, ccs-checkpoint
 ccs-health.sh      # Session health 評分
 ccs-dispatch.sh    # ccs-dispatch, ccs-jobs
 ccs-review.sh      # ccs-review — session 回顧報告
+ccs-project.sh     # ccs-project — 專案層級洞察報告
 install.sh         # 安裝腳本（依賴檢查 + bashrc + skill symlink）
-templates/         # Jinja2 HTML 模板（ccs-review 用）
+templates/         # Jinja2 HTML 模板（ccs-review、ccs-project 用）
 skills/            # Claude Code skill — 主要介面
 docs/              # CLI 指令參考 + 歸檔設計文件
 ```

--- a/docs/adr/001-modular-source-split.md
+++ b/docs/adr/001-modular-source-split.md
@@ -31,6 +31,8 @@ ccs-feature.sh   — feature clustering + ccs-tag
 ccs-ops.sh       — ccs-crash, ccs-recap, ccs-checkpoint
 ccs-health.sh    — session health 評分
 ccs-dispatch.sh  — ccs-dispatch, ccs-jobs
+ccs-review.sh    — ccs-review
+ccs-project.sh   — ccs-project
 ```
 
 設計原則：

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -416,6 +416,33 @@ ccs-review --since 2026-03-24 --until 2026-03-31 --summarize
 - Responsive（手機友善）
 - `<details>` 原生折疊，零 JS 依賴
 
+## ccs-project
+
+專案層級洞察報告：投入成本、功能進度、開發節奏、程式碼變動、跨 session 問題模式。
+報告分兩層：摘要（主管看）和細節（開發者看）。
+
+```bash
+ccs-project                           # 偵測 cwd 專案
+ccs-project /path/to/repo             # 指定專案
+ccs-project --since 2026-03-01        # 限縮時間
+ccs-project --format html -o ./reports/  # HTML 匯出
+ccs-project --no-insights             # 跳過 LLM 洞察
+```
+
+自動限縮：最多 50 個 session 或 90 天（取嚴）。
+
+**報告維度：**
+- 功能進度追蹤（讀 features.jsonl，含狀態色標）
+- 累積投入成本（session 數、工時、turns）
+- 開發節奏分析（活躍天曆、連續天/中斷天）
+- 程式碼變動摘要（per-branch commits、top files、行數）
+- 跨 session 問題模式（LLM 洞察，透過 orchestrator 觸發）
+
+**HTML 特色：**
+- Dark theme，與 ccs-review 風格一致
+- 摘要層固定（stats cards + 功能進度 + 洞察）
+- 細節層折疊（節奏、程式碼變動、session 列表）
+
 **依賴（選用）：**
 - `jinja2`：`--format html`（`pip3 install jinja2`）
 - `weasyprint`：`--format pdf`（`pip3 install weasyprint`）

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ do_install() {
   echo
 
   # Check files exist
-  local modules=(ccs-core.sh ccs-health.sh ccs-viewer.sh ccs-handoff.sh ccs-overview.sh ccs-feature.sh ccs-ops.sh ccs-dispatch.sh ccs-review.sh ccs-dashboard.sh)
+  local modules=(ccs-core.sh ccs-health.sh ccs-viewer.sh ccs-handoff.sh ccs-overview.sh ccs-feature.sh ccs-ops.sh ccs-dispatch.sh ccs-review.sh ccs-project.sh ccs-dashboard.sh)
   local all_found=true
   for mod in "${modules[@]}"; do
     if [ ! -f "${SCRIPT_DIR}/${mod}" ]; then
@@ -184,6 +184,7 @@ do_install() {
   echo "  ccs-dispatch        — dispatch task to Claude Code"
   echo "  ccs-jobs            — view dispatch job history"
   echo "  ccs-review          — session review report (md/html/pdf)"
+  echo "  ccs-project         — per-project insight report (md/html)"
   echo
   echo "Skills installed:"
   echo "  ccs-orchestrator    — interactive work orchestrator (Claude Code skill)"

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccs-orchestrator
-description: "MANDATORY for any ccs-* command execution. Never run ccs-* commands via Bash directly — always invoke this skill instead. Triggers on: ccs-status, ccs-overview, ccs-crash, ccs-checkpoint, ccs-recap, ccs-feature, ccs-handoff, ccs-pick, ccs-health, ccs-dispatch, ccs-jobs, ccs-review. Also triggers on: 'checkpoint', 'overview', 'recap', 'sessions', 'crash', 'health', 'handoff', 'dispatch', 'review', 'session review', '回顧', '報告', 'weekly report', '週報', '跑一下checkpoint', '目前狀態', '工作總覽', 'what am I working on', 'show my sessions', 'セッションの状態'. This skill handles output rendering (via _ccs_to_file + Read) so results display correctly in session view."
+description: "MANDATORY for any ccs-* command execution. Never run ccs-* commands via Bash directly — always invoke this skill instead. Triggers on: ccs-status, ccs-overview, ccs-crash, ccs-checkpoint, ccs-recap, ccs-feature, ccs-handoff, ccs-pick, ccs-health, ccs-dispatch, ccs-jobs, ccs-review, ccs-project. Also triggers on: 'checkpoint', 'overview', 'recap', 'sessions', 'crash', 'health', 'handoff', 'dispatch', 'review', 'session review', 'project report', 'project insights', '回顧', '報告', 'weekly report', '週報', '專案報告', '專案洞察', '跑一下checkpoint', '目前狀態', '工作總覽', 'what am I working on', 'show my sessions', 'セッションの状態'. This skill handles output rendering (via _ccs_to_file + Read) so results display correctly in session view."
 ---
 
 # CCS Orchestrator
@@ -56,6 +56,8 @@ description: "MANDATORY for any ccs-* command execution. Never run ccs-* command
 | review [sid] | rv | `ccs-review [sid]` — session review 報告 |
 | review html [sid] | | `ccs-review [sid] --format html -o <path>` — HTML 報告 |
 | weekly [since] [until] | wk | `ccs-review --since <date> --until <date>` — 週報 |
+| project [path] | pj | `ccs-project [path]` — 專案層級洞察報告 |
+| project html [path] | | `ccs-project [path] --format html -o <path>` — HTML 報告 |
 
 ## Routing Rules
 
@@ -177,3 +179,24 @@ Session review 產生進度報告，可分享給主管。有兩種模式：
 2. 呈現結果
 3. 用 `<options>` 問：「要 LLM 彙整本週亮點？」「匯出 HTML」「匯出 PDF」
 4. 若選 LLM 彙整 → 收集各 session cache 摘要 → 派 subagent → 呈現
+
+### Project 流程
+
+專案層級洞察報告，結合投入成本、功能進度、開發節奏、程式碼變動。
+
+1. 執行 `ccs-project [path] --format json` 取得結構化資料
+2. 檢查 insights cache（`~/.local/share/ccs-dashboard/project-cache/<encoded>.insights.json`）
+3. 若無 cache 或已過期（>24h）：
+   - 從 JSON 取 `sessions`、`features`、`code_changes`、`rhythm`
+   - 派 subagent 生成洞察：
+     a. **健康度摘要**（prompt: 綜合所有維度，3-5 句整體評估）
+     b. **重複問題**（prompt: 從 session topics 和 code changes 找重複模式）
+     c. **改善建議**（prompt: 基於節奏和問題模式，3 條可行建議）
+   - 組成 insights JSON：`{"health_summary":"...","recurring_issues":[...],"hotspot_files":[...],"suggestions":[...],"generated_at":"..."}`
+   - 寫入 cache：
+     ```bash
+     mkdir -p "$(_ccs_data_dir)/project-cache"
+     echo '<insights json>' > "$(_ccs_data_dir)/project-cache/<encoded>.insights.json"
+     ```
+4. 執行 `ccs-project [path] --format md` 呈現結果
+5. 用 `<options>` 問：「要匯出 HTML？」「回到總覽」

--- a/templates/project.html
+++ b/templates/project.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ project_name }} — Project Report</title>
+<style>
+  :root {
+    --bg: #1a1b26; --surface: #24283b; --text: #a9b1d6;
+    --accent: #7aa2f7; --green: #9ece6a; --yellow: #e0af68;
+    --red: #f7768e; --blue: #7aa2f7; --gray: #565f89;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    background: var(--bg); color: var(--text);
+    max-width: 960px; margin: 0 auto; padding: 24px;
+  }
+  .stats-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px; margin: 16px 0;
+  }
+  .stat-card {
+    background: var(--surface); border-radius: 8px; padding: 16px;
+    border-left: 3px solid var(--accent);
+  }
+  .stat-card .label { font-size: 0.8em; color: var(--gray); }
+  .stat-card .value { font-size: 1.4em; font-weight: bold; color: var(--accent); }
+  .feature-row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 12px; border-radius: 6px;
+    background: var(--surface); margin: 4px 0;
+  }
+  .status-badge {
+    padding: 2px 8px; border-radius: 4px; font-size: 0.75em;
+    font-weight: bold;
+  }
+  .status-completed { background: var(--green); color: #1a1b26; }
+  .status-in_progress { background: var(--blue); color: #1a1b26; }
+  .status-stale { background: var(--yellow); color: #1a1b26; }
+  .status-idle { background: var(--gray); color: var(--text); }
+  .heatmap { display: flex; flex-wrap: wrap; gap: 3px; margin: 12px 0; }
+  .heat-cell {
+    width: 14px; height: 14px; border-radius: 2px;
+    background: var(--surface);
+  }
+  .heat-1 { background: #2d4a22; }
+  .heat-2 { background: #3e6b2f; }
+  .heat-3 { background: #5a9e3c; }
+  .heat-4 { background: var(--green); }
+  details { margin: 12px 0; }
+  summary {
+    cursor: pointer; font-weight: bold; padding: 8px;
+    background: var(--surface); border-radius: 6px;
+  }
+  .section { margin: 24px 0; }
+  h1 { color: var(--accent); margin-bottom: 8px; }
+  h2 { color: var(--text); margin: 16px 0 8px; font-size: 1.1em; }
+  .truncated-notice {
+    background: var(--yellow); color: #1a1b26;
+    padding: 6px 12px; border-radius: 4px; font-size: 0.85em;
+    margin: 8px 0;
+  }
+  .session-row {
+    display: grid; grid-template-columns: 80px 90px 1fr 60px 60px;
+    gap: 8px; padding: 6px 8px; font-size: 0.85em;
+    border-bottom: 1px solid var(--surface);
+  }
+  .session-row:hover { background: var(--surface); }
+</style>
+</head>
+<body>
+
+<h1>{{ project_name }}</h1>
+<p style="color:var(--gray)">{{ project }}</p>
+
+{% if period.truncated %}
+<div class="truncated-notice">
+  顯示最近 {{ period.session_count }} 個 session（共 {{ period.truncated_total }} 個）
+</div>
+{% endif %}
+
+<!-- Stats Cards -->
+<div class="stats-grid">
+  <div class="stat-card">
+    <div class="label">期間</div>
+    <div class="value" style="font-size:1em">{{ period.from }} ~ {{ period.to }}</div>
+    <div class="label">{{ period.total_days }} 天</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Sessions</div>
+    <div class="value">{{ period.session_count }}</div>
+    <div class="label">活躍 {{ period.active_days }} 天</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">估算工時</div>
+    <div class="value">{{ cost.estimated_hours }}h</div>
+    <div class="label">{{ cost.total_rounds }} turns</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">程式碼</div>
+    <div class="value" style="color:var(--green)">+{{ code_changes.lines_added }}</div>
+    <div class="label" style="color:var(--red)">-{{ code_changes.lines_deleted }}</div>
+  </div>
+</div>
+
+<!-- Features -->
+{% if features %}
+<div class="section">
+  <h2>功能進度</h2>
+  {% for f in features %}
+  <div class="feature-row">
+    <span class="status-badge status-{{ f.status }}">{{ f.status }}</span>
+    <span>{{ f.branch or f.id }}</span>
+    <span style="color:var(--gray)">— {{ f.label }}</span>
+    <span style="margin-left:auto;color:var(--gray)">{{ f.todos_done }}/{{ f.todos_total }}</span>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<!-- Insights -->
+{% if insights %}
+<div class="section">
+  <h2>洞察</h2>
+  <p>{{ insights.health_summary }}</p>
+  {% if insights.suggestions %}
+  <ul>
+    {% for s in insights.suggestions %}<li>{{ s }}</li>{% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endif %}
+
+<!-- Rhythm (collapsible) -->
+<details class="section">
+  <summary>開發節奏</summary>
+  <div style="padding:12px 0">
+    <p>最長連續: {{ rhythm.longest_streak }} 天 | 最長中斷: {{ rhythm.longest_gap }} 天 | 平均: {{ rhythm.avg_sessions_per_day }} sessions/天</p>
+    <div class="heatmap">
+      {% for day in rhythm.heatmap %}
+      <div class="heat-cell heat-{{ [day.sessions, 4]|min }}"
+           title="{{ day.date }}: {{ day.sessions }} sessions"></div>
+      {% endfor %}
+    </div>
+  </div>
+</details>
+
+<!-- Code Changes (collapsible) -->
+<details class="section">
+  <summary>程式碼變動</summary>
+  <div style="padding:12px 0">
+    {% if code_changes.by_branch %}
+    <h2 style="font-size:0.9em">依 Branch</h2>
+    {% for b in code_changes.by_branch %}
+    <div style="padding:4px 0">
+      <strong>{{ b.branch }}</strong> ({{ b.commits }} commits)
+      <div style="color:var(--gray);font-size:0.85em">{{ b.summary }}</div>
+    </div>
+    {% endfor %}
+    {% endif %}
+    {% if code_changes.top_files %}
+    <h2 style="font-size:0.9em;margin-top:12px">修改最多的檔案</h2>
+    {% for f in code_changes.top_files[:10] %}
+    <div style="font-size:0.85em">{{ f.path }} ({{ f.changes }}x)</div>
+    {% endfor %}
+    {% endif %}
+  </div>
+</details>
+
+<!-- Problem Patterns (collapsible) -->
+{% if insights and insights.recurring_issues %}
+<details class="section">
+  <summary>問題模式</summary>
+  <div style="padding:12px 0">
+    <ul>
+      {% for issue in insights.recurring_issues %}<li>{{ issue }}</li>{% endfor %}
+    </ul>
+    {% if insights.hotspot_files %}
+    <h2 style="font-size:0.9em;margin-top:12px">熱點檔案</h2>
+    <ul>
+      {% for f in insights.hotspot_files %}<li>{{ f }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</details>
+{% endif %}
+
+<!-- Session List (collapsible) -->
+<details class="section">
+  <summary>Session 列表 ({{ sessions|length }})</summary>
+  <div style="padding:12px 0">
+    <div class="session-row" style="font-weight:bold;color:var(--gray)">
+      <span>SID</span><span>日期</span><span>Topic</span><span>Turns</span><span>時長</span>
+    </div>
+    {% for s in sessions %}
+    <div class="session-row">
+      <span style="font-family:monospace">{{ s.sid }}</span>
+      <span>{{ s.date }}</span>
+      <span>{{ s.topic[:60] if s.topic else '' }}</span>
+      <span>{{ s.turns }}</span>
+      <span>{{ s.duration_min }}m</span>
+    </div>
+    {% endfor %}
+  </div>
+</details>
+
+<footer style="margin-top:32px;padding:12px 0;border-top:1px solid var(--surface);color:var(--gray);font-size:0.8em">
+  Generated by ccs-project · {{ period.to }}
+</footer>
+
+</body>
+</html>

--- a/tests/fixture-helper.sh
+++ b/tests/fixture-helper.sh
@@ -22,7 +22,7 @@ assert_eq() {
 
 assert_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if echo "$haystack" | grep -qF "$needle"; then
+  if echo "$haystack" | grep -qF -- "$needle"; then
     printf '  PASS: %s\n' "$label"
     PASS=$((PASS + 1))
   else
@@ -34,7 +34,7 @@ assert_contains() {
 
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"
-  if echo "$haystack" | grep -qF "$needle"; then
+  if echo "$haystack" | grep -qF -- "$needle"; then
     printf '  FAIL: %s (found: "%s")\n' \
       "$label" "$needle"
     FAIL=$((FAIL + 1))

--- a/tests/test-project.sh
+++ b/tests/test-project.sh
@@ -210,4 +210,21 @@ assert_eq "json: has sessions" "true" "$(echo "$project_json" | jq 'has("session
 assert_eq "json: session_count matches" "2" "$(echo "$project_json" | jq '.period.session_count')"
 assert_eq "json: insights null" "null" "$(echo "$project_json" | jq '.insights')"
 
+echo "=== _ccs_project_md: markdown rendering ==="
+
+md_output=$(_ccs_project_json "-pool2-user-repo-cost" | _ccs_project_md)
+assert_contains "md: has title" "$md_output" "Project Report"
+assert_contains "md: has period" "$md_output" "期間"
+assert_contains "md: has cost section" "$md_output" "投入成本"
+assert_contains "md: has rhythm section" "$md_output" "開發節奏"
+assert_contains "md: has session list" "$md_output" "Session"
+
+echo "=== ccs-project CLI: help flag ==="
+
+help_output=$(ccs-project --help 2>&1)
+assert_contains "cli: has usage" "$help_output" "ccs-project"
+assert_contains "cli: has --since" "$help_output" "--since"
+assert_contains "cli: has --format" "$help_output" "--format"
+assert_contains "cli: has --project" "$help_output" "--project"
+
 test_summary

--- a/tests/test-project.sh
+++ b/tests/test-project.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source tests/fixture-helper.sh
+source ccs-core.sh
+source ccs-feature.sh
+source ccs-review.sh
+source ccs-project.sh
+
+setup_test_dir "project"
+
+echo "=== _ccs_project_collect: basic session collection ==="
+
+# Setup: fake projects dir with two projects
+export CCS_PROJECTS_DIR="$TEST_DIR/projects"
+PROJ_A="$TEST_DIR/projects/-pool2-user-repo-alpha"
+PROJ_B="$TEST_DIR/projects/-pool2-user-repo-beta"
+mkdir -p "$PROJ_A" "$PROJ_B"
+
+# Create JSONL files for project A (3 sessions)
+for i in 1 2 3; do
+  cat > "$PROJ_A/session-${i}.jsonl" <<JSONL
+{"type":"user","message":{"content":"task $i"},"timestamp":"2026-03-0${i}T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"done $i"}]},"timestamp":"2026-03-0${i}T10:30:00Z"}
+JSONL
+  touch_minutes_ago "$PROJ_A/session-${i}.jsonl" $((i * 1440))
+done
+
+# Create JSONL for project B (should not appear)
+cat > "$PROJ_B/session-b1.jsonl" <<'JSONL'
+{"type":"user","message":{"content":"other project"},"timestamp":"2026-03-01T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]},"timestamp":"2026-03-01T10:30:00Z"}
+JSONL
+
+# Test: collect for project A by encoded dir name
+result=$(_ccs_project_collect "-pool2-user-repo-alpha")
+count=$(echo "$result" | grep -c '.jsonl' || true)
+assert_eq "collect: 3 sessions for alpha" "3" "$count"
+
+# Test: no beta sessions mixed in
+beta_count=$(echo "$result" | grep -c 'beta' || true)
+assert_eq "collect: no beta sessions" "0" "$beta_count"
+
+echo "=== _ccs_project_collect: sorted by mtime descending ==="
+
+# Most recent file (1 day ago) should be first
+first_file=$(echo "$result" | head -1)
+assert_contains "collect: newest first" "$first_file" "session-1.jsonl"
+
+echo "=== _ccs_project_collect: auto-truncation by count ==="
+
+# Create 55 sessions to test 50-cap
+for i in $(seq 4 55); do
+  cat > "$PROJ_A/session-many-${i}.jsonl" <<JSONL
+{"type":"user","message":{"content":"task $i"},"timestamp":"2026-03-01T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]},"timestamp":"2026-03-01T10:30:00Z"}
+JSONL
+  touch_minutes_ago "$PROJ_A/session-many-${i}.jsonl" $((i * 10))
+done
+
+result=$(_ccs_project_collect "-pool2-user-repo-alpha")
+count=$(echo "$result" | grep -c '.jsonl' || true)
+assert_eq "collect: capped at 50" "50" "$count"
+
+echo "=== _ccs_project_cost: cost aggregation ==="
+
+COST_DIR="$TEST_DIR/projects/-pool2-user-repo-cost"
+mkdir -p "$COST_DIR"
+
+cat > "$COST_DIR/sess-cost-1.jsonl" <<'JSONL'
+{"type":"user","message":{"content":"task one"},"timestamp":"2026-04-01T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Working on it."}]},"timestamp":"2026-04-01T10:15:00Z"}
+{"type":"user","message":{"content":"continue"},"timestamp":"2026-04-01T10:16:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Done."}]},"timestamp":"2026-04-01T10:30:00Z"}
+JSONL
+
+cat > "$COST_DIR/sess-cost-2.jsonl" <<'JSONL'
+{"type":"user","message":{"content":"task two"},"timestamp":"2026-04-02T14:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"OK."}]},"timestamp":"2026-04-02T14:20:00Z"}
+JSONL
+
+touch_minutes_ago "$COST_DIR/sess-cost-1.jsonl" 1440
+touch_minutes_ago "$COST_DIR/sess-cost-2.jsonl" 60
+
+cost_json=$(_ccs_project_cost "-pool2-user-repo-cost")
+assert_eq "cost: session_count" "2" "$(echo "$cost_json" | jq '.session_count')"
+assert_eq "cost: total_rounds" "3" "$(echo "$cost_json" | jq '.total_rounds')"
+assert_eq "cost: total_duration" "50" "$(echo "$cost_json" | jq '.total_duration_min')"
+assert_eq "cost: has estimated_hours" "true" "$(echo "$cost_json" | jq 'has("estimated_hours")')"
+
+echo "=== _ccs_project_features: filter features by project ==="
+
+export CCS_DATA_DIR="$TEST_DIR/data"
+mkdir -p "$CCS_DATA_DIR"
+cat > "$CCS_DATA_DIR/features.jsonl" <<'JSONL'
+{"id":"alpha/gh1","label":"Add login","project":"/pool2/user/repo-alpha","sessions":["sess1","sess2"],"branch":"feat/login","status":"completed","todos_done":5,"todos_total":5,"last_active_min":1440,"last_exchange":"Done","git_dirty":0,"updated":"2026-04-01T10:00:00"}
+{"id":"alpha/gh2","label":"Fix bug","project":"/pool2/user/repo-alpha","sessions":["sess3"],"branch":"fix/crash","status":"in_progress","todos_done":2,"todos_total":4,"last_active_min":30,"last_exchange":"Working","git_dirty":3,"updated":"2026-04-07T10:00:00"}
+{"id":"beta/gh5","label":"Other project","project":"/pool2/user/repo-beta","sessions":["sess9"],"branch":"feat/x","status":"idle","todos_done":0,"todos_total":1,"last_active_min":9999,"last_exchange":"","git_dirty":0,"updated":"2026-03-01T10:00:00"}
+{"id":"_ungrouped","sessions":["sess99"]}
+JSONL
+
+features_json=$(_ccs_project_features "/pool2/user/repo-alpha")
+feat_count=$(echo "$features_json" | jq 'length')
+assert_eq "features: 2 for alpha" "2" "$feat_count"
+
+statuses=$(echo "$features_json" | jq -r '.[].status' | sort | tr '\n' ',')
+assert_contains "features: has completed" "$statuses" "completed"
+assert_contains "features: has in_progress" "$statuses" "in_progress"
+
+echo "=== _ccs_project_rhythm: rhythm analysis ==="
+
+RHYTHM_DIR="$TEST_DIR/projects/-pool2-user-repo-rhythm"
+mkdir -p "$RHYTHM_DIR"
+
+# Days: Apr 1, 2, 3 (streak=3), gap, Apr 6, 7 (streak=2)
+# Gap = 2 days (Apr 4, 5)
+for day in 01 02 03 06 07; do
+  cat > "$RHYTHM_DIR/sess-d${day}.jsonl" <<JSONL
+{"type":"user","message":{"content":"work on day $day"},"timestamp":"2026-04-${day}T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]},"timestamp":"2026-04-${day}T10:30:00Z"}
+JSONL
+done
+# Two sessions on Apr 1
+cat > "$RHYTHM_DIR/sess-d01b.jsonl" <<'JSONL'
+{"type":"user","message":{"content":"second session"},"timestamp":"2026-04-01T14:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]},"timestamp":"2026-04-01T14:20:00Z"}
+JSONL
+
+# Set mtimes within 90-day window
+touch_minutes_ago "$RHYTHM_DIR/sess-d01.jsonl" $((7 * 1440))
+touch_minutes_ago "$RHYTHM_DIR/sess-d01b.jsonl" $((7 * 1440 - 240))
+touch_minutes_ago "$RHYTHM_DIR/sess-d02.jsonl" $((6 * 1440))
+touch_minutes_ago "$RHYTHM_DIR/sess-d03.jsonl" $((5 * 1440))
+touch_minutes_ago "$RHYTHM_DIR/sess-d06.jsonl" $((2 * 1440))
+touch_minutes_ago "$RHYTHM_DIR/sess-d07.jsonl" $((1 * 1440))
+
+rhythm_json=$(_ccs_project_rhythm "-pool2-user-repo-rhythm")
+assert_eq "rhythm: longest_streak" "3" "$(echo "$rhythm_json" | jq '.longest_streak')"
+assert_eq "rhythm: longest_gap" "2" "$(echo "$rhythm_json" | jq '.longest_gap')"
+assert_eq "rhythm: active_days" "5" "$(echo "$rhythm_json" | jq '.heatmap | length')"
+
+apr1_count=$(echo "$rhythm_json" | jq '.heatmap[] | select(.date == "2026-04-01") | .sessions')
+assert_eq "rhythm: apr1 has 2 sessions" "2" "$apr1_count"
+
+echo "=== _ccs_project_code_changes: git analysis ==="
+
+CODE_REPO="$TEST_DIR/repo-code"
+mkdir -p "$CODE_REPO"
+git -C "$CODE_REPO" init --quiet
+git -C "$CODE_REPO" symbolic-ref HEAD refs/heads/master
+git -C "$CODE_REPO" config user.email "test@test.com"
+git -C "$CODE_REPO" config user.name "Test"
+
+# Initial commit
+echo "line1" > "$CODE_REPO/main.sh"
+git -C "$CODE_REPO" add main.sh
+git -C "$CODE_REPO" commit -m "init" --quiet
+
+# Feature branch with commits
+git -C "$CODE_REPO" checkout -b feat/login --quiet
+echo "line2" >> "$CODE_REPO/main.sh"
+echo "new file" > "$CODE_REPO/auth.sh"
+git -C "$CODE_REPO" add -A
+git -C "$CODE_REPO" commit -m "feat: add auth" --quiet
+echo "line3" >> "$CODE_REPO/main.sh"
+git -C "$CODE_REPO" add -A
+git -C "$CODE_REPO" commit -m "feat: extend auth" --quiet
+
+# Back to master with another commit
+git -C "$CODE_REPO" checkout master --quiet
+echo "fix" >> "$CODE_REPO/main.sh"
+git -C "$CODE_REPO" add -A
+git -C "$CODE_REPO" commit -m "fix: typo" --quiet
+
+changes_json=$(_ccs_project_code_changes "$CODE_REPO" "90")
+assert_eq "code: has by_branch" "true" "$(echo "$changes_json" | jq 'has("by_branch")')"
+assert_eq "code: has top_files" "true" "$(echo "$changes_json" | jq 'has("top_files")')"
+assert_eq "code: has lines_added" "true" "$(echo "$changes_json" | jq 'has("lines_added")')"
+
+branch_count=$(echo "$changes_json" | jq '.by_branch | length')
+assert_eq "code: 2 branches" "2" "$branch_count"
+
+echo "=== _ccs_project_json: full JSON assembly ==="
+
+# Reuse COST_DIR from earlier test (has 2 sessions)
+# Create a git repo at a mock "resolved" path
+PROJ_REPO="$TEST_DIR/pool2/user/repo-cost"
+mkdir -p "$PROJ_REPO"
+git -C "$PROJ_REPO" init --quiet
+git -C "$PROJ_REPO" symbolic-ref HEAD refs/heads/master
+git -C "$PROJ_REPO" config user.email "test@test.com"
+git -C "$PROJ_REPO" config user.name "Test"
+echo "init" > "$PROJ_REPO/main.sh"
+git -C "$PROJ_REPO" add main.sh
+git -C "$PROJ_REPO" commit -m "init" --quiet
+
+# Mock _ccs_resolve_project_path for this test
+_ccs_resolve_project_path() {
+  echo "$PROJ_REPO"
+}
+
+project_json=$(_ccs_project_json "-pool2-user-repo-cost")
+assert_eq "json: has project" "true" "$(echo "$project_json" | jq 'has("project")')"
+assert_eq "json: has period" "true" "$(echo "$project_json" | jq 'has("period")')"
+assert_eq "json: has cost" "true" "$(echo "$project_json" | jq 'has("cost")')"
+assert_eq "json: has features" "true" "$(echo "$project_json" | jq 'has("features")')"
+assert_eq "json: has rhythm" "true" "$(echo "$project_json" | jq 'has("rhythm")')"
+assert_eq "json: has code_changes" "true" "$(echo "$project_json" | jq 'has("code_changes")')"
+assert_eq "json: has sessions" "true" "$(echo "$project_json" | jq 'has("sessions")')"
+assert_eq "json: session_count matches" "2" "$(echo "$project_json" | jq '.period.session_count')"
+assert_eq "json: insights null" "null" "$(echo "$project_json" | jq '.insights')"
+
+test_summary


### PR DESCRIPTION
## Summary

- 新增 `ccs-project` 模組，提供專案層級洞察報告
- 五維度分析：功能進度、投入成本、開發節奏、程式碼變動、LLM 洞察
- 支援 md / html / json 輸出，HTML 採 dark theme 分層設計
- 自動限縮：50 session / 90 天取嚴
- 整合 orchestrator skill routing

## Files

- `ccs-project.sh` — 資料層 + md 渲染 + CLI entry point
- `ccs-project-render.py` — HTML 渲染（Jinja2）
- `templates/project.html` — HTML template（dark theme, two-layer）
- `tests/test-project.sh` — 37 tests, all passing
- `ccs-dashboard.sh` — source line
- `skills/ccs-orchestrator/SKILL.md` — project routing + insights flow
- Cross-file refs updated per sync-checklist

## Test plan

- [x] `bash tests/test-project.sh` — 37/37 PASS
- [x] Full regression: all 12 test suites pass
- [x] HTML smoke test with sample JSON
- [ ] Manual: `ccs-project` on a real project directory
- [ ] Manual: `ccs-project --format html -o ./` verify HTML output

🤖 Generated with [Claude Code](https://claude.ai/code)