### PR TITLE
fix: insights UX — highlights summary + collapsible details

### DIFF
--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -585,6 +585,23 @@ _ccs_project_md() {
   if [ "$has_insights" = "true" ]; then
     echo "## 洞察"
     echo ""
+
+    # Highlights (short bullet points for summary layer)
+    local highlights_count
+    highlights_count=$(echo "$json" | jq '.insights.highlights | length // 0')
+    if [ "$highlights_count" -gt 0 ]; then
+      echo "$json" | jq -r '.insights.highlights[]? | "- \(.)"'
+      echo ""
+    else
+      # Fallback: show first sentence of health_summary
+      echo "$json" | jq -r '.insights.health_summary // empty' | head -1
+      echo ""
+    fi
+
+    # Detailed analysis (collapsible in md via <details>)
+    echo "<details>"
+    echo "<summary>詳細分析</summary>"
+    echo ""
     echo "$json" | jq -r '.insights.health_summary // empty'
     echo ""
     local issues_count
@@ -601,6 +618,8 @@ _ccs_project_md() {
       echo "$json" | jq -r '.insights.suggestions[]? | "- \(.)"'
       echo ""
     fi
+    echo "</details>"
+    echo ""
   fi
 
   # Session list

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -192,7 +192,8 @@ Session review 產生進度報告，可分享給主管。有兩種模式：
      a. **健康度摘要**（prompt: 綜合所有維度，3-5 句整體評估）
      b. **重複問題**（prompt: 從 session topics 和 code changes 找重複模式）
      c. **改善建議**（prompt: 基於節奏和問題模式，3 條可行建議）
-   - 組成 insights JSON：`{"health_summary":"...","recurring_issues":[...],"hotspot_files":[...],"suggestions":[...],"generated_at":"..."}`
+   - 組成 insights JSON：`{"highlights":["一句話重點1","一句話重點2",...],"health_summary":"...","recurring_issues":[...],"hotspot_files":[...],"suggestions":[...],"generated_at":"..."}`
+   - `highlights` 是 3-5 個 bullet points，每條一句話（≤30 字），用於摘要層快速瀏覽
    - 寫入 cache：
      ```bash
      mkdir -p "$(_ccs_data_dir)/project-cache"

--- a/templates/project.html
+++ b/templates/project.html
@@ -123,12 +123,31 @@
 {% if insights %}
 <div class="section">
   <h2>洞察</h2>
-  <p>{{ insights.health_summary }}</p>
-  {% if insights.suggestions %}
-  <ul>
-    {% for s in insights.suggestions %}<li>{{ s }}</li>{% endfor %}
+  {% if insights.highlights %}
+  <ul style="margin:8px 0;padding-left:20px">
+    {% for h in insights.highlights %}<li>{{ h }}</li>{% endfor %}
   </ul>
+  {% else %}
+  <p>{{ insights.health_summary[:200] if insights.health_summary else '' }}...</p>
   {% endif %}
+  <details style="margin-top:8px">
+    <summary style="font-size:0.85em">詳細分析</summary>
+    <div style="padding:12px 0">
+      <p style="margin-bottom:12px">{{ insights.health_summary }}</p>
+      {% if insights.recurring_issues %}
+      <h2 style="font-size:0.9em">重複問題</h2>
+      <ul>
+        {% for issue in insights.recurring_issues %}<li>{{ issue }}</li>{% endfor %}
+      </ul>
+      {% endif %}
+      {% if insights.suggestions %}
+      <h2 style="font-size:0.9em;margin-top:12px">建議</h2>
+      <ul>
+        {% for s in insights.suggestions %}<li>{{ s }}</li>{% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+  </details>
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary

- Insights 新增 `highlights` 欄位（3-5 句一行重點）
- md 輸出：highlights 固定顯示，完整分析折疊在 `<details>` 裡
- HTML 輸出：同上，摘要層只看重點
- Orchestrator prompt 更新，指示 subagent 產出 highlights
- Fallback：無 highlights 時顯示 health_summary 首行

## Test plan

- [x] `bash tests/test-project.sh` — 37/37 PASS

🤖 Generated with [Claude Code](https://claude.ai/code)