### PR TITLE
fix: restore _ccs_collect_sessions compat + unify basename handling

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -895,6 +895,9 @@ _ccs_data_dir() {
 
 # Usage: _ccs_collect_sessions [-a|--all] out_files out_projects out_rows
 # Three nameref output arrays.
+# Output format (TAB-separated row):
+#   f1=prov  f2=project  f3=ago_min  f4=status  f5=color  f6=display_line  f7=badge
+# _out_projects stores the encoded dir name (for _ccs_resolve_project_path).
 _ccs_collect_sessions() {
   local show_all=""
   if [ "${1:-}" = "-a" ] || [ "${1:-}" = "--all" ]; then
@@ -902,27 +905,37 @@ _ccs_collect_sessions() {
   fi
 
   local -n _out_files=$1 _out_projects=$2 _out_rows=$3
-  
+
   local script_dir
   script_dir="$_CCS_DASHBOARD_DIR"
-  
-  # Note: The cutoff filtering is still handled in Bash here for backwards compatibility
+
   local cutoff
   cutoff=$(date -d "7 days ago" +%s 2>/dev/null || date -v-7d +%s 2>/dev/null)
-  
+
   while IFS='|' read -r prov proj ago status color display_proj sid ago_str topic badge filepath; do
     [ -z "$proj" ] && continue
-    
-    # Re-implement the 7-day cutoff for default collection
+
     if [ -z "$show_all" ]; then
        local mod
        mod=$(stat -c "%Y" "$filepath" 2>/dev/null || echo 0)
        [ "$mod" -lt "$cutoff" ] 2>/dev/null && continue
     fi
-    
+
+    # Recover encoded dir name for _ccs_resolve_project_path
+    local encoded_dir
+    if [ "$prov" = "C" ]; then
+      encoded_dir=$(basename "$(dirname "$filepath")")
+    else
+      encoded_dir="$proj"
+    fi
+
+    # Build TAB-separated row (backward-compatible + prov prefix)
+    local display
+    display=$(printf '%-35s %-20s %-12s %s' "$proj" "$sid" "$ago_str" "$topic")
+
     _out_files+=("$filepath")
-    _out_projects+=("$proj")
-    _out_rows+=("$prov|$proj|$ago|$status|$color|$display_proj|$sid|$ago_str|$topic|$badge|$filepath")
+    _out_projects+=("$encoded_dir")
+    _out_rows+=("$(printf '%s\t%s\t%d\t%s\t%s\t%s\t%s' "$prov" "$proj" "$ago" "$status" "$color" "$display" "$badge")")
   done < <(python3 "$script_dir/internal/ccs_collect.py" $show_all)
 }
 

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -583,7 +583,7 @@ _ccs_detect_crash() {
 
     local mtime sid
     mtime=$(stat -c "%Y" "$f" 2>/dev/null) || continue
-    sid=$(basename "$f" .jsonl)
+    sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
 
     # Path 1: Reboot detection
     # Any pre-boot session without a running process was killed by reboot.

--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -464,7 +464,7 @@ HELP
     fi
 
     local full_sid mod_date dir project status
-    full_sid=$(basename "$jsonl" .jsonl)
+    full_sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     mod_date=$(stat -c "%y" "$jsonl" | cut -d. -f1)
     dir=$(basename "$(dirname "$jsonl")")
     project=$(echo "$dir" | sed "s/^${_CCS_HOME_ENCODED}-*//; s/-/\//g")

--- a/ccs-feature.sh
+++ b/ccs-feature.sh
@@ -87,10 +87,10 @@ _ccs_feature_cluster() {
     local dir="${__fc_projects[$i]}"
     local row="${__fc_rows[$i]}"
 
-    # Parse row fields (tab-separated) + get topic from JSONL
+    # Parse row fields (tab-separated: prov, project, ago, status, color, display, badge)
     local project sid topic
-    project=$(echo "$row" | cut -f1)
-    sid=$(basename "$f" .jsonl | cut -c1-8)
+    project=$(echo "$row" | cut -f2)
+    sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
     topic=$(_ccs_topic_from_jsonl "$f")
 
     # Friendly project name for feature ID prefix
@@ -202,8 +202,8 @@ _ccs_feature_cluster() {
       local _sf="${__fc_files[$idx]}"
       local _srow="${__fc_rows[$idx]}"
       local s_sid s_ago
-      s_sid=$(basename "$_sf" .jsonl | cut -c1-8)
-      s_ago=$(echo "$_srow" | cut -f2)
+      s_sid=$(basename "$_sf" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
+      s_ago=$(echo "$_srow" | cut -f3)
       session_ids+=("$s_sid")
 
       [ "$s_ago" -lt "$min_ago" ] && min_ago=$s_ago

--- a/ccs-feature.sh
+++ b/ccs-feature.sh
@@ -267,7 +267,7 @@ _ccs_feature_cluster() {
     local -a ug_ids=()
     for idx in "${ungrouped_indices[@]}"; do
       local ug_sid
-      ug_sid=$(basename "${__fc_files[$idx]}" .jsonl | cut -c1-8)
+      ug_sid=$(basename "${__fc_files[$idx]}" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
       ug_ids+=("$ug_sid")
     done
     local ug_json

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -70,7 +70,7 @@ HELP
   local latest="${open_sessions[0]}"
   local full_sid sid mod_date topic
 
-  full_sid=$(basename "$latest" .jsonl)
+  full_sid=$(basename "$latest" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
   sid=$(echo "$full_sid" | cut -c1-8)
   mod_date=$(stat -c "%y" "$latest" | cut -d. -f1)
 
@@ -100,7 +100,7 @@ HELP
   local zombie_count=0
   for f in "${open_sessions[@]}"; do
     local s_sid s_mod s_ago s_age s_topic
-    s_sid=$(basename "$f" .jsonl | cut -c1-8)
+    s_sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
     s_mod=$(stat -c "%Y" "$f"); s_ago=$(( ($(date +%s) - s_mod) / 60 ))
     if [ "$s_ago" -lt 60 ]; then s_age="${s_ago}m"
     elif [ "$s_ago" -lt 1440 ]; then s_age="$((s_ago/60))h"
@@ -269,7 +269,7 @@ HELP
 
   # ── Session metadata ──
   local full_sid sid topic dir project project_dir
-  full_sid=$(basename "$jsonl" .jsonl)
+  full_sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
   sid=$(echo "$full_sid" | cut -c1-8)
   topic=$(_ccs_topic_from_jsonl "$jsonl")
 

--- a/ccs-health.sh
+++ b/ccs-health.sh
@@ -23,7 +23,7 @@ CCS_HEALTH_STALE_DAYS="${CCS_HEALTH_STALE_DAYS:-7}"
 _ccs_health_events() {
   local f="$1"
   local sid
-  sid=$(basename "$f" .jsonl | cut -c1-8)
+  sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
 
   jq -s --arg sid "$sid" '
     reduce .[] as $line (
@@ -284,7 +284,7 @@ HELP
     # If prefix given, filter by session ID
     if [ -n "$prefix" ]; then
       local bname
-      bname=$(basename "$f" .jsonl)
+      bname=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       if [[ "$bname" != "${prefix}"* ]]; then
         continue
       fi
@@ -312,7 +312,7 @@ HELP
   for f in "${files[@]}"; do
     # Skip crashed sessions — health report is meaningless for dead sessions
     local _h_sid
-    _h_sid=$(basename "$f" .jsonl)
+    _h_sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     if [ -n "${_health_crash_map[$_h_sid]+x}" ] && [[ "${_health_crash_map[$_h_sid]}" == high:* ]]; then
       continue
     fi

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -18,7 +18,7 @@ _ccs_crash_md() {
   local i
   for ((i = 0; i < count; i++)); do
     local f="${_files[$i]}"
-    local sid=$(basename "$f" .jsonl)
+    local sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     [ -n "${_map[$sid]+x}" ] || continue
 
     local conf_path="${_map[$sid]}"
@@ -73,7 +73,7 @@ _ccs_crash_md() {
   for ((_i = 0; _i < ${#_files[@]}; _i++)); do
     local _cf="${_files[$_i]}"
     local _csid
-    _csid=$(basename "$_cf" .jsonl)
+    _csid=$(basename "$_cf" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     [ -n "${_map[$_csid]+x}" ] || continue
     local _age=$(( (_now_epoch - $(stat -c %Y "$_cf")) / 60 ))
     [ "$_age" -ge 4320 ] && (( _stale++ ))
@@ -105,7 +105,7 @@ _ccs_crash_json() {
   local i
   for ((i = 0; i < count; i++)); do
     local f="${_files[$i]}"
-    local sid=$(basename "$f" .jsonl)
+    local sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     [ -n "${_map[$sid]+x}" ] || continue
 
     local conf_path="${_map[$sid]}"
@@ -196,7 +196,7 @@ _ccs_crash_clean_by_id() {
     local count=${#_files[@]}
     for ((i = 0; i < count; i++)); do
       local f="${_files[$i]}"
-      local sid=$(basename "$f" .jsonl)
+      local sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       [ -n "${_map[$sid]+x}" ] || continue
       if [[ "$sid" == "$id"* ]]; then
         matches+=("$sid")
@@ -291,7 +291,7 @@ _ccs_crash_clean_all() {
 
   for ((i = 0; i < count; i++)); do
     local f="${_files[$i]}"
-    local sid=$(basename "$f" .jsonl)
+    local sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     [ -n "${_map[$sid]+x}" ] || continue
 
     _ccs_archive_session "$f"
@@ -497,7 +497,7 @@ _ccs_recap_collect() {
       _pc=$(jq -c 'select(.type == "user" and ((.isMeta // false) == false))' "$jsonl" 2>/dev/null | wc -l)
       [ "${_pc:-0}" -lt 2 ] && continue
 
-      sid=$(basename "$jsonl" .jsonl)
+      sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       topic=$(_ccs_topic_from_jsonl "$jsonl")
       last_iso=$(date -d "@$mtime" -Iseconds)
 
@@ -646,7 +646,7 @@ _ccs_recap_collect() {
     while IFS= read -r jsonl; do
       mtime=$(stat -c %Y "$jsonl" 2>/dev/null) || continue
       (( mtime < from_epoch )) && continue
-      sid=$(basename "$jsonl" .jsonl)
+      sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       topic=$(_ccs_topic_from_jsonl "$jsonl")
       dl_text=$(jq -r 'select(.type == "user" and .isMeta != true) |
         .message.content | if type == "string" then . else "" end' "$jsonl" 2>/dev/null |
@@ -1088,7 +1088,7 @@ _ccs_checkpoint_collect() {
       (( mtime < since_epoch )) && continue
 
       local sid topic is_archived age_min
-      sid=$(basename "$jsonl" .jsonl)
+      sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       topic=$(_ccs_topic_from_jsonl "$jsonl")
       age_min=$(( (now_epoch - mtime) / 60 ))
 

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -28,8 +28,8 @@ _ccs_crash_md() {
     [ "$confidence" = "low" ] && icon="🟡"
 
     local row="${_rows[$i]}"
-    local project=$(echo "$row" | cut -f1)
-    local ago_min=$(echo "$row" | cut -f2)
+    local project=$(echo "$row" | cut -f2)
+    local ago_min=$(echo "$row" | cut -f3)
     local topic=$(_ccs_topic_from_jsonl "$f")
 
     # Session data (last message, todos, git)
@@ -113,7 +113,7 @@ _ccs_crash_json() {
     local detection_path="${conf_path#*:}"
 
     local row="${_rows[$i]}"
-    local project=$(echo "$row" | cut -f1)
+    local project=$(echo "$row" | cut -f2)
     local topic=$(_ccs_topic_from_jsonl "$f")
 
     local data
@@ -242,13 +242,13 @@ _ccs_crash_clean() {
 
   for ((i = 0; i < count; i++)); do
     local f="${_files[$i]}"
-    local sid=$(basename "$f" .jsonl)
+    local sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     [ -n "${_map[$sid]+x}" ] || continue
     total=$((total + 1))
 
     local conf_path="${_map[$sid]}"
     local row="${_rows[$i]}"
-    local project=$(echo "$row" | cut -f1)
+    local project=$(echo "$row" | cut -f2)
     local topic=$(_ccs_topic_from_jsonl "$f")
 
     printf '\n\033[1m[%d/%d]\033[0m \033[31m%s\033[0m — %s\n' \

--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -118,7 +118,7 @@ _ccs_overview_md() {
     local dir="${_projects[$i]}"
     local row="${_rows[$i]}"
 
-    # Parse row fields (tab-separated: project, ago_min, status, color, display...)
+    # Parse row fields (tab-separated: prov, project, ago_min, status, color, display, badge)
     local project ago_min status sid topic
     project=$(echo "$row" | cut -f2)
     ago_min=$(echo "$row" | cut -f3)
@@ -127,7 +127,7 @@ _ccs_overview_md() {
     local resolved_path
     resolved_path=$(_ccs_resolve_project_path "$dir")
 
-    sid=$(basename "$f" .jsonl | cut -c1-8)
+    sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
     topic=$(_ccs_topic_from_jsonl "$f")
 
     # Status emoji
@@ -140,7 +140,7 @@ _ccs_overview_md() {
     esac
 
     # Override status icon if crash-interrupted (high confidence)
-    local full_sid=$(basename "$f" .jsonl)
+    local full_sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     if [ -n "${4:-}" ] && [ -n "${_crash_md[$full_sid]+x}" ] && [[ "${_crash_md[$full_sid]}" == high:* ]]; then
       emoji="🔴"
     fi
@@ -301,7 +301,7 @@ _ccs_overview_json() {
     resolved_path=$(_ccs_resolve_project_path "$dir")
 
     local sid
-    sid=$(basename "$f" .jsonl | cut -c1-8)
+    sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
     local topic
     topic=$(_ccs_topic_from_jsonl "$f")
 
@@ -317,7 +317,7 @@ _ccs_overview_json() {
 
     # Per-session crash fields (4th arg is optional)
     local crash_interrupted=false crash_confidence=""
-    local full_sid=$(basename "$f" .jsonl)
+    local full_sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     if [ -n "${4:-}" ] && [ -n "${_crash_json[$full_sid]+x}" ]; then
       crash_interrupted=true
       crash_confidence="${_crash_json[$full_sid]%%:*}"
@@ -505,7 +505,7 @@ _ccs_overview_files() {
     local _of="${__of_files[$i]}"
     local _dir="${__of_projects[$i]}"
     local _sid
-    _sid=$(basename "$_of" .jsonl | cut -c1-4)
+    _sid=$(basename "$_of" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-4)
     local _mod
     _mod=$(stat -c "%Y" "$_of" 2>/dev/null || echo 0)
 

--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -358,7 +358,7 @@ _ccs_project_json() {
     local f
     for f in "${session_files[@]}"; do
       local sid topic sstats turns duration_min session_date
-      sid=$(basename "$f" .jsonl | cut -c1-8)
+      sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
       topic=$(_ccs_topic_from_jsonl "$f")
       sstats=$(_ccs_session_stats "$f")
       turns=$(echo "$sstats" | jq '.rounds')

--- a/ccs-review.sh
+++ b/ccs-review.sh
@@ -111,7 +111,7 @@ _ccs_session_stats() {
 _ccs_review_json() {
   local jsonl="$1"
   local sid
-  sid=$(basename "$jsonl" .jsonl)
+  sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
 
   local dir project
   dir=$(basename "$(dirname "$jsonl")")

--- a/ccs-viewer.sh
+++ b/ccs-viewer.sh
@@ -42,7 +42,7 @@ HELP
     mod=$(stat -c "%Y" "$f")
     ago=$(( (now - mod) / 60 ))
 
-    full_sid=$(basename "$f" .jsonl)
+    full_sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
     sid=$(echo "$full_sid" | cut -c1-8)
 
     local dir
@@ -286,7 +286,7 @@ HELP
 
   # ── Session metadata ──
   local full_sid sid mod_date topic status dir project
-  full_sid=$(basename "$jsonl" .jsonl)
+  full_sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
   sid=$(echo "$full_sid" | cut -c1-8)
   mod_date=$(stat -c "%y" "$jsonl" | cut -d. -f1)
 


### PR DESCRIPTION
## Summary

修復 PR #41 (Multi-Provider Dashboard) 引入的 regression，恢復 `_ccs_collect_sessions` 的向後相容輸出格式。

Fixes #42

### 問題
- `_ccs_collect_sessions` 輸出從 TAB 改成 pipe `|`，但 `ccs-overview`、`ccs-crash`、`ccs-feature` 等下游 consumer 未更新
- `_out_projects` 從 encoded dir name 改成 decoded path，導致 `_ccs_resolve_project_path` 失敗
- `basename .jsonl` 不處理 Gemini `.json` 檔

### 修復
1. **`_ccs_collect_sessions`**：轉換 Python pipe 輸出為 TAB 格式（含 prov prefix），恢復 encoded dir name
2. **`ccs-ops.sh` / `ccs-feature.sh`**：field index +1（配合新 prov 欄位）
3. **全 codebase**：統一 `basename .jsonl` → sed 處理 `.jsonl` + `.json`（9 檔 20 處）

## Test plan

- [x] `ccs-sessions` — 正常顯示
- [x] `ccs-active` — 正常顯示 + crash 標記
- [x] `ccs-status --md` — 正常輸出
- [x] `ccs-overview --md` — 修復前 "division by 0"，修復後正常
- [x] `ccs-crash` — 修復前顯示 raw row，修復後正常
- [x] `ccs-feature --md` — 正常顯示
- [x] `tests/test-status.sh` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.ai/code)