### PR TITLE
feat: full support for Gemini CLI sessions (.json) with security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ If you use Code CLI Sessions heavily — multiple providers, multiple repos, mul
 - **Sessions are invisible.** No built-in way to list, search, or compare sessions. Each terminal is its own silo. Close the tab and the context is gone.
 - **Multi-repo chaos.** Working on a backend fix, a frontend feature, and a docs update simultaneously? Good luck remembering which session was doing what, in which repo.
 - **Zombie processes pile up.** Suspended claude processes (from terminal multiplexers, crashed tabs, or `Ctrl+Z`) silently eat 190-500 MB each. No warning, no cleanup.
-- **Context doesn't transfer.** Starting a new session means re-explaining everything. The old session's knowledge — files touched, decisions made, remaining todos — is trapped in a JSONL file nobody reads.
+- **Context doesn't transfer.** Starting a new session means re-explaining everything. The old session's knowledge — files touched, decisions made, remaining todos — is trapped in a JSON/JSONL file nobody reads.
 - **No cross-session view.** A single feature might span 5 sessions across 3 days. There's no way to see the full picture without manually digging through logs.
 
 ## Before / After
 
-**Before:** You're left staring at raw JSONL files.
+**Before:** You're left staring at raw JSON/JSONL files.
 
 ```
 $ ls ~/.claude/projects/
 -home-alice-backend-api/    -home-alice-frontend/    -home-alice-docs/
 $ ls ~/.claude/projects/-home-alice-backend-api/
 3a8f1c42-...jsonl  7b2e9d15-...jsonl  a1c4f8e2-...jsonl
-# Now what? Open each 50MB JSONL in vim?
+# Now what? Open each 50MB JSON/JSONL in vim?
 ```
 
 **After:** Just ask Claude. The included [custom skill](https://docs.anthropic.com/en/docs/claude-code/skills) gives you an interactive orchestrator — no commands to memorize.
@@ -183,7 +183,7 @@ Strikethrough     -           archived    has last-prompt marker
 | Required | Purpose |
 |----------|---------|
 | bash 4+ | mapfile, associative arrays |
-| jq | JSONL parsing |
+| jq | JSON/JSONL parsing |
 | coreutils | stat, date, find |
 
 | Optional | Purpose |

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -84,36 +84,34 @@ _ccs_topic_from_jsonl() {
   local topic=""
   local provider=$(_ccs_get_provider "$f")
   
-  if grep -q "change_title" "$f" 2>/dev/null; then
-    if [ "$provider" = "gemini" ]; then
-      # Gemini can be top-level array or object with .messages
-      # New object format (v0.35+): .messages[] | .toolCalls[]
-      topic=$(jq -r '
-        (if type == "array" then . else .messages // [] end)[]? |
-        select(.type == "gemini" or .type == "assistant" or .type == "model" or .role == "model") |
-        (
-          (.toolCalls[]? | select(.name == "mcp__happy__change_title") | .args.title) //
-          (.content[]? | select(.type == "toolCall" and .name == "mcp__happy__change_title") | .args.title) //
-          (select(.type == "tool_use" and .name == "mcp__happy__change_title") | .input.title)
-        )
-      ' "$f" 2>/dev/null | tail -1)
-    else
+  if [ "$provider" = "gemini" ]; then
+    # Check toolCalls for title change (support both .messages[] and top-level array)
+    topic=$(jq -r '
+      (if type == "array" then . else .messages // [] end)[]? |
+      select(.toolCalls) | .toolCalls[] |
+      select(.name == "mcp__happy__change_title") |
+      .args.title' "$f" 2>/dev/null | tail -1)
+  else
+    if grep -q "change_title" "$f" 2>/dev/null; then
       topic=$(grep "change_title" "$f" 2>/dev/null | jq -r '
         .message.content[]? |
         select(.type == "tool_use" and .name == "mcp__happy__change_title") |
         .input.title' 2>/dev/null | tail -1)
     fi
   fi
+
   if [ -z "$topic" ]; then
     # Find first real user message (skip meta, local-command, system tags, slash commands)
     # Strip XML tags from content to avoid <command-message> etc. leaking into topic
     if [ "$provider" = "gemini" ]; then
       topic=$(jq -r '
-        (if type == "array" then . else .messages // [] end)[]? |
-        select((.type == "user" or .role == "user") and ((.isMeta // false) == false)) |
-        (.content | if type == "array" then .[] | .text else . end) |
-        select(type == "string" and (test("^/") | not) and (test("^\\s*$") | not)) |
-        gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+        (if type == "array" then . else .messages // [] end)[]?
+        | select((.type == "user" or .role == "user") and ((.isMeta // false) == false))
+        | (.content // .message.content)
+        | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end
+        | select(test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+        | select(test("^\\s*$") | not)
+        | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
       ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
     else
       topic=$(jq -r '
@@ -141,9 +139,9 @@ _ccs_resolve_jsonl() {
       echo "$result"
       return 0
     fi
-    # Fallback: search Gemini chats dirs
+    # Fallback: search Gemini chats dirs (more flexibly for UUIDs)
     local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
-    find "$gemini_dir/tmp" -maxdepth 3 -path "*/chats/${prefix}*.json" 2>/dev/null | head -1
+    find "$gemini_dir/tmp" -maxdepth 3 \( -name "*${prefix}*.json" \) 2>/dev/null | grep "/chats/" | head -1
   else
     local search_dirs=()
     if [ "$search_all" = "true" ]; then
@@ -177,13 +175,41 @@ _ccs_resolve_jsonl() {
 }
 
 # ── Helper: extract prompt-response pairs index from JSONL ──
-# Output: tab-separated lines: prompt_line_num \t prompt_text_preview
+# Output: tab-separated lines: real_idx \t has_resp \t is_meta \t preview
 _ccs_build_pairs_index() {
   local jsonl="$1"
-  # Extract all user prompts (string content = real user input, not tool_result)
-  # and the next assistant text response after each
-  jq -r 'select(.type == "user" and (.message.content | type == "string")) | .message.content | gsub("\n"; " ") | .[:120]' "$jsonl" 2>/dev/null \
-    | cat -n
+  local provider=$(_ccs_get_provider "$jsonl")
+  
+  local jq_user_filter
+  if [ "$provider" = "gemini" ]; then
+    jq_user_filter='select(.value.type == "user" or .value.role == "user")
+      | select(.value.isMeta != true)
+      | (.value.content // .value.message.content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end) as $txt
+      | select($txt | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+      | select($txt | test("^\\s*$") | not)'
+  else
+    jq_user_filter='select(.value.type == "user" and (.value.message.content | type == "string"))
+      | select(.value.isMeta != true)
+      | select(.value.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+      | select(.value.message.content | test("^\\s*$") | not)'
+  fi
+
+  jq -r "
+    (if type == \"array\" then . else .messages // [] end)
+    | to_entries as \$all
+    | [ \$all[] | select(.value.type == \"user\" or .value.role == \"user\") ] as \$all_users
+    | [ \$all[] | $jq_user_filter ] as \$filtered_users
+    | range(0; (\$filtered_users | length)) as \$i
+    | \$filtered_users[\$i] as \$u
+    | (\$u.key) as \$start_pos
+    | (\$all_users | map(.key == \$u.key) | index(true) + 1) as \$ri
+    | (if \$i + 1 < (\$filtered_users | length) then \$filtered_users[\$i+1].key else (\$all | length) end) as \$end_pos
+    | (\$all[\$start_pos + 1 : \$end_pos] | map(select(.value.type == \"assistant\" or .value.type == \"gemini\" or .value.type == \"model\" or .value.role == \"assistant\" or .value.role == \"model\")) | length > 0 | tostring) as \$has_resp
+    | (\$u.value.content // \$u.value.message.content | if type == \"array\" then [.[]? | select(.text) | .text] | join(\" \") else . end) as \$text
+    | (\$u.value.isMeta // false | tostring) as \$is_meta
+    | (\$text | .[:120] | gsub(\"\\n\"; \" \")) as \$preview
+    | \"\(\$ri)\t\(\$has_resp)\t\(\$is_meta)\t\(\$preview)\"
+  " "$jsonl" 2>/dev/null
 }
 
 # ── Helper: extract the Nth prompt-response pair ──
@@ -195,32 +221,70 @@ _ccs_get_pair() {
 
   # Extract user prompts, assistant text, AND tool_use summaries
   # so interrupted turns still show what the agent was doing
-  jq -c '
-    if .type == "user" and (.message.content | type == "string") then
-      {role: "user", text: .message.content}
-    elif .type == "assistant" then
-      (.message.content | if type == "array" then
-        [.[] | select(.type == "text") | .text] | join("\n")
-      else . end) as $t |
-      (.message.content | if type == "array" then
-        [.[] | select(.type == "tool_use") |
-          if .name == "Read" then "📖 Read " + .input.file_path
-          elif .name == "Edit" then "✏️ Edit " + .input.file_path
-          elif .name == "Write" then "📝 Write " + .input.file_path
-          elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80])
-          elif .name == "Grep" then "🔍 Grep " + .input.pattern
-          elif .name == "Glob" then "🔍 Glob " + .input.pattern
-          elif .name == "Agent" then "🤖 Agent: " + (.input.description // "")
-          else "🔧 " + .name end
-        ] | join("\n")
-      else "" end) as $tools |
-      (.message.content | if type == "array" then
-        [.[] | select(.type == "thinking") | "💭 (thinking...)"] | join("\n")
-      else "" end) as $thinking |
-      {role: "assistant", text: $t, tools: $tools, thinking: $thinking}
-    else empty end
-  ' "$jsonl" 2>/dev/null \
-    | jq -sc --argjson idx "$pair_idx" '
+  if [ "$(_ccs_get_provider "$jsonl")" = "gemini" ]; then
+    jq -c '
+      (if type == "array" then . else .messages // [] end)[]? |
+      if (.type == "user" or .role == "user") then
+        {role: "user", text: ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join("\n") else (. // "") end)}
+      elif (.type == "assistant" or .type == "gemini" or .type == "model" or .role == "assistant" or .role == "model") then
+        (.content // .message.content | if type == "array" then
+          [.[]? | select(.text) | .text] | join("\n")
+        elif type == "string" then .
+        else "" end) as $t |
+        (((.content // .message.content) | if type == "array" then
+          [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .) |
+            if .name == "read_file" then "📖 Read " + (.args.file_path // "")
+            elif .name == "replace" then "✏️ Edit " + (.args.file_path // "")
+            elif .name == "write_file" then "📝 Write " + (.args.file_path // "")
+            elif .name == "run_shell_command" then "$ " + (.args.command | split("\n") | first | .[:80])
+            elif .name == "grep_search" then "🔍 Grep " + (.args.pattern // "")
+            elif .name == "glob" then "🔍 Glob " + (.args.pattern // "")
+            elif .name == "activate_skill" then "🤖 Skill: " + .args.name
+            else "🔧 " + .name end
+          ]
+        else [] end) +
+        (.toolCalls | if type == "array" then
+          [.[]? |
+            if .name == "read_file" then "📖 Read " + (.args.file_path // "")
+            elif .name == "replace" then "✏️ Edit " + (.args.file_path // "")
+            elif .name == "write_file" then "📝 Write " + (.args.file_path // "")
+            elif .name == "run_shell_command" then "$ " + (.args.command | split("\n") | first | .[:80])
+            elif .name == "grep_search" then "🔍 Grep " + (.args.pattern // "")
+            elif .name == "glob" then "🔍 Glob " + (.args.pattern // "")
+            elif .name == "activate_skill" then "🤖 Skill: " + .args.name
+            else "🔧 " + .name end
+          ]
+        else [] end) | join("\n")) as $tools |
+        {role: "assistant", text: $t, tools: $tools}
+      else empty end
+    ' "$jsonl" 2>/dev/null
+  else
+    jq -c '
+      if .type == "user" and (.message.content | type == "string") then
+        {role: "user", text: .message.content}
+      elif .type == "assistant" then
+        (.message.content | if type == "array" then
+          [.[] | select(.type == "text") | .text] | join("\n")
+        else . end) as $t |
+        (.message.content | if type == "array" then
+          [.[] | select(.type == "tool_use") |
+            if .name == "Read" then "📖 Read " + .input.file_path
+            elif .name == "Edit" then "✏️ Edit " + .input.file_path
+            elif .name == "Write" then "📝 Write " + .input.file_path
+            elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80])
+            elif .name == "Grep" then "🔍 Grep " + .input.pattern
+            elif .name == "Glob" then "🔍 Glob " + .input.pattern
+            elif .name == "Agent" then "🤖 Agent: " + (.input.description // "")
+            else "🔧 " + .name end
+          ] | join("\n")
+        else "" end) as $tools |
+        (.message.content | if type == "array" then
+          [.[] | select(.type == "thinking") | "💭 (thinking...)"] | join("\n")
+        else "" end) as $thinking |
+        {role: "assistant", text: $t, tools: $tools, thinking: $thinking}
+      else empty end
+    ' "$jsonl" 2>/dev/null
+  fi | jq -sc --argjson idx "$pair_idx" '
       . as $arr |
       [to_entries[] | select(.value.role == "user")] as $users |
       if ($idx < 1 or $idx > ($users | length)) then empty
@@ -234,15 +298,18 @@ _ccs_get_pair() {
           tools: ([.[].tools] | map(select(length > 0)) | join("\n")),
           thinking: ([.[].thinking] | map(select(length > 0)) | join("\n"))
         }) as $resp |
-        if ($resp.texts | length) > 0 then
-          {role: "assistant", text: $resp.texts}
+        (if ($resp.texts | length) > 0 and ($resp.tools | length) > 0 then
+          $resp.texts + "\n\n" + $resp.tools
+        elif ($resp.texts | length) > 0 then
+          $resp.texts
         elif ($resp.tools | length) > 0 then
-          {role: "assistant", text: ("⚡ interrupted — agent was executing:\n" + $resp.tools)}
+          "⚡ interrupted — agent was executing:\n" + $resp.tools
         elif ($resp.thinking | length) > 0 then
-          {role: "assistant", text: "⚡ interrupted — agent was thinking"}
+          "⚡ interrupted — agent was thinking"
         else
-          {role: "assistant", text: ""}
-        end
+          ""
+        end) as $combined_text |
+        {role: "assistant", text: $combined_text}
       end
     '
 }
@@ -251,10 +318,21 @@ _ccs_get_pair() {
 # Usage: _ccs_conversation_md <jsonl> <pair_count> <max_user_lines> <max_asst_lines>
 _ccs_conversation_md() {
   local jsonl="$1" pair_count="${2:-5}" max_ulines="${3:-5}" max_alines="${4:-8}"
+  local provider=$(_ccs_get_provider "$jsonl")
+  local asst_label="Claude"
+  [ "$provider" = "gemini" ] && asst_label="Gemini"
 
   # Build filtered pair indices (reuse ccs-resume-prompt logic)
   local -a real_to_raw=()
   local raw_idx=0
+  
+  local jq_filter
+  if [ "$provider" = "gemini" ]; then
+    jq_filter='(if type == "array" then . else .messages // [] end)[]? | select(.type == "user" or .role == "user") | [((.isMeta // false) | tostring), ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | .[:80] | gsub("\n"; " "))] | @tsv'
+  else
+    jq_filter='select(.type == "user" and (.message.content | type == "string")) | [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] | @tsv'
+  fi
+
   while IFS=$'\t' read -r is_meta content; do
     raw_idx=$((raw_idx + 1))
     [ "$is_meta" = "true" ] && continue
@@ -265,11 +343,7 @@ _ccs_conversation_md() {
     [[ "$content" =~ ^[[:space:]]*/quit ]] && continue
     [ -z "${content// /}" ] && continue
     real_to_raw+=("$raw_idx")
-  done < <(jq -r '
-    select(.type == "user" and (.message.content | type == "string")) |
-    [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] |
-    @tsv
-  ' "$jsonl" 2>/dev/null)
+  done < <(jq -r "$jq_filter" "$jsonl" 2>/dev/null)
 
   local real_count=${#real_to_raw[@]}
   local start_from=$((real_count - pair_count + 1))
@@ -295,36 +369,63 @@ _ccs_conversation_md() {
 ..."
 
     printf '**[%d/%d] User:**\n%s\n\n' "$ri" "$real_count" "$user_preview"
-    printf '**[%d/%d] Claude:**\n%s\n\n' "$ri" "$real_count" "$asst_preview"
+    printf '**[%d/%d] %s:**\n%s\n\n' "$ri" "$real_count" "$asst_label" "$asst_preview"
   done
 }
 
 # ── Helper: extract recent file operations from JSONL ──
 _ccs_recent_files_md() {
   local jsonl="$1"
-  jq -r '
-    select(.type == "assistant") |
-    .message.content[]? |
-    select(.type == "tool_use") |
-    if .name == "Read" then "R " + .input.file_path
-    elif .name == "Edit" then "E " + .input.file_path
-    elif .name == "Write" then "W " + .input.file_path
-    elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80])
-    else empty end
-  ' "$jsonl" 2>/dev/null | tail -15 | sort -u
+  local provider=$(_ccs_get_provider "$jsonl")
+  if [ "$provider" = "gemini" ]; then
+    jq -r '
+      (if type == "array" then . else .messages // [] end)[]? |
+      select(.type == "assistant" or .type == "gemini" or .type == "model" or .role == "assistant" or .role == "model") |
+      (.toolCalls // (.content // .message.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? |
+      if .name == "read_file" then "R " + .args.file_path
+      elif .name == "replace" then "E " + .args.file_path
+      elif .name == "write_file" then "W " + .args.file_path
+      elif .name == "run_shell_command" then "$ " + (.args.command | split("\n") | first | .[:80])
+      elif .name == "grep_search" then "🔍 Grep " + .args.pattern
+      elif .name == "glob" then "🔍 Glob " + .args.pattern
+      else empty end
+    ' "$jsonl" 2>/dev/null | tail -15 | sort -u
+  else
+    jq -r '
+      select(.type == "assistant") |
+      .message.content[]? |
+      select(.type == "tool_use") |
+      if .name == "Read" then "R " + .input.file_path
+      elif .name == "Edit" then "E " + .input.file_path
+      elif .name == "Write" then "W " + .input.file_path
+      elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80])
+      else empty end
+    ' "$jsonl" 2>/dev/null | tail -15 | sort -u
+  fi
 }
 
 # ── Helper: extract TodoWrite items from JSONL ──
 _ccs_todos_md() {
   local jsonl="$1"
-  # Find the last TodoWrite call and extract its items
-  jq -r '
-    select(.type == "assistant") |
-    .message.content[]? |
-    select(.type == "tool_use" and .name == "TodoWrite") |
-    .input.todos[]? |
-    (if .status == "completed" then "- [x] " elif .status == "in_progress" then "- [~] " else "- [ ] " end) + .content
-  ' "$jsonl" 2>/dev/null | tail -20
+  local provider=$(_ccs_get_provider "$jsonl")
+  if [ "$provider" = "gemini" ]; then
+    jq -r '
+      (if type == "array" then . else .messages // [] end)[]? |
+      select(.type == "assistant" or .type == "gemini" or .type == "model" or .role == "assistant" or .role == "model") |
+      (.toolCalls // (.content // .message.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? |
+      select(.name == "write_todos") |
+      .args.todos[]? |
+      (if .status == "completed" then "- [x] " elif .status == "in_progress" then "- [~] " else "- [ ] " end) + .content
+    ' "$jsonl" 2>/dev/null | tail -20
+  else
+    jq -r '
+      select(.type == "assistant") |
+      .message.content[]? |
+      select(.type == "tool_use" and .name == "TodoWrite") |
+      .input.todos[]? |
+      (if .status == "completed" then "- [x] " elif .status == "in_progress" then "- [~] " else "- [ ] " end) + .content
+    ' "$jsonl" 2>/dev/null | tail -20
+  fi
 }
 
 # ── ccs-sessions [hours] — all sessions within N hours (default 24) ──

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -43,7 +43,13 @@ _ccs_get_provider() {
 _ccs_is_archived() {
   local f="$1"
   if [ "$(_ccs_get_provider "$f")" = "gemini" ]; then
-    return 1 # Gemini doesn't use standard archive markers yet
+    # Gemini: check for injected "archived": true flag
+    local is_archived
+    is_archived=$(jq -r '.archived // false' "$f" 2>/dev/null)
+    if [ "$is_archived" = "true" ]; then
+      return 0
+    fi
+    return 1
   fi
   # Check 1: /exit pattern (handles missing last-prompt after resume→/exit)
   # The /exit sequence writes 3 user events at the very end: caveat, command, stdout.
@@ -79,9 +85,18 @@ _ccs_topic_from_jsonl() {
   local provider=$(_ccs_get_provider "$f")
   
   if grep -q "change_title" "$f" 2>/dev/null; then
-    # Both formats can be filtered with standard jq if we unpack Gemini arrays
     if [ "$provider" = "gemini" ]; then
-      topic=$(jq -r '.[] | select(.type == "tool_use" and .name == "mcp__happy__change_title") | .input.title' "$f" 2>/dev/null | tail -1)
+      # Gemini can be top-level array or object with .messages
+      # New object format (v0.35+): .messages[] | .toolCalls[]
+      topic=$(jq -r '
+        (if type == "array" then . else .messages // [] end)[]? |
+        select(.type == "gemini" or .type == "assistant" or .type == "model" or .role == "model") |
+        (
+          (.toolCalls[]? | select(.name == "mcp__happy__change_title") | .args.title) //
+          (.content[]? | select(.type == "toolCall" and .name == "mcp__happy__change_title") | .args.title) //
+          (select(.type == "tool_use" and .name == "mcp__happy__change_title") | .input.title)
+        )
+      ' "$f" 2>/dev/null | tail -1)
     else
       topic=$(grep "change_title" "$f" 2>/dev/null | jq -r '
         .message.content[]? |
@@ -94,11 +109,11 @@ _ccs_topic_from_jsonl() {
     # Strip XML tags from content to avoid <command-message> etc. leaking into topic
     if [ "$provider" = "gemini" ]; then
       topic=$(jq -r '
-        .[] | select(.type == "user" and (.message.content | type == "string")
-          and ((.isMeta // false) == false)
-          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
-          and (.message.content | test("^\\s*$") | not))
-        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+        (if type == "array" then . else .messages // [] end)[]? |
+        select((.type == "user" or .role == "user") and ((.isMeta // false) == false)) |
+        (.content | if type == "array" then .[] | .text else . end) |
+        select(type == "string" and (test("^/") | not) and (test("^\\s*$") | not)) |
+        gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
       ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
     else
       topic=$(jq -r '
@@ -618,16 +633,18 @@ _ccs_detect_crash() {
   local idle_window_start=$((now - idle_window * 60))
 
   # Get running session info (once)
-  # Method 1: session IDs from --resume args
+  # Method 1: session IDs from --resume or --session args
   local running_sids=""
-  running_sids=$(ps -eo args 2>/dev/null | grep -oP '(?<=--resume )[0-9a-f-]{36}' | sort -u)
-  # Method 2: normalized cwds of all claude processes
+  running_sids=$(ps -eo args 2>/dev/null | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' | sort -u)
+  # Method 2: normalized cwds of all claude or gemini processes
   # Claude Code encodes paths by replacing /._  with -, so we normalize both sides
   # to alphanumeric segments joined by - for comparison.
   local running_cwds_normalized=""
   running_cwds_normalized=$({
     for p in $(pgrep -u "$(id -u)" -f "claude.*--output-format" 2>/dev/null) \
-             $(pgrep -u "$(id -u)" -x "claude" 2>/dev/null); do
+             $(pgrep -u "$(id -u)" -x "claude" 2>/dev/null) \
+             $(pgrep -u "$(id -u)" -x "gemini" 2>/dev/null) \
+             $(pgrep -u "$(id -u)" -f "bin/gemini|index.mjs gemini|happy-coder" 2>/dev/null); do
       readlink "/proc/$p/cwd" 2>/dev/null
     done
   } | sort -u | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
@@ -640,7 +657,9 @@ _ccs_detect_crash() {
 
     local mtime sid
     if [[ "$f" == *.json ]]; then
-       local last_ts=$(jq -r '.[-1].timestamp // empty' "$f" 2>/dev/null)
+       # Claude format: [..., {"timestamp": "..."}]
+       # Gemini format: {"lastUpdated": "...", "messages": [...]}
+       local last_ts=$(jq -r 'if type == "array" then .[-1].timestamp else .lastUpdated end // empty' "$f" 2>/dev/null)
        if [ -n "$last_ts" ]; then
          mtime=$(date -d "$last_ts" +%s 2>/dev/null || stat -c "%Y" "$f" 2>/dev/null)
        else
@@ -651,6 +670,7 @@ _ccs_detect_crash() {
     fi
     [ -n "$mtime" ] || continue
     sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
+    echo "DEBUG: checking $sid, f=$f, mtime=$mtime, age=$((now-mtime))" >&2
 
     # Path 1: Reboot detection
     # Any pre-boot session without a running process was killed by reboot.
@@ -660,7 +680,7 @@ _ccs_detect_crash() {
     #   within window = was actively writing near boot time
     #   outside window = was idle but process killed by reboot
     if [ "$boot_epoch" -gt 0 ] && [ "$mtime" -lt "$reboot_upper" ]; then
-      echo "$running_sids" | grep -q "$sid" && continue
+      echo "$running_sids" | grep -qw "$sid" && continue
       if [ "$mtime" -ge "$reboot_window_start" ]; then
         _crash_out["$sid"]="high:reboot"
       else
@@ -678,14 +698,14 @@ _ccs_detect_crash() {
     # Method 1: exact session ID match (--resume sessions) — precise
     # Method 2: cwd match (Happy-launched sessions without --resume) — approximate
     local is_running_exact=false is_running_cwd=false
-    if echo "$running_sids" | grep -q "$sid"; then
+    if echo "$running_sids" | grep -qw "$sid"; then
       is_running_exact=true
     elif [ -n "${_cd_projects[$i]}" ]; then
       # Normalize project dir name to match normalized cwds
       # Both sides: replace /._  with -, collapse multiple -, strip leading -
       local _proj_normalized
       _proj_normalized=$(echo "${_cd_projects[$i]}" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
-      [ -n "$_proj_normalized" ] && echo "$running_cwds_normalized" | grep -qF "$_proj_normalized" &&
+      [ -n "$_proj_normalized" ] && echo "$running_cwds_normalized" | grep -qE ".*$_proj_normalized$" &&
       is_running_cwd=true
     fi
 
@@ -706,16 +726,36 @@ _ccs_detect_crash() {
     # Process running (exact or cwd) — not crashed
     ("$is_running_exact" || "$is_running_cwd") && continue
 
-    # Check for interrupt signals in last assistant message (raw JSONL)
-    # Last assistant message: content array with no text entries = mid-execution crash
-    local has_text
-    has_text=$(tac "$f" 2>/dev/null | grep -m1 '"type":"assistant"' | jq -r '
-      if .message.content then
-        ([.message.content[] | select(.type == "text" and (.text | length > 0))] | length)
-      else
-        0
-      end
-    ' 2>/dev/null)
+    # Check for interrupt signals in last assistant message
+    # Mid-execution crash: assistant message started but contains no text content
+    local has_text=0
+    if [[ "$f" == *.json ]]; then
+      # Gemini or Claude-exported-JSON: parse whole file
+      has_text=$(jq -r '
+        (if type == "array" then . else .messages // [] end) |
+        [.[] | select(.type == "assistant" or .type == "gemini" or .type == "model")] | last |
+        (.message.content // .content) as $c |
+        if $c | type == "array" then
+          ([$c[] | select(.type == "text" and (.text | length > 0))] | length)
+        elif $c | type == "string" then
+          ($c | length)
+        else 0 end
+      ' "$f" 2>/dev/null)
+    else
+      # Claude JSONL: use tac for speed, but only call jq if assistant message found
+      local last_asst
+      last_asst=$(tac "$f" 2>/dev/null | grep -m1 -E '"type":"(assistant|gemini|model)"')
+      if [ -n "$last_asst" ]; then
+        has_text=$(echo "$last_asst" | jq -r '
+          (.message.content // .content) as $c |
+          if $c | type == "array" then
+            ([$c[] | select(.type == "text" and (.text | length > 0))] | length)
+          elif $c | type == "string" then
+            ($c | length)
+          else 0 end
+        ' 2>/dev/null)
+      fi
+    fi
 
     if [ "${has_text:-0}" = "0" ]; then
       _crash_out["$sid"]="high:non-reboot"

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -17,6 +17,7 @@ _CCS_DASHBOARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 #   _ccs_todos_md           — TodoWrite items from JSONL
 #   _ccs_find_project_dir    — find encoded project dir from filesystem path
 #   _ccs_resolve_project_path — resolve JSONL dir name → filesystem path
+#   _ccs_gemini_chats_dir   — resolve current project's Gemini chats directory
 #   _ccs_get_boot_epoch     — system boot time as epoch
 #   _ccs_detect_crash       — detect crash-interrupted sessions
 #
@@ -116,19 +117,46 @@ _ccs_topic_from_jsonl() {
 # ── Helper: resolve JSONL file from args ──
 _ccs_resolve_jsonl() {
   local projects_dir="$HOME/.claude/projects"
-  local prefix="$1" search_all="$2"
+  local prefix="${1:-}" search_all="${2:-}"
   if [ -n "$prefix" ]; then
-    find "$projects_dir" -maxdepth 2 \( -name "${prefix}*.jsonl" -o -name "${prefix}*.json" \) ! -path "*/subagents/*" 2>/dev/null | head -1
+    # Search Claude projects
+    local result
+    result=$(find "$projects_dir" -maxdepth 2 \( -name "${prefix}*.jsonl" -o -name "${prefix}*.json" \) ! -path "*/subagents/*" 2>/dev/null | head -1)
+    if [ -n "$result" ]; then
+      echo "$result"
+      return 0
+    fi
+    # Fallback: search Gemini chats dirs
+    local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
+    find "$gemini_dir/tmp" -maxdepth 3 -path "*/chats/${prefix}*.json" 2>/dev/null | head -1
   else
-    local search_dir
+    local search_dirs=()
     if [ "$search_all" = "true" ]; then
-      search_dir="$projects_dir"
+      search_dirs+=("$projects_dir")
+      # Add all Gemini project chats dirs
+      local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
+      if [ -d "$gemini_dir/tmp" ]; then
+        local d
+        for d in "$gemini_dir/tmp"/*/chats; do
+          [ -d "$d" ] && search_dirs+=("$d")
+        done
+      fi
     else
       local encoded_dir
-      encoded_dir=$(_ccs_find_project_dir "$(pwd)") || return 1
-      search_dir="$projects_dir/$encoded_dir"
+      encoded_dir=$(_ccs_find_project_dir "$(pwd)") || true
+      [ -n "$encoded_dir" ] && search_dirs+=("$projects_dir/$encoded_dir")
+      # Also search current project's Gemini chats dir
+      local gemini_chats
+      gemini_chats=$(_ccs_gemini_chats_dir "$(pwd)") && search_dirs+=("$gemini_chats")
     fi
-    find "$search_dir" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
+    [ ${#search_dirs[@]} -eq 0 ] && return 1
+    # Find most recently modified session across all search dirs
+    local find_args=()
+    for d in "${search_dirs[@]}"; do
+      [ ${#find_args[@]} -gt 0 ] && find_args+=("-o")
+      find_args+=("-path" "$d/*")
+    done
+    find "${search_dirs[@]}" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
       | sort -rn | head -1 | cut -f2
   fi
 }
@@ -732,6 +760,37 @@ _ccs_find_project_dir() {
       return 0
     }
   done
+  return 1
+}
+
+# ── Helper: resolve Gemini chats directory for a filesystem path ──
+# Uses ~/.gemini/projects.json to map path → slug, then returns chats dir.
+# Falls back to current project slug if no argument given.
+_ccs_gemini_chats_dir() {
+  local target="${1:-$(pwd)}"
+  local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
+  local projects_json="$gemini_dir/projects.json"
+  [ -f "$projects_json" ] || return 1
+
+  # Find the slug for this path (exact match or longest prefix match)
+  local slug
+  slug=$(python3 -c "
+import json, sys, os
+target = os.path.realpath('$target')
+pj = json.load(open('$projects_json'))
+best_path, best_slug = '', ''
+for path, slug in pj.get('projects', {}).items():
+    rp = os.path.realpath(path)
+    if target == rp or target.startswith(rp + '/'):
+        if len(rp) > len(best_path):
+            best_path, best_slug = rp, slug
+if best_slug:
+    print(best_slug)
+" 2>/dev/null)
+  [ -z "$slug" ] && return 1
+
+  local chats_dir="$gemini_dir/tmp/$slug/chats"
+  [ -d "$chats_dir" ] && echo "$chats_dir" && return 0
   return 1
 }
 

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -30,8 +30,20 @@ _CCS_DASHBOARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 #   1. last-prompt exists AND no assistant event follows it, OR
 #   2. Last user events are /exit commands (Claude Code bug: resume→/exit may not write last-prompt)
 # Returns 0 if archived, 1 if not.
+_ccs_get_provider() {
+  local f="$1"
+  if [[ "$f" == *.json ]]; then
+    echo "gemini"
+  else
+    echo "claude"
+  fi
+}
+
 _ccs_is_archived() {
   local f="$1"
+  if [ "$(_ccs_get_provider "$f")" = "gemini" ]; then
+    return 1 # Gemini doesn't use standard archive markers yet
+  fi
   # Check 1: /exit pattern (handles missing last-prompt after resume→/exit)
   # The /exit sequence writes 3 user events at the very end: caveat, command, stdout.
   # Key signal: last line is a user event containing "Goodbye!" or "See ya!" (exit stdout).
@@ -63,22 +75,39 @@ _ccs_session_row() {
 _ccs_topic_from_jsonl() {
   local f="$1"
   local topic=""
+  local provider=$(_ccs_get_provider "$f")
+  
   if grep -q "change_title" "$f" 2>/dev/null; then
-    topic=$(grep "change_title" "$f" 2>/dev/null | jq -r '
-      .message.content[]? |
-      select(.type == "tool_use" and .name == "mcp__happy__change_title") |
-      .input.title' 2>/dev/null | tail -1)
+    # Both formats can be filtered with standard jq if we unpack Gemini arrays
+    if [ "$provider" = "gemini" ]; then
+      topic=$(jq -r '.[] | select(.type == "tool_use" and .name == "mcp__happy__change_title") | .input.title' "$f" 2>/dev/null | tail -1)
+    else
+      topic=$(grep "change_title" "$f" 2>/dev/null | jq -r '
+        .message.content[]? |
+        select(.type == "tool_use" and .name == "mcp__happy__change_title") |
+        .input.title' 2>/dev/null | tail -1)
+    fi
   fi
   if [ -z "$topic" ]; then
     # Find first real user message (skip meta, local-command, system tags, slash commands)
     # Strip XML tags from content to avoid <command-message> etc. leaking into topic
-    topic=$(jq -r '
-      select(.type == "user" and (.message.content | type == "string")
-        and ((.isMeta // false) == false)
-        and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
-        and (.message.content | test("^\\s*$") | not))
-      | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
-    ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
+    if [ "$provider" = "gemini" ]; then
+      topic=$(jq -r '
+        .[] | select(.type == "user" and (.message.content | type == "string")
+          and ((.isMeta // false) == false)
+          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+          and (.message.content | test("^\\s*$") | not))
+        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+      ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
+    else
+      topic=$(jq -r '
+        select(.type == "user" and (.message.content | type == "string")
+          and ((.isMeta // false) == false)
+          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+          and (.message.content | test("^\\s*$") | not))
+        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+      ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
+    fi
   fi
   [ -z "$topic" ] && topic="-"
   echo "$topic"
@@ -89,7 +118,7 @@ _ccs_resolve_jsonl() {
   local projects_dir="$HOME/.claude/projects"
   local prefix="$1" search_all="$2"
   if [ -n "$prefix" ]; then
-    find "$projects_dir" -maxdepth 2 -name "${prefix}*.jsonl" ! -path "*/subagents/*" 2>/dev/null | head -1
+    find "$projects_dir" -maxdepth 2 \( -name "${prefix}*.jsonl" -o -name "${prefix}*.json" \) ! -path "*/subagents/*" 2>/dev/null | head -1
   else
     local search_dir
     if [ "$search_all" = "true" ]; then
@@ -99,7 +128,7 @@ _ccs_resolve_jsonl() {
       encoded_dir=$(_ccs_find_project_dir "$(pwd)") || return 1
       search_dir="$projects_dir/$encoded_dir"
     fi
-    find "$search_dir" -maxdepth 2 -name "*.jsonl" ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
+    find "$search_dir" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
       | sort -rn | head -1 | cut -f2
   fi
 }
@@ -446,7 +475,7 @@ HELP
     last_active="-"
     if [ -n "$sid" ]; then
       local jsonl
-      jsonl=$(find "$HOME/.claude/projects" -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null | head -1)
+      jsonl=$(find "$HOME/.claude/projects" -maxdepth 2 \( -name "${sid}.jsonl" -o -name "${sid}.json" \) 2>/dev/null | head -1)
       if [ -n "$jsonl" ]; then
         last_active=$(date -d "$(stat -c '%y' "$jsonl")" '+%Y/%m/%d %H:%M:%S' 2>/dev/null || echo "-")
         topic=$(_ccs_topic_from_jsonl "$jsonl")
@@ -582,7 +611,17 @@ _ccs_detect_crash() {
     [ -f "$f" ] || continue
 
     local mtime sid
-    mtime=$(stat -c "%Y" "$f" 2>/dev/null) || continue
+    if [[ "$f" == *.json ]]; then
+       local last_ts=$(jq -r '.[-1].timestamp // empty' "$f" 2>/dev/null)
+       if [ -n "$last_ts" ]; then
+         mtime=$(date -d "$last_ts" +%s 2>/dev/null || stat -c "%Y" "$f" 2>/dev/null)
+       else
+         mtime=$(stat -c "%Y" "$f" 2>/dev/null)
+       fi
+    else
+       mtime=$(stat -c "%Y" "$f" 2>/dev/null)
+    fi
+    [ -n "$mtime" ] || continue
     sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
 
     # Path 1: Reboot detection

--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -186,7 +186,7 @@ HELP
     last_active="-"
     if [ -n "$sid" ]; then
       local jsonl
-      jsonl=$(find "$projects_dir" -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null | head -1)
+      jsonl=$(find "$projects_dir" -maxdepth 2 \( -name "${sid}.jsonl" -o -name "${sid}.json" \) 2>/dev/null | head -1)
       if [ -n "$jsonl" ]; then
         last_active=$(date -d "$(stat -c '%y' "$jsonl")" '+%Y/%m/%d %H:%M:%S' 2>/dev/null || echo "-")
         topic=$(_ccs_topic_from_jsonl "$jsonl")
@@ -355,7 +355,7 @@ _ccs_status_md() {
     topic="-"
     if [ -n "$sid" ]; then
       local jsonl
-      jsonl=$(find "$projects_dir" -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null | head -1)
+      jsonl=$(find "$projects_dir" -maxdepth 2 \( -name "${sid}.jsonl" -o -name "${sid}.json" \) 2>/dev/null | head -1)
       [ -n "$jsonl" ] && topic=$(_ccs_topic_from_jsonl "$jsonl")
     fi
 
@@ -482,7 +482,15 @@ HELP
     fi
 
     local total_prompts
-    total_prompts=$(jq -c 'select(.type == "user" and (.message.content | type == "string"))' "$jsonl" 2>/dev/null | wc -l)
+    local provider=$(_ccs_get_provider "$jsonl")
+    local jq_filter='select(.type == "user" and (.message.content | type == "string"))'
+    total_prompts=$( (
+      if [ "$provider" = "gemini" ]; then
+        jq -c ".[]" "$jsonl" 2>/dev/null
+      else
+        cat "$jsonl" 2>/dev/null
+      fi
+    ) | jq -c "$jq_filter" 2>/dev/null | wc -l)
 
     echo "### 🔍 #${idx} ${topic}"
     echo
@@ -506,7 +514,12 @@ HELP
       echo "${assistant_text}"
       echo
       echo "---"
-      echo "_Resume: \`claude --resume ${full_sid}\`_"
+      local provider=$(_ccs_get_provider "$jsonl")
+      if [ "$provider" = "gemini" ]; then
+        echo "_Resume: \`gemini --session ${full_sid}\`_"
+      else
+        echo "_Resume: \`claude --resume ${full_sid}\`_"
+      fi
       return 0
     fi
 
@@ -539,7 +552,12 @@ HELP
     done
     echo
     echo "---"
-    echo "_Resume: \`claude --resume ${full_sid}\`_"
+    local provider=$(_ccs_get_provider "$jsonl")
+    if [ "$provider" = "gemini" ]; then
+      echo "_Resume: \`gemini --session ${full_sid}\`_"
+    else
+      echo "_Resume: \`claude --resume ${full_sid}\`_"
+    fi
   else
     ccs-details --last "$sid"
   fi

--- a/ccs-feature.sh
+++ b/ccs-feature.sh
@@ -372,7 +372,7 @@ _ccs_feature_md() {
       for ug_sid in "${ug_sids[@]}"; do
         # Find session file by prefix
         local ug_file
-        ug_file=$(find "$HOME/.claude/projects" \( -name "${ug_sid}*.jsonl" -o -name "${ug_sid}*.json" \) -type f 2>/dev/null | head -1)
+        ug_file=$(_ccs_resolve_jsonl "$ug_sid")
         if [ -n "$ug_file" ]; then
           local ug_topic ug_ago
           ug_topic=$(_ccs_topic_from_jsonl "$ug_file")
@@ -479,7 +479,7 @@ _ccs_feature_terminal() {
       mapfile -t ug_sids < <(echo "$ungrouped_json" | jq -r '.sessions[]')
       for ug_sid in "${ug_sids[@]}"; do
         local ug_file
-        ug_file=$(find "$HOME/.claude/projects" \( -name "${ug_sid}*.jsonl" -o -name "${ug_sid}*.json" \) -type f 2>/dev/null | head -1)
+        ug_file=$(_ccs_resolve_jsonl "$ug_sid")
         if [ -n "$ug_file" ]; then
           local ug_topic ug_ago ug_mod ug_now
           ug_topic=$(_ccs_topic_from_jsonl "$ug_file")
@@ -545,7 +545,7 @@ _ccs_feature_detail_md() {
     mapfile -t session_sids < <(echo "$feature_line" | jq -r '.sessions[]')
     for sid in "${session_sids[@]}"; do
       local sfile
-      sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
+      sfile=$(_ccs_resolve_jsonl "$sid")
       [ -z "$sfile" ] && continue
       local sdata
       sdata=$(_ccs_overview_session_data "$sfile")
@@ -562,7 +562,7 @@ _ccs_feature_detail_md() {
   first_sid=$(echo "$feature_line" | jq -r '.sessions[0] // ""')
   if [ -n "$first_sid" ]; then
     local first_file
-    first_file=$(find "$HOME/.claude/projects" \( -name "${first_sid}*.jsonl" -o -name "${first_sid}*.json" \) -type f 2>/dev/null | head -1)
+    first_file=$(_ccs_resolve_jsonl "$first_sid")
     if [ -n "$first_file" ]; then
       local encoded_dir
       encoded_dir=$(basename "$(dirname "$first_file")")
@@ -595,7 +595,7 @@ _ccs_feature_detail_md() {
   for sid in "${session_sids2[@]}"; do
     sn=$((sn + 1))
     local sfile
-    sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
+    sfile=$(_ccs_resolve_jsonl "$sid")
     if [ -n "$sfile" ]; then
       local stopic smod snow sago
       stopic=$(_ccs_topic_from_jsonl "$sfile")
@@ -644,7 +644,7 @@ _ccs_feature_timeline_md() {
   local -a entries=()
   for sid in "${session_sids[@]}"; do
     local sfile
-    sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
+    sfile=$(_ccs_resolve_jsonl "$sid")
     [ -z "$sfile" ] && continue
     local smod
     smod=$(stat -c "%Y" "$sfile" 2>/dev/null)
@@ -795,7 +795,7 @@ HELP
       }
       # Validate session exists
       local found
-      found=$(find "$HOME/.claude/projects" \( -name "${session_prefix}*.jsonl" -o -name "${session_prefix}*.json" \) -type f 2>/dev/null | head -1)
+      found=$(_ccs_resolve_jsonl "$session_prefix")
       [ -z "$found" ] && { echo "Session '$session_prefix' not found." >&2; return 1; }
 
       jq -nc --arg s "$session_prefix" --arg f "$feature_id" \
@@ -863,7 +863,7 @@ HELP
       }
       # Validate session exists
       local found
-      found=$(find "$HOME/.claude/projects" \( -name "${session_prefix}*.jsonl" -o -name "${session_prefix}*.json" \) -type f 2>/dev/null | head -1)
+      found=$(_ccs_resolve_jsonl "$session_prefix")
       [ -z "$found" ] && { echo "Session '$session_prefix' not found." >&2; return 1; }
 
       jq -nc --arg s "$session_prefix" --arg f "$feature_id" \

--- a/ccs-feature.sh
+++ b/ccs-feature.sh
@@ -372,7 +372,7 @@ _ccs_feature_md() {
       for ug_sid in "${ug_sids[@]}"; do
         # Find session file by prefix
         local ug_file
-        ug_file=$(find "$HOME/.claude/projects" -name "${ug_sid}*.jsonl" -type f 2>/dev/null | head -1)
+        ug_file=$(find "$HOME/.claude/projects" \( -name "${ug_sid}*.jsonl" -o -name "${ug_sid}*.json" \) -type f 2>/dev/null | head -1)
         if [ -n "$ug_file" ]; then
           local ug_topic ug_ago
           ug_topic=$(_ccs_topic_from_jsonl "$ug_file")
@@ -479,7 +479,7 @@ _ccs_feature_terminal() {
       mapfile -t ug_sids < <(echo "$ungrouped_json" | jq -r '.sessions[]')
       for ug_sid in "${ug_sids[@]}"; do
         local ug_file
-        ug_file=$(find "$HOME/.claude/projects" -name "${ug_sid}*.jsonl" -type f 2>/dev/null | head -1)
+        ug_file=$(find "$HOME/.claude/projects" \( -name "${ug_sid}*.jsonl" -o -name "${ug_sid}*.json" \) -type f 2>/dev/null | head -1)
         if [ -n "$ug_file" ]; then
           local ug_topic ug_ago ug_mod ug_now
           ug_topic=$(_ccs_topic_from_jsonl "$ug_file")
@@ -545,7 +545,7 @@ _ccs_feature_detail_md() {
     mapfile -t session_sids < <(echo "$feature_line" | jq -r '.sessions[]')
     for sid in "${session_sids[@]}"; do
       local sfile
-      sfile=$(find "$HOME/.claude/projects" -name "${sid}*.jsonl" -type f 2>/dev/null | head -1)
+      sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
       [ -z "$sfile" ] && continue
       local sdata
       sdata=$(_ccs_overview_session_data "$sfile")
@@ -562,7 +562,7 @@ _ccs_feature_detail_md() {
   first_sid=$(echo "$feature_line" | jq -r '.sessions[0] // ""')
   if [ -n "$first_sid" ]; then
     local first_file
-    first_file=$(find "$HOME/.claude/projects" -name "${first_sid}*.jsonl" -type f 2>/dev/null | head -1)
+    first_file=$(find "$HOME/.claude/projects" \( -name "${first_sid}*.jsonl" -o -name "${first_sid}*.json" \) -type f 2>/dev/null | head -1)
     if [ -n "$first_file" ]; then
       local encoded_dir
       encoded_dir=$(basename "$(dirname "$first_file")")
@@ -595,7 +595,7 @@ _ccs_feature_detail_md() {
   for sid in "${session_sids2[@]}"; do
     sn=$((sn + 1))
     local sfile
-    sfile=$(find "$HOME/.claude/projects" -name "${sid}*.jsonl" -type f 2>/dev/null | head -1)
+    sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
     if [ -n "$sfile" ]; then
       local stopic smod snow sago
       stopic=$(_ccs_topic_from_jsonl "$sfile")
@@ -644,7 +644,7 @@ _ccs_feature_timeline_md() {
   local -a entries=()
   for sid in "${session_sids[@]}"; do
     local sfile
-    sfile=$(find "$HOME/.claude/projects" -name "${sid}*.jsonl" -type f 2>/dev/null | head -1)
+    sfile=$(find "$HOME/.claude/projects" \( -name "${sid}*.jsonl" -o -name "${sid}*.json" \) -type f 2>/dev/null | head -1)
     [ -z "$sfile" ] && continue
     local smod
     smod=$(stat -c "%Y" "$sfile" 2>/dev/null)
@@ -795,7 +795,7 @@ HELP
       }
       # Validate session exists
       local found
-      found=$(find "$HOME/.claude/projects" -name "${session_prefix}*.jsonl" -type f 2>/dev/null | head -1)
+      found=$(find "$HOME/.claude/projects" \( -name "${session_prefix}*.jsonl" -o -name "${session_prefix}*.json" \) -type f 2>/dev/null | head -1)
       [ -z "$found" ] && { echo "Session '$session_prefix' not found." >&2; return 1; }
 
       jq -nc --arg s "$session_prefix" --arg f "$feature_id" \
@@ -863,7 +863,7 @@ HELP
       }
       # Validate session exists
       local found
-      found=$(find "$HOME/.claude/projects" -name "${session_prefix}*.jsonl" -type f 2>/dev/null | head -1)
+      found=$(find "$HOME/.claude/projects" \( -name "${session_prefix}*.jsonl" -o -name "${session_prefix}*.json" \) -type f 2>/dev/null | head -1)
       [ -z "$found" ] && { echo "Session '$session_prefix' not found." >&2; return 1; }
 
       jq -nc --arg s "$session_prefix" --arg f "$feature_id" \

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -42,19 +42,27 @@ HELP
   mkdir -p "$handoff_dir"
 
   # Find matching project dir in .claude/projects (fuzzy match)
-  local encoded_dir
-  encoded_dir=$(_ccs_find_project_dir "$project_dir") || {
-    echo "No Claude sessions found for: $project_dir"
+  local encoded_dir session_dir=""
+  encoded_dir=$(_ccs_find_project_dir "$project_dir") && session_dir="$projects_dir/$encoded_dir"
+
+  # Find Gemini chats dir
+  local gemini_chats
+  gemini_chats=$(_ccs_gemini_chats_dir "$project_dir")
+
+  if [ -z "$session_dir" ] && [ -z "$gemini_chats" ]; then
+    echo "No Code CLI sessions found for: $project_dir"
     return 1
-  }
-  local session_dir="$projects_dir/$encoded_dir"
+  fi
 
   # Collect open (non-archived) sessions from last 7 days, sorted by recency
   local open_sessions=()
   while IFS=$'\t' read -r _ path; do
     open_sessions+=("$path")
   done < <(
-    find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) -mmin -10080 ! -path "*/subagents/*" -print0 2>/dev/null \
+    {
+      [ -n "$session_dir" ] && [ -d "$session_dir" ] && find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) -mmin -10080 ! -path "*/subagents/*" -print0
+      [ -n "$gemini_chats" ] && [ -d "$gemini_chats" ] && find "$gemini_chats" -maxdepth 1 -name "*.json" -mmin -10080 -print0
+    } 2>/dev/null \
     | while IFS= read -r -d '' f; do
         _ccs_is_archived "$f" && continue
         printf '%s\t%s\n' "$(stat -c '%Y' "$f")" "$f"
@@ -71,7 +79,17 @@ HELP
   local full_sid sid mod_date topic
 
   full_sid=$(basename "$latest" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
-  sid=$(echo "$full_sid" | cut -c1-8)
+  if [ "$(_ccs_get_provider "$latest")" = "gemini" ]; then
+    local real_sid
+    real_sid=$(jq -r '.sessionId // empty' "$latest" 2>/dev/null)
+    if [ -n "$real_sid" ]; then
+      sid=$(echo "$real_sid" | awk -F'-' '{print $NF}' | cut -c1-8)
+    else
+      sid=$(echo "$full_sid" | cut -c1-8)
+    fi
+  else
+    sid=$(echo "$full_sid" | cut -c1-8)
+  fi
   mod_date=$(stat -c "%y" "$latest" | cut -d. -f1)
 
   topic=$(_ccs_topic_from_jsonl "$latest")
@@ -268,16 +286,30 @@ HELP
   fi
 
   # ── Session metadata ──
-  local full_sid sid topic dir project project_dir
+  local full_sid sid topic dir project project_dir provider
+  provider=$(_ccs_get_provider "$jsonl")
   full_sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
-  sid=$(echo "$full_sid" | cut -c1-8)
+  
+  if [ "$provider" = "gemini" ]; then
+    # Gemini filename: session-YYYY-MM-DDTHH-MM-SID.json
+    sid=$(echo "$full_sid" | rev | cut -d- -f1 | rev | cut -c1-8)
+    dir=$(basename "$(dirname "$(dirname "$jsonl")")")
+    project="$dir"
+  else
+    sid=$(echo "$full_sid" | cut -c1-8)
+    dir=$(basename "$(dirname "$jsonl")")
+    project=$(echo "$dir" | sed "s/^${_CCS_HOME_ENCODED}-*//; s/-/\//g")
+  fi
+  
+  [ -z "$project" ] && project="~(home)"
   topic=$(_ccs_topic_from_jsonl "$jsonl")
 
-  dir=$(basename "$(dirname "$jsonl")")
-  project=$(echo "$dir" | sed "s/^${_CCS_HOME_ENCODED}-*//; s/-/\//g")
-  [ -z "$project" ] && project="~(home)"
   # Reconstruct project_dir from encoded dir name
-  project_dir=$(_ccs_resolve_project_path "$dir" 2>/dev/null)
+  if [ "$provider" = "gemini" ]; then
+    project_dir=$(dirname "$(dirname "$jsonl")")
+  else
+    project_dir=$(_ccs_resolve_project_path "$dir" 2>/dev/null)
+  fi
   [ ! -d "$project_dir" ] && project_dir=""
 
   # ── Git context (if project dir exists) ──
@@ -291,11 +323,20 @@ HELP
   # ── Extract recent conversation pairs ──
   # Count only real user prompts (skip meta/system messages)
   # Build filtered pair indices: map real prompt index → raw prompt index
+  local provider=$(_ccs_get_provider "$jsonl")
   local -a real_to_raw=()
   local raw_idx=0
+
+  local jq_filter
+  if [ "$provider" = "gemini" ]; then
+    jq_filter='(if type == "array" then . else .messages // [] end)[]? | select(.type == "user" or .role == "user") | [((.isMeta // false) | tostring), ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | .[:80] | gsub("\n"; " "))] | @tsv'
+  else
+    jq_filter='select(.type == "user" and (.message.content | type == "string")) | [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] | @tsv'
+  fi
+
   while IFS=$'\t' read -r is_meta content; do
     raw_idx=$((raw_idx + 1))
-    # Skip meta messages (isMeta flag from Claude)
+    # Skip meta messages
     [ "$is_meta" = "true" ] && continue
     # Skip system/command wrapper messages
     case "$content" in
@@ -306,18 +347,7 @@ HELP
     [[ "$content" =~ ^[[:space:]]*/quit ]] && continue
     [ -z "${content// /}" ] && continue
     real_to_raw+=("$raw_idx")
-  local provider=$(_ccs_get_provider "$jsonl")
-  done < <(
-    if [ "$provider" = "gemini" ]; then
-      jq -c ".[]" "$jsonl" 2>/dev/null
-    else
-      cat "$jsonl" 2>/dev/null
-    fi | jq -r '
-      select(.type == "user" and (.message.content | type == "string")) |
-      [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] |
-      @tsv
-    ' 2>/dev/null
-  )
+  done < <(jq -r "$jq_filter" "$jsonl" 2>/dev/null)
 
   local real_count=${#real_to_raw[@]}
   local start_from=$((real_count - pair_count + 1))
@@ -325,6 +355,9 @@ HELP
 
   local conversation_summary=""
   local ri
+  local asst_label="Claude"
+  [ "$provider" = "gemini" ] && asst_label="Gemini"
+
   for ((ri = start_from; ri <= real_count; ri++)); do
     local raw_p=${real_to_raw[$((ri - 1))]}
     local pair_json user_text assistant_text user_preview assistant_preview
@@ -347,21 +380,20 @@ HELP
 ### [${ri}/${real_count}] User
 ${user_preview}
 
-### [${ri}/${real_count}] Claude
+### [${ri}/${real_count}] ${asst_label}
 ${assistant_preview}
 "
   done
 
   # ── Extract tool usage from last assistant turn ──
   local recent_files=""
-  local jq_recent_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | if .name == "Read" then "R " + .input.file_path elif .name == "Edit" then "E " + .input.file_path elif .name == "Write" then "W " + .input.file_path elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80]) else empty end'
-  recent_files=$( (
-    if [ "$provider" = "gemini" ]; then
-      jq -c ".[]" "$jsonl" 2>/dev/null
-    else
-      cat "$jsonl" 2>/dev/null
-    fi
-  ) | jq -r "$jq_recent_filter" 2>/dev/null | tail -10 | sort -u)
+  local jq_recent_filter
+  if [ "$provider" = "gemini" ]; then
+    jq_recent_filter='(if type == "array" then . else .messages // [] end)[]? | select(.type == "assistant" or .type == "gemini" or .type == "model" or .role == "assistant" or .role == "model") | (.toolCalls // (.content // .message.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? | if .name == "read_file" then "R " + .args.file_path elif .name == "replace" then "E " + .args.file_path elif .name == "write_file" then "W " + .args.file_path elif .name == "run_shell_command" then "$ " + (.args.command | split("\n") | first | .[:80]) else empty end'
+  else
+    jq_recent_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | if .name == "Read" then "R " + .input.file_path elif .name == "Edit" then "E " + .input.file_path elif .name == "Write" then "W " + .input.file_path elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80]) else empty end'
+  fi
+  recent_files=$(jq -r "$jq_recent_filter" "$jsonl" 2>/dev/null | tail -10 | sort -u)
 
   # ── Build the prompt ──
   local prompt=""

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -54,7 +54,7 @@ HELP
   while IFS=$'\t' read -r _ path; do
     open_sessions+=("$path")
   done < <(
-    find "$session_dir" -maxdepth 1 -name "*.jsonl" -mmin -10080 ! -path "*/subagents/*" -print0 2>/dev/null \
+    find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) -mmin -10080 ! -path "*/subagents/*" -print0 2>/dev/null \
     | while IFS= read -r -d '' f; do
         _ccs_is_archived "$f" && continue
         printf '%s\t%s\n' "$(stat -c '%Y' "$f")" "$f"
@@ -306,11 +306,18 @@ HELP
     [[ "$content" =~ ^[[:space:]]*/quit ]] && continue
     [ -z "${content// /}" ] && continue
     real_to_raw+=("$raw_idx")
-  done < <(jq -r '
-    select(.type == "user" and (.message.content | type == "string")) |
-    [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] |
-    @tsv
-  ' "$jsonl" 2>/dev/null)
+  local provider=$(_ccs_get_provider "$jsonl")
+  done < <(
+    if [ "$provider" = "gemini" ]; then
+      jq -c ".[]" "$jsonl" 2>/dev/null
+    else
+      cat "$jsonl" 2>/dev/null
+    fi | jq -r '
+      select(.type == "user" and (.message.content | type == "string")) |
+      [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] |
+      @tsv
+    ' 2>/dev/null
+  )
 
   local real_count=${#real_to_raw[@]}
   local start_from=$((real_count - pair_count + 1))
@@ -347,16 +354,14 @@ ${assistant_preview}
 
   # ── Extract tool usage from last assistant turn ──
   local recent_files=""
-  recent_files=$(jq -r '
-    select(.type == "assistant") |
-    .message.content[]? |
-    select(.type == "tool_use") |
-    if .name == "Read" then "R " + .input.file_path
-    elif .name == "Edit" then "E " + .input.file_path
-    elif .name == "Write" then "W " + .input.file_path
-    elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80])
-    else empty end
-  ' "$jsonl" 2>/dev/null | tail -10 | sort -u)
+  local jq_recent_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | if .name == "Read" then "R " + .input.file_path elif .name == "Edit" then "E " + .input.file_path elif .name == "Write" then "W " + .input.file_path elif .name == "Bash" then "$ " + (.input.command | split("\n") | first | .[:80]) else empty end'
+  recent_files=$( (
+    if [ "$provider" = "gemini" ]; then
+      jq -c ".[]" "$jsonl" 2>/dev/null
+    else
+      cat "$jsonl" 2>/dev/null
+    fi
+  ) | jq -r "$jq_recent_filter" 2>/dev/null | tail -10 | sort -u)
 
   # ── Build the prompt ──
   local prompt=""
@@ -398,7 +403,12 @@ PROMPT_EOF
       printf "\033[90m---\033[0m\n"
       printf "\033[90mPaste the above into a new session, or use:\033[0m\n"
       printf "\033[33m  ccs-resume-prompt %s --copy     \033[90m# copy to clipboard\033[0m\n" "$sid"
-      printf "\033[33m  claude --resume %s  \033[90m# resume with full context (heavier)\033[0m\n" "$full_sid"
+      local provider=$(_ccs_get_provider "$jsonl")
+      if [ "$provider" = "gemini" ]; then
+        printf "\033[33m  gemini --session %s  \033[90m# resume with full context (heavier)\033[0m\n" "$full_sid"
+      else
+        printf "\033[33m  claude --resume %s  \033[90m# resume with full context (heavier)\033[0m\n" "$full_sid"
+      fi
     fi
   fi
 

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -83,7 +83,7 @@ HELP
     local real_sid
     real_sid=$(jq -r '.sessionId // empty' "$latest" 2>/dev/null)
     if [ -n "$real_sid" ]; then
-      sid=$(echo "$real_sid" | awk -F'-' '{print $NF}' | cut -c1-8)
+      sid=$(echo "$real_sid" | awk -F'-' '{print $1}' | cut -c1-8)
     else
       sid=$(echo "$full_sid" | cut -c1-8)
     fi

--- a/ccs-health.sh
+++ b/ccs-health.sh
@@ -25,7 +25,13 @@ _ccs_health_events() {
   local sid
   sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//' | cut -c1-8)
 
-  jq -s --arg sid "$sid" '
+  local provider=$(_ccs_get_provider "$f")
+  local pipe_cmd="cat"
+  if [ "$provider" = "gemini" ]; then
+    pipe_cmd="jq -c .[]"
+  fi
+
+  eval "$pipe_cmd '$f'" 2>/dev/null | jq -s --arg sid "$sid" '
     reduce .[] as $line (
       {
         first_ts: null, last_ts: null, prompt_count: 0,
@@ -291,7 +297,7 @@ HELP
     fi
     files+=("$f")
   done < <(find "$projects_dir" \
-    -maxdepth 2 -name "*.jsonl" -type f \
+    -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) -type f \
     ! -path "*/subagents/*" \
     -print0 2>/dev/null)
 

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -62,7 +62,7 @@ _ccs_crash_md() {
     echo "- **最後訊息：** $last_user"
     [ -n "$todo_summary" ] && echo "- **Todos：** $todo_summary"
     [ -n "$git_branch" ] && echo "- **Git：** $git_branch ($git_dirty uncommitted files)"
-    local provider=$(_ccs_get_provider "$jsonl")
+    local provider=$(_ccs_get_provider "$f")
     local resume_cmd="claude --resume $sid"
     if [ "$provider" = "gemini" ]; then
       resume_cmd="gemini --session $sid"
@@ -140,7 +140,7 @@ _ccs_crash_json() {
     local mtime=$(stat -c "%Y" "$f" 2>/dev/null)
     local last_iso=$(date -d "@$mtime" --iso-8601=seconds 2>/dev/null)
 
-    local provider=$(_ccs_get_provider "$jsonl")
+    local provider=$(_ccs_get_provider "$f")
     local resume_cmd="claude --resume $sid"
     if [ "$provider" = "gemini" ]; then
       resume_cmd="gemini --session $sid"
@@ -190,6 +190,13 @@ _ccs_archive_session() {
   [ -f "$f" ] || return 1
   # Gemini .json files are JSON arrays — appending JSONL marker would corrupt them
   if [ "$(_ccs_get_provider "$f")" = "gemini" ]; then
+    # Use jq to inject an "archived": true flag into the top-level object
+    local tmpf
+    tmpf=$(mktemp)
+    if jq '. + {"archived": true}' "$f" > "$tmpf" 2>/dev/null; then
+      cat "$tmpf" > "$f"
+    fi
+    rm -f "$tmpf"
     return 0
   fi
   printf '{"type":"last-prompt"}\n' >> "$f"

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -515,8 +515,13 @@ _ccs_recap_collect() {
       (( mtime < from_epoch )) && continue
 
       # Skip short sessions (< 2 user prompts) to reduce noise
-      local _pc
-      _pc=$(jq -c 'select(.type == "user" and ((.isMeta // false) == false))' "$jsonl" 2>/dev/null | wc -l)
+      local _pc provider
+      provider=$(_ccs_get_provider "$jsonl")
+      if [ "$provider" = "gemini" ]; then
+        _pc=$(jq -c '.messages[] | select(.type == "user" or .role == "user")' "$jsonl" 2>/dev/null | wc -l)
+      else
+        _pc=$(jq -c 'select(.type == "user" and ((.isMeta // false) == false))' "$jsonl" 2>/dev/null | wc -l)
+      fi
       [ "${_pc:-0}" -lt 2 ] && continue
 
       sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
@@ -538,21 +543,30 @@ _ccs_recap_collect() {
       td_done=0 td_pending=0 td_ip=0
       pending_items=()
       completed_items=()
+      local jq_todos_filter
+      if [ "$provider" = "gemini" ]; then
+        jq_todos_filter='[.messages[] | select(.type == "gemini" or .type == "assistant" or .role == "model" or .type == "model") | (.toolCalls // (.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? | select(.name == "write_todos" or .name == "TodoWrite") | .args.todos // .input.todos] | last // [] | .[]? | [.status, .content] | @tsv'
+      else
+        jq_todos_filter='[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | .input.todos] | last // [] | .[]? | [.status, .content] | @tsv'
+      fi
+
       while IFS=$'\t' read -r t_status t_content; do
         case "$t_status" in
           completed)    (( td_done++ )); completed_items+=("$t_content") ;;
           pending)      (( td_pending++ )); pending_items+=("$t_content") ;;
           in_progress)  (( td_ip++ )); pending_items+=("$t_content") ;;
         esac
-      done < <(jq -s -r '[.[] | select(.type == "assistant") | .message.content[]? |
-        select(.type == "tool_use" and .name == "TodoWrite") |
-        .input.todos] | last // [] | .[]? | [.status, .content] | @tsv' "$jsonl" 2>/dev/null)
+      done < <(jq -s -r "$jq_todos_filter" "$jsonl" 2>/dev/null)
 
       # Last exchange preview
       local preview=""
-      preview=$(jq -r 'select(.type == "user" and .isMeta != true) |
-        .message.content | if type == "string" then . else "" end |
-        gsub("\n"; " ") | .[:80]' "$jsonl" 2>/dev/null | tail -1)
+      if [ "$provider" = "gemini" ]; then
+        preview=$(jq -r '.messages[] | select(.type == "user" or .role == "user") | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | gsub("\n"; " ") | .[:80]' "$jsonl" 2>/dev/null | tail -1)
+      else
+        preview=$(jq -r 'select(.type == "user" and .isMeta != true) |
+          .message.content | if type == "string" then . else "" end |
+          gsub("\n"; " ") | .[:80]' "$jsonl" 2>/dev/null | tail -1)
+      fi
 
       # 組裝 session JSON
       local pending_json completed_json
@@ -670,8 +684,16 @@ _ccs_recap_collect() {
       (( mtime < from_epoch )) && continue
       sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
       topic=$(_ccs_topic_from_jsonl "$jsonl")
-      dl_text=$(jq -r 'select(.type == "user" and .isMeta != true) |
-        .message.content | if type == "string" then . else "" end' "$jsonl" 2>/dev/null |
+      local provider
+      provider=$(_ccs_get_provider "$jsonl")
+      local jq_dl_filter
+      if [ "$provider" = "gemini" ]; then
+        jq_dl_filter='.messages[] | select((.type == "user" or .role == "user") and .isMeta != true) | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end'
+      else
+        jq_dl_filter='select(.type == "user" and .isMeta != true) | .message.content | if type == "string" then . else "" end'
+      fi
+
+      dl_text=$(jq -r "$jq_dl_filter" "$jsonl" 2>/dev/null |
         grep -iE '(deadline|due|urgent|ASAP|月底|趕|今天|明天|後天|這週|下週|本週|by (monday|tuesday|wednesday|thursday|friday|tomorrow|end of))' |
         head -1 | sed 's/^[[:space:]]*//' | cut -c1-80)
       if [ -n "$dl_text" ]; then
@@ -1136,10 +1158,15 @@ _ccs_checkpoint_collect() {
       fi
 
       # Extract todos (pending/in_progress only)
-      local todos_json="[]"
-      todos_json=$(jq -s -c '[.[] | select(.type == "assistant") | .message.content[]? |
-        select(.type == "tool_use" and .name == "TodoWrite") |
-        .input.todos] | last // [] | [.[]? | select(.status != "completed") | {status, content}]' "$jsonl" 2>/dev/null)
+      local todos_json="[]" provider
+      provider=$(_ccs_get_provider "$jsonl")
+      if [ "$provider" = "gemini" ]; then
+        todos_json=$(jq -c '[.messages[] | select(.type == "gemini" or .type == "assistant" or .role == "model" or .type == "model") | (.toolCalls // (.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? | select(.name == "write_todos" or .name == "TodoWrite") | .args.todos // .input.todos] | last // [] | [.[]? | select(.status != "completed") | {status, content}]' "$jsonl" 2>/dev/null)
+      else
+        todos_json=$(jq -s -c '[.[] | select(.type == "assistant") | .message.content[]? |
+          select(.type == "tool_use" and .name == "TodoWrite") |
+          .input.todos] | last // [] | [.[]? | select(.status != "completed") | {status, content}]' "$jsonl" 2>/dev/null)
+      fi
       [ -z "$todos_json" ] || [ "$todos_json" = "null" ] && todos_json="[]"
       local todo_count
       todo_count=$(echo "$todos_json" | jq 'length')
@@ -1149,8 +1176,15 @@ _ccs_checkpoint_collect() {
       if (( age_min > 120 )); then
         # Naturally ended? (last message is assistant + no pending todos)
         local last_type
-        last_type=$(jq -s '[.[] | select(.type == "assistant" or .type == "user")] | last | .type // ""' "$jsonl" 2>/dev/null)
-        if [ "$last_type" = '"assistant"' ] && (( todo_count == 0 )); then
+        if [ "$provider" = "gemini" ]; then
+          last_type=$(jq -r '.messages[] | select(.type == "user" or .role == "user" or .type == "gemini" or .type == "assistant" or .type == "model" or .role == "model") | .type // .role' "$jsonl" 2>/dev/null | tail -1)
+          # Normalize
+          [[ "$last_type" =~ ^(gemini|assistant|model)$ ]] && last_type="assistant"
+        else
+          last_type=$(jq -s -r '[.[] | select(.type == "assistant" or .type == "user")] | last | .type // ""' "$jsonl" 2>/dev/null)
+        fi
+
+        if [ "$last_type" = "assistant" ] && (( todo_count == 0 )); then
           # Treat as done
           done_json=$(echo "$done_json" | jq -c --arg p "$proj_name" --arg t "$topic" --arg s "$sid" \
             '. + [{project: $p, topic: $t, session: $s}]')
@@ -1159,7 +1193,14 @@ _ccs_checkpoint_collect() {
           is_blocked=true
         fi
       else
-        if jq -r 'select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content' "$jsonl" 2>/dev/null \
+        local jq_msg_filter
+        if [ "$provider" = "gemini" ]; then
+          jq_msg_filter='.messages[] | select((.type == "user" or .role == "user") and .isMeta != true) | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end'
+        else
+          jq_msg_filter='select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
+        fi
+
+        if jq -r "$jq_msg_filter" "$jsonl" 2>/dev/null \
           | tail -5 \
           | grep -qiE '(blocked|卡住|等待|waiting|stuck)'; then
           is_blocked=true

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -62,7 +62,12 @@ _ccs_crash_md() {
     echo "- **最後訊息：** $last_user"
     [ -n "$todo_summary" ] && echo "- **Todos：** $todo_summary"
     [ -n "$git_branch" ] && echo "- **Git：** $git_branch ($git_dirty uncommitted files)"
-    echo "- **Resume：** \`claude --resume $sid\`"
+    local provider=$(_ccs_get_provider "$jsonl")
+    local resume_cmd="claude --resume $sid"
+    if [ "$provider" = "gemini" ]; then
+      resume_cmd="gemini --session $sid"
+    fi
+    echo "- **Resume：** \`$resume_cmd\`"
     echo "- **Detail：** \`ccs-session ${sid:0:8}\`"
     echo ""
   done
@@ -135,18 +140,24 @@ _ccs_crash_json() {
     local mtime=$(stat -c "%Y" "$f" 2>/dev/null)
     local last_iso=$(date -d "@$mtime" --iso-8601=seconds 2>/dev/null)
 
-    jq -nc \
-      --arg sid "$sid" \
-      --arg conf "$confidence" \
-      --arg dpath "$detection_path" \
-      --arg proj "$project" \
-      --arg topic "$topic" \
-      --arg last_act "$last_iso" \
-      --arg last_msg "$last_user" \
-      --argjson todos "${todos:-[]}" \
-      --arg git_br "$git_branch" \
-      --argjson git_d "$git_dirty" \
-      --arg resume "claude --resume $sid" \
+    local provider=$(_ccs_get_provider "$jsonl")
+    local resume_cmd="claude --resume $sid"
+    if [ "$provider" = "gemini" ]; then
+      resume_cmd="gemini --session $sid"
+    fi
+
+    jq -n -c \
+    --arg sid "$sid" \
+    --arg conf "$confidence" \
+    --arg dpath "$path" \
+    --arg proj "$project" \
+    --arg topic "$topic" \
+    --arg last_act "$last_iso" \
+    --arg last_msg "$last_user" \
+    --argjson todos "${todos:-[]}" \
+    --arg git_br "$git_branch" \
+    --argjson git_d "$git_dirty" \
+    --arg resume "$resume_cmd" \
       '{
         session_id: $sid[0:8],
         session_uuid: $sid,
@@ -400,7 +411,7 @@ _ccs_detect_last_workday() {
     # 跳過今天
     (( day_epoch >= today_start )) && continue
     active_dates["$day_start"]=$day_epoch
-  done < <(find "$claude_dir" -name "*.jsonl" -printf "%T@\n" 2>/dev/null)
+  done < <(find "$claude_dir" \( -name "*.jsonl" -o -name "*.json" \) -printf "%T@\n" 2>/dev/null)
 
   if [ ${#active_dates[@]} -eq 0 ]; then
     # 無任何歷史 session，fallback 到昨天
@@ -434,7 +445,7 @@ _ccs_recap_scan_projects() {
     [ -z "${seen[$dir]+_}" ] || continue
     seen["$dir"]=1
     echo "$dir"
-  done < <(find "$claude_dir" -maxdepth 2 -name "*.jsonl" ! -path "*/subagents/*" 2>/dev/null)
+  done < <(find "$claude_dir" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" 2>/dev/null)
 }
 
 # _ccs_recap_collect — 收集 recap 數據，輸出 JSON
@@ -572,7 +583,7 @@ _ccs_recap_collect() {
       (( todos_done += td_done ))
       (( todos_pending += td_pending ))
       (( todos_in_progress += td_ip ))
-    done < <(find "$session_dir" -maxdepth 1 -name "*.jsonl" ! -path "*/subagents/*" 2>/dev/null)
+    done < <(find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" 2>/dev/null)
 
     # Features（從 features.jsonl 讀取此專案的 features）
     local data_dir
@@ -623,7 +634,7 @@ _ccs_recap_collect() {
         elif .name == "Write" then "W\t" + .input.file_path
         elif .name == "Read" then "R\t" + .input.file_path
         else empty end' "$jsonl" 2>/dev/null)
-    done < <(find "$session_dir" -maxdepth 1 -name "*.jsonl" ! -path "*/subagents/*" 2>/dev/null)
+    done < <(find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" 2>/dev/null)
 
     # 排序取 top 5（合併 edits + reads 的所有 key，避免遺漏只有 Read 的檔案）
     unset all_hot_files 2>/dev/null
@@ -657,7 +668,7 @@ _ccs_recap_collect() {
           --arg t "$dl_text" --arg sid "$sid" --arg topic "$topic" \
           '. += [{text:$t, session_id:$sid, session_topic:$topic}]')
       fi
-    done < <(find "$session_dir" -maxdepth 1 -name "*.jsonl" ! -path "*/subagents/*" 2>/dev/null)
+    done < <(find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" 2>/dev/null)
 
     # 組裝此專案的 JSON
     jq -n \
@@ -1165,7 +1176,7 @@ _ccs_checkpoint_collect() {
       else
         wip_json=$(echo "$wip_json" | jq -c --argjson e "$entry" '. + [$e]')
       fi
-    done < <(find "$session_dir" -maxdepth 1 -name "*.jsonl" ! -path "*/subagents/*" 2>/dev/null)
+    done < <(find "$session_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" 2>/dev/null)
   done
 
   # Build result

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -188,6 +188,10 @@ _ccs_crash_json() {
 _ccs_archive_session() {
   local f="$1"
   [ -f "$f" ] || return 1
+  # Gemini .json files are JSON arrays — appending JSONL marker would corrupt them
+  if [ "$(_ccs_get_provider "$f")" = "gemini" ]; then
+    return 0
+  fi
   printf '{"type":"last-prompt"}\n' >> "$f"
 }
 

--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -12,9 +12,9 @@ _ccs_overview_session_data() {
   local jq_deadline_filter
 
   if [ "$provider" = "gemini" ]; then
-    jq_user_filter='.[] | select(.type == "user" and (.message.content | type == "string"))'
-    jq_todos_filter='.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
-    jq_deadline_filter='.[] | select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
+    jq_user_filter='.messages[] | select(.type == "user" or .role == "user")'
+    jq_todos_filter='.messages[] | select(.type == "gemini" or .type == "assistant" or .role == "model" or .type == "model") | (.toolCalls // (.content | if type == "array" then [.[]? | select(.toolCall or .type == "toolCall") | (.toolCall // .)] else [] end))[]? | select(.name == "write_todos" or .name == "TodoWrite") | .args.todos // .input.todos'
+    jq_deadline_filter='.messages[] | select((.type == "user" or .role == "user") and ((.isMeta // false) == false)) | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end'
   else
     jq_user_filter='select(.type == "user" and (.message.content | type == "string"))'
     jq_todos_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
@@ -33,10 +33,11 @@ _ccs_overview_session_data() {
       [to_entries[] | {
         raw_idx: (.key + 1),
         is_meta: (.value.isMeta // false),
-        content: .value.message.content
+        content: .value.content
       }]
       | [.[] | select(
           .is_meta == false
+          and (.content | type == "string")
           and (.content | test("^\\s*/exit|^\\s*/quit|^<local-command|^<command-name|^<system-") | not)
           and (.content | test("^\\s*$") | not)
         )]
@@ -59,9 +60,9 @@ _ccs_overview_session_data() {
   local deadline_ctx=""
   deadline_ctx=$(jq -r "$jq_deadline_filter" "$jsonl" 2>/dev/null \
     | tail -5 \
-    | grep -iE '"'"'(deadline|before|週|月底|by |due|urgent|ASAP|趕|今天|明天|後天)'"'"' \
+    | grep -iE '(deadline|before|週|月底|by |due|urgent|ASAP|趕|今天|明天|後天)' \
     | cut -c1-150 \
-    | paste -sd '"'"'|'"'"' -)
+    | paste -sd '|' -)
 
   # Output JSON
   jq -nc \
@@ -69,11 +70,11 @@ _ccs_overview_session_data() {
     --arg asst_text "$asst_text" \
     --argjson todos "$todos_json" \
     --arg deadline "$deadline_ctx" \
-    '"'"'{
+    '{
       last_exchange: {user: $user_text, assistant: $asst_text},
       todos: $todos,
       deadline_context: (if $deadline == "" then null else $deadline end)
-    }'"'"'
+    }'
 }
 
 # ── Helper: render overview as Markdown ──
@@ -845,15 +846,19 @@ _ccs_overview_terminal() {
     color=$(echo "$row" | cut -f5)
 
     # Override color for crash-interrupted sessions (high confidence)
-    local full_sid
+    local full_sid sid
     full_sid=$(basename "$f" | sed -e "s/\.jsonl$//" -e "s/\.json$//")
+    if [[ "$f" == *.json ]]; then
+      sid=$(echo "$full_sid" | rev | cut -d- -f1 | rev | cut -c1-8)
+    else
+      sid="${full_sid:0:8}"
+    fi
+
     local crash_suffix=""
     if [ -n "${4:-}" ] && [ -n "${_crash_term[$full_sid]+x}" ] && [[ "${_crash_term[$full_sid]}" == high:* ]]; then
       color="\033[31m"
       crash_suffix=" 💀"
     fi
-
-    local sid="${full_sid:0:8}"
     local topic
     topic=$(_ccs_topic_from_jsonl "$f")
 

--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -6,6 +6,20 @@
 # Outputs a JSON object with: last_exchange, todos, deadline_context
 _ccs_overview_session_data() {
   local jsonl="$1"
+  local provider=$(_ccs_get_provider "$jsonl")
+  local jq_user_filter
+  local jq_todos_filter
+  local jq_deadline_filter
+
+  if [ "$provider" = "gemini" ]; then
+    jq_user_filter='.[] | select(.type == "user" and (.message.content | type == "string"))'
+    jq_todos_filter='.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
+    jq_deadline_filter='.[] | select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
+  else
+    jq_user_filter='select(.type == "user" and (.message.content | type == "string"))'
+    jq_todos_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
+    jq_deadline_filter='select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
+  fi
 
   # --- Last Exchange (last non-meta user-assistant pair) ---
   # _ccs_get_pair expects a 1-based index into ALL user prompts (including meta).
@@ -14,9 +28,7 @@ _ccs_overview_session_data() {
   # filter out meta/system, take the last one's raw index.
   local user_text="" asst_text=""
   local last_raw_idx
-  last_raw_idx=$(jq -c '
-    select(.type == "user" and (.message.content | type == "string"))
-  ' "$jsonl" 2>/dev/null \
+  last_raw_idx=$(jq -c "$jq_user_filter" "$jsonl" 2>/dev/null \
     | jq -sc '
       [to_entries[] | {
         raw_idx: (.key + 1),
@@ -40,25 +52,16 @@ _ccs_overview_session_data() {
 
   # --- Todos (last TodoWrite) ---
   local todos_json
-  todos_json=$(jq -c '
-    select(.type == "assistant") |
-    .message.content[]? |
-    select(.type == "tool_use" and .name == "TodoWrite") |
-    [.input.todos[]? | {content, status}]
-  ' "$jsonl" 2>/dev/null | tail -1)
+  todos_json=$(jq -c "$jq_todos_filter" "$jsonl" 2>/dev/null | tail -1)
   [ -z "$todos_json" ] && todos_json="[]"
 
   # --- Deadline Context (keyword search in last 5 non-meta user messages) ---
   local deadline_ctx=""
-  deadline_ctx=$(jq -r '
-    select(.type == "user" and (.message.content | type == "string")
-      and ((.isMeta // false) == false)) |
-    .message.content
-  ' "$jsonl" 2>/dev/null \
+  deadline_ctx=$(jq -r "$jq_deadline_filter" "$jsonl" 2>/dev/null \
     | tail -5 \
-    | grep -iE '(deadline|before|週|月底|by |due|urgent|ASAP|趕|今天|明天|後天)' \
+    | grep -iE '"'"'(deadline|before|週|月底|by |due|urgent|ASAP|趕|今天|明天|後天)'"'"' \
     | cut -c1-150 \
-    | paste -sd '|' -)
+    | paste -sd '"'"'|'"'"' -)
 
   # Output JSON
   jq -nc \
@@ -66,11 +69,11 @@ _ccs_overview_session_data() {
     --arg asst_text "$asst_text" \
     --argjson todos "$todos_json" \
     --arg deadline "$deadline_ctx" \
-    '{
+    '"'"'{
       last_exchange: {user: $user_text, assistant: $asst_text},
       todos: $todos,
       deadline_context: (if $deadline == "" then null else $deadline end)
-    }'
+    }'"'"'
 }
 
 # ── Helper: render overview as Markdown ──

--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -36,7 +36,7 @@ _ccs_project_collect() {
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     all_files+=("${line#*$'\t'}")
-  done < <(find "$target_dir" -maxdepth 1 -name "*.jsonl" \
+  done < <(find "$target_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
     ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
     | sort -rn)
 
@@ -321,7 +321,7 @@ _ccs_project_json() {
   # Total count for truncation indicator
   local projects_dir="${CCS_PROJECTS_DIR:-$HOME/.claude/projects}"
   local total_count
-  total_count=$(find "$projects_dir/$encoded_dir" -maxdepth 1 -name "*.jsonl" \
+  total_count=$(find "$projects_dir/$encoded_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
     ! -path "*/subagents/*" 2>/dev/null | wc -l)
 
   local truncated=false truncated_total=null

--- a/ccs-project.sh
+++ b/ccs-project.sh
@@ -28,17 +28,23 @@ _ccs_project_collect() {
   local until_date="${3:-}"
   local projects_dir="${CCS_PROJECTS_DIR:-$HOME/.claude/projects}"
   local target_dir="$projects_dir/$encoded_dir"
+  local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
+  local gemini_chats="$gemini_dir/tmp/$encoded_dir/chats"
 
-  [ -d "$target_dir" ] || return 1
+  # Need at least one valid search directory
+  [ -d "$target_dir" ] || [ -d "$gemini_chats" ] || return 1
 
-  # Collect all JSONLs, sorted by mtime descending
+  # Collect all session files from Claude and Gemini, sorted by mtime descending
   local -a all_files=()
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     all_files+=("${line#*$'\t'}")
-  done < <(find "$target_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
-    ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
-    | sort -rn)
+  done < <({
+    [ -d "$target_dir" ] && find "$target_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
+      ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null
+    [ -d "$gemini_chats" ] && find "$gemini_chats" -maxdepth 1 -name "*.json" \
+      ! -name "*.meta.json" -printf '%T@\t%p\n' 2>/dev/null
+  } | sort -rn)
 
   [ ${#all_files[@]} -eq 0 ] && return 0
 
@@ -318,11 +324,16 @@ _ccs_project_json() {
 
   local session_count=${#session_files[@]}
 
-  # Total count for truncation indicator
+  # Total count for truncation indicator (Claude + Gemini)
   local projects_dir="${CCS_PROJECTS_DIR:-$HOME/.claude/projects}"
+  local gemini_dir="${CCS_GEMINI_DIR:-$HOME/.gemini}"
   local total_count
-  total_count=$(find "$projects_dir/$encoded_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
-    ! -path "*/subagents/*" 2>/dev/null | wc -l)
+  total_count=$({
+    find "$projects_dir/$encoded_dir" -maxdepth 1 \( -name "*.jsonl" -o -name "*.json" \) \
+      ! -path "*/subagents/*" 2>/dev/null
+    find "$gemini_dir/tmp/$encoded_dir/chats" -maxdepth 1 -name "*.json" \
+      ! -name "*.meta.json" 2>/dev/null
+  } | wc -l)
 
   local truncated=false truncated_total=null
   if [ "$total_count" -gt "$session_count" ]; then

--- a/ccs-review.sh
+++ b/ccs-review.sh
@@ -22,11 +22,16 @@
 # Output: JSON object {"Read": N, "Edit": N, ...}
 _ccs_tool_use_stats() {
   local jsonl="$1"
-  jq -s '
+  local provider=$(_ccs_get_provider "$jsonl")
+  local pipe_cmd="cat"
+  if [ "$provider" = "gemini" ]; then
+    pipe_cmd="jq -c .[]"
+  fi
+  eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '
     [.[] | select(.type == "assistant") |
      .message.content[]? | select(.type == "tool_use") | .name] |
     group_by(.) | map({(.[0]): length}) | add // {}
-  ' "$jsonl" 2>/dev/null
+  ' 2>/dev/null
 }
 
 # ── Cache: write LLM summary ──
@@ -58,13 +63,18 @@ _ccs_review_cache_read() {
 # Output: JSON with rounds, duration, char_count, token_estimate, tool_use
 _ccs_session_stats() {
   local jsonl="$1"
+  local provider=$(_ccs_get_provider "$jsonl")
+  local pipe_cmd="cat"
+  if [ "$provider" = "gemini" ]; then
+    pipe_cmd="jq -c .[]"
+  fi
 
   local rounds
-  rounds=$(jq -s '[.[] | select(.type == "user" and (.message.content | type == "string"))] | length' "$jsonl" 2>/dev/null)
+  rounds=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '[.[] | select(.type == "user" and (.message.content | type == "string"))] | length' 2>/dev/null)
 
   local first_ts last_ts
-  first_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | head -1)
-  last_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | tail -1)
+  first_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | head -1)
+  last_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | tail -1)
 
   local duration_min=0
   if [ -n "$first_ts" ] && [ -n "$last_ts" ]; then
@@ -75,7 +85,7 @@ _ccs_session_stats() {
   fi
 
   local char_count
-  char_count=$(jq -s '
+  char_count=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '
     [.[] |
       if .type == "user" and (.message.content | type == "string") then
         (.message.content | length)
@@ -83,7 +93,7 @@ _ccs_session_stats() {
         ([.message.content[]? | select(.type == "text") | .text | length] | add // 0)
       else 0 end
     ] | add // 0
-  ' "$jsonl" 2>/dev/null)
+  ' 2>/dev/null)
 
   local token_estimate=$(( char_count * 10 / 25 ))
 
@@ -349,7 +359,7 @@ _ccs_review_weekly_collect() {
   since_epoch=$(date -d "$since" +%s 2>/dev/null)
   until_epoch=$(date -d "$until_date 23:59:59" +%s 2>/dev/null)
 
-  find "$projects_dir" -maxdepth 2 -name "*.jsonl" ! -path "*/subagents/*" -print0 2>/dev/null \
+  find "$projects_dir" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" -print0 2>/dev/null \
     | while IFS= read -r -d '' f; do
       local mtime
       mtime=$(stat -c "%Y" "$f")
@@ -539,9 +549,9 @@ HELP
   local jsonl
   if [ -n "${CCS_PROJECTS_DIR:-}" ]; then
     if [ -n "$session_id" ]; then
-      jsonl=$(find "$CCS_PROJECTS_DIR" -maxdepth 2 -name "${session_id}*.jsonl" ! -path "*/subagents/*" 2>/dev/null | head -1)
+      jsonl=$(find "$CCS_PROJECTS_DIR" -maxdepth 2 \( -name "${session_id}*.jsonl" -o -name "${session_id}*.json" \) ! -path "*/subagents/*" 2>/dev/null | head -1)
     else
-      jsonl=$(find "$CCS_PROJECTS_DIR" -maxdepth 2 -name "*.jsonl" ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
+      jsonl=$(find "$CCS_PROJECTS_DIR" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) ! -path "*/subagents/*" -printf '%T@\t%p\n' 2>/dev/null \
         | sort -rn | head -1 | cut -f2)
     fi
   else

--- a/ccs-review.sh
+++ b/ccs-review.sh
@@ -23,15 +23,32 @@
 _ccs_tool_use_stats() {
   local jsonl="$1"
   local provider=$(_ccs_get_provider "$jsonl")
-  local pipe_cmd="cat"
+  
   if [ "$provider" = "gemini" ]; then
-    pipe_cmd="jq -c .[]"
+    jq -r '
+      (if type == "array" then . else .messages // [] end) |
+      [.[] | select(.type == "gemini" or .type == "assistant") | .toolCalls[]? | .name] |
+      map(
+        if . == "read_file" then "Read"
+        elif . == "replace" then "Edit"
+        elif . == "write_file" then "Write"
+        elif . == "run_shell_command" then "Bash"
+        elif . == "grep_search" then "Grep"
+        elif . == "glob" then "Glob"
+        elif . == "activate_skill" then "Skill"
+        elif . == "list_directory" then "List"
+        elif . == "google_web_search" then "Search"
+        else . end
+      ) |
+      group_by(.) | map({(.[0]): length}) | add // {}
+    ' "$jsonl" 2>/dev/null
+  else
+    jq -s '
+      [.[] | select(.type == "assistant") |
+       .message.content[]? | select(.type == "tool_use") | .name] |
+      group_by(.) | map({(.[0]): length}) | add // {}
+    ' "$jsonl" 2>/dev/null
   fi
-  eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '
-    [.[] | select(.type == "assistant") |
-     .message.content[]? | select(.type == "tool_use") | .name] |
-    group_by(.) | map({(.[0]): length}) | add // {}
-  ' 2>/dev/null
 }
 
 # ── Cache: write LLM summary ──
@@ -64,36 +81,49 @@ _ccs_review_cache_read() {
 _ccs_session_stats() {
   local jsonl="$1"
   local provider=$(_ccs_get_provider "$jsonl")
-  local pipe_cmd="cat"
+
+  local rounds first_ts last_ts duration_min char_count
+  
   if [ "$provider" = "gemini" ]; then
-    pipe_cmd="jq -c .[]"
-  fi
-
-  local rounds
-  rounds=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '[.[] | select(.type == "user" and (.message.content | type == "string"))] | length' 2>/dev/null)
-
-  local first_ts last_ts
-  first_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | head -1)
-  last_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | tail -1)
-
-  local duration_min=0
-  if [ -n "$first_ts" ] && [ -n "$last_ts" ]; then
-    local first_epoch last_epoch
-    first_epoch=$(date -d "$first_ts" +%s 2>/dev/null || echo 0)
-    last_epoch=$(date -d "$last_ts" +%s 2>/dev/null || echo 0)
-    duration_min=$(( (last_epoch - first_epoch) / 60 ))
-  fi
-
-  local char_count
-  char_count=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '
-    [.[] |
-      if .type == "user" and (.message.content | type == "string") then
-        (.message.content | length)
-      elif .type == "assistant" then
-        ([.message.content[]? | select(.type == "text") | .text | length] | add // 0)
+    rounds=$(jq -r '(if type == "array" then . else .messages // [] end) | [.[] | select((.type == "user" or .role == "user") and .isMeta != true and ((.content // .message.content | if type == "array" then [.[]? | select(.text) | .text] | join("") else . end) | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit|^\\s*$") | not))] | length' "$jsonl" 2>/dev/null)
+    first_ts=$(jq -r '.startTime // empty' "$jsonl" 2>/dev/null)
+    last_ts=$(jq -r '.lastUpdated // empty' "$jsonl" 2>/dev/null)
+    duration_min=$(jq -r '
+      if .startTime and .lastUpdated then
+        ((.lastUpdated | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) - (.startTime | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)) / 60 | floor
       else 0 end
-    ] | add // 0
-  ' 2>/dev/null)
+    ' "$jsonl" 2>/dev/null || echo 0)
+    char_count=$(jq -r '
+      (if type == "array" then . else .messages // [] end) |
+      [.[] |
+        if (.type == "user" or .role == "user" or .type == "assistant" or .type == "gemini" or .type == "model") then
+          ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join("") else (. // "") end | length)
+        else 0 end
+      ] | add // 0
+    ' "$jsonl" 2>/dev/null)
+  else
+    rounds=$(jq -s '[.[] | select(.type == "user" and (.message.content | type == "string") and .isMeta != true and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit|^\\s*$") | not))] | length' "$jsonl" 2>/dev/null)
+    first_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | head -1)
+    last_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | tail -1)
+
+    duration_min=0
+    if [ -n "$first_ts" ] && [ -n "$last_ts" ]; then
+      local first_epoch last_epoch
+      first_epoch=$(date -d "$first_ts" +%s 2>/dev/null || echo 0)
+      last_epoch=$(date -d "$last_ts" +%s 2>/dev/null || echo 0)
+      duration_min=$(( (last_epoch - first_epoch) / 60 ))
+    fi
+
+    char_count=$(jq -s '
+      [.[] |
+        if .type == "user" and (.message.content | type == "string") then
+          (.message.content | length)
+        elif .type == "assistant" then
+          ([.message.content[]? | select(.type == "text") | .text | length] | add // 0)
+        else 0 end
+      ] | add // 0
+    ' "$jsonl" 2>/dev/null)
+  fi
 
   local token_estimate=$(( char_count * 10 / 25 ))
 
@@ -123,12 +153,22 @@ _ccs_review_json() {
   local sid
   sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
 
-  local dir project
-  dir=$(basename "$(dirname "$jsonl")")
-  project=$(_ccs_resolve_project_path "$dir" 2>/dev/null || echo "$dir")
+  local project
+  if [ "$(_ccs_get_provider "$jsonl")" = "gemini" ]; then
+    # Gemini: Project is the directory name above "chats"
+    project=$(basename "$(dirname "$(dirname "$jsonl")")")
+  else
+    local dir
+    dir=$(basename "$(dirname "$jsonl")")
+    project=$(_ccs_resolve_project_path "$dir" 2>/dev/null || echo "$dir")
+  fi
 
   local model
-  model=$(jq -r 'select(.type == "assistant") | .message.model // empty' "$jsonl" 2>/dev/null | head -1)
+  if [ "$(_ccs_get_provider "$jsonl")" = "gemini" ]; then
+    model=$(jq -r '(if type == "array" then . else .messages // [] end)[] | select(.type == "gemini" or .type == "assistant") | .model // empty' "$jsonl" 2>/dev/null | head -1)
+  else
+    model=$(jq -r 'select(.type == "assistant") | .message.model // empty' "$jsonl" 2>/dev/null | head -1)
+  fi
   [ -z "$model" ] && model="unknown"
 
   local topic
@@ -139,55 +179,64 @@ _ccs_review_json() {
 
   # Todos: extract from LAST TodoWrite call only
   local todos_json
-  todos_json=$(jq -s '
-    [.[] | select(.type == "assistant") |
-     .message.content[]? |
-     select(.type == "tool_use" and .name == "TodoWrite")] |
-    if length > 0 then
-      last | .input.todos | map({status: .status, content: .content})
-    else [] end
-  ' "$jsonl" 2>/dev/null)
+  if [ "$(_ccs_get_provider "$jsonl")" = "gemini" ]; then
+    todos_json=$(jq -c '(if type == "array" then . else .messages // [] end) | [.[] | select(.type == "gemini" or .type == "assistant") | .toolCalls[]? | select(.name == "write_todos")] | if length > 0 then last | .args.todos | map({status: .status, content: .content}) else [] end' "$jsonl" 2>/dev/null)
+  else
+    todos_json=$(jq -s '
+      [.[] | select(.type == "assistant") |
+       .message.content[]? |
+       select(.type == "tool_use" and .name == "TodoWrite")] |
+      if length > 0 then
+        last | .input.todos | map({status: .status, content: .content})
+      else [] end
+    ' "$jsonl" 2>/dev/null)
+  fi
   [ -z "$todos_json" ] || [ "$todos_json" = "null" ] && todos_json="[]"
 
   # Recent files
   local recent_files
-  recent_files=$(_ccs_recent_files_md "$jsonl")
+  recent_files=$(_ccs_recent_files_md "$jsonl" | sed 's/^R /📖 Read /; s/^E /✏️ Edit /; s/^W /📝 Write /; s/^\$ /💻 Bash /; s/^🔍 Grep /🔍 Grep /; s/^🔍 Glob /🔍 Glob /')
   local recent_json
   recent_json=$(echo "$recent_files" | jq -Rs 'split("\n") | map(select(length > 0))' 2>/dev/null)
   [ -z "$recent_json" ] && recent_json="[]"
 
   # Conversation pairs
-  local pair_count conv_json="[]"
-  pair_count=$(jq -s '[.[] | select(.type == "user" and (.message.content | type == "string"))] | length' "$jsonl" 2>/dev/null)
-  if [ "$pair_count" -gt 0 ]; then
+  local conv_json="[]"
+  local -a real_indices=()
+  real_indices=($(_ccs_build_pairs_index "$jsonl" | cut -f1))
+
+  if [ ${#real_indices[@]} -gt 0 ]; then
     local pairs_arr="["
-    local i
-    for (( i=1; i<=pair_count; i++ )); do
+    local idx i=1
+    for idx in "${real_indices[@]}"; do
       local pair_data user_text asst_text tools_text
-      pair_data=$(_ccs_get_pair "$jsonl" "$i")
+      pair_data=$(_ccs_get_pair "$jsonl" "$idx")
       user_text=$(echo "$pair_data" | jq -r 'select(.role == "user") | .text' 2>/dev/null)
       asst_text=$(echo "$pair_data" | jq -r 'select(.role == "assistant") | .text' 2>/dev/null)
 
       # Extract tool names for this pair
-      tools_text=$(jq -c '
-        if .type == "user" and (.message.content | type == "string") then
-          {role: "user", text: .message.content}
-        elif .type == "assistant" then
-          (.message.content | if type == "array" then
-            [.[] | select(.type == "tool_use") |
-              if .name == "Read" then "Read " + .input.file_path
-              elif .name == "Edit" then "Edit " + .input.file_path
-              elif .name == "Write" then "Write " + .input.file_path
-              elif .name == "Bash" then "Bash: " + (.input.command | split("\n") | first | .[:60])
-              elif .name == "Grep" then "Grep " + .input.pattern
-              elif .name == "Agent" then "Agent: " + (.input.description // "")
-              else .name end
-            ] | join("\n")
-          else "" end) as $tools |
-          {role: "assistant", tools: $tools}
-        else empty end
-      ' "$jsonl" 2>/dev/null \
-        | jq -sc --argjson idx "$i" '
+      if [ "$(_ccs_get_provider "$jsonl")" = "gemini" ]; then
+        tools_text=$(jq -c '
+          (if type == "array" then . else .messages // [] end)[] |
+          if (.type == "user" or .role == "user") then
+            {role: "user", text: ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join("\n") else . end)}
+          elif (.type == "assistant" or .type == "gemini" or .type == "model") then
+            (.toolCalls | if type == "array" then
+              [.[]? |
+                if .name == "read_file" then "📖 Read " + (.args.file_path // "")
+                elif .name == "replace" then "✏️ Edit " + (.args.file_path // "")
+                elif .name == "write_file" then "📝 Write " + (.args.file_path // "")
+                elif .name == "run_shell_command" then "💻 Bash: " + (.args.command | split("\n") | first | .[:60])
+                elif .name == "grep_search" then "🔍 Grep " + .args.pattern
+                elif .name == "glob" then "🔍 Glob " + .args.pattern
+                elif .name == "activate_skill" then "🤖 Skill: " + .args.name
+                else "🔧 " + .name end
+              ] | join("\n")
+            else "" end) as $tools |
+            {role: "assistant", tools: $tools}
+          else empty end
+        ' "$jsonl" 2>/dev/null \
+        | jq -sc --argjson idx "$idx" '
           . as $arr |
           [to_entries[] | select(.value.role == "user")] as $users |
           if ($idx < 1 or $idx > ($users | length)) then ""
@@ -198,6 +247,38 @@ _ccs_review_json() {
             map(select(length > 0)) | join("\n")
           end
         ')
+      else
+        tools_text=$(jq -c '
+          if .type == "user" and (.message.content | type == "string") then
+            {role: "user", text: .message.content}
+          elif .type == "assistant" then
+            (.message.content | if type == "array" then
+              [.[] | select(.type == "tool_use") |
+                if .name == "Read" then "📖 Read " + .input.file_path
+                elif .name == "Edit" then "✏️ Edit " + .input.file_path
+                elif .name == "Write" then "📝 Write " + .input.file_path
+                elif .name == "Bash" then "💻 Bash: " + (.input.command | split("\n") | first | .[:60])
+                elif .name == "Grep" then "🔍 Grep " + .input.pattern
+                elif .name == "Glob" then "🔍 Glob " + .input.pattern
+                elif .name == "Agent" then "🤖 Agent: " + (.input.description // "")
+                else "🔧 " + .name end
+              ] | join("\n")
+            else "" end) as $tools |
+            {role: "assistant", tools: $tools}
+          else empty end
+        ' "$jsonl" 2>/dev/null \
+        | jq -sc --argjson idx "$idx" '
+          . as $arr |
+          [to_entries[] | select(.value.role == "user")] as $users |
+          if ($idx < 1 or $idx > ($users | length)) then ""
+          else
+            $users[$idx - 1].key as $spos |
+            (if $idx < ($users | length) then $users[$idx].key else ($arr | length) end) as $epos |
+            [$arr[$spos + 1 : $epos][] | select(.role == "assistant") | .tools] |
+            map(select(length > 0)) | join("\n")
+          end
+        ')
+      fi
 
       local tools_json
       tools_json=$(echo "$tools_text" | jq -Rs 'split("\n") | map(select(length > 0))' 2>/dev/null)
@@ -209,6 +290,7 @@ _ccs_review_json() {
         --arg asst "$asst_text" \
         --argjson tools "$tools_json" \
         '{index: $idx, user: $user, assistant: $asst, tools: $tools}')
+      i=$((i+1))
     done
     pairs_arr+="]"
     conv_json="$pairs_arr"
@@ -231,9 +313,12 @@ _ccs_review_json() {
     git_json=$(jq -n --arg b "$branch" --argjson c "$recent_commits" '{branch: $b, recent_commits: $c}')
   fi
 
+  local provider=$(_ccs_get_provider "$jsonl")
+
   # Assemble
   jq -n \
     --arg sid "$sid" \
+    --arg provider "$provider" \
     --arg project "$project" \
     --arg topic "$topic" \
     --arg model "$model" \
@@ -245,6 +330,7 @@ _ccs_review_json() {
     --argjson conv "$conv_json" \
     '{
       session_id: $sid,
+      provider: $provider,
       project: $project,
       topic: $topic,
       model: $model,
@@ -269,7 +355,7 @@ _ccs_review_md() {
   local json
   json=$(cat)
 
-  local topic project duration rounds chars tokens model
+  local topic project duration rounds chars tokens model provider
   topic=$(echo "$json" | jq -r '.topic')
   project=$(echo "$json" | jq -r '.project')
   duration=$(echo "$json" | jq -r '.time_range.duration_min')
@@ -277,6 +363,11 @@ _ccs_review_md() {
   chars=$(echo "$json" | jq -r '.stats.char_count')
   tokens=$(echo "$json" | jq -r '.stats.token_estimate')
   model=$(echo "$json" | jq -r '.model')
+  provider=$(echo "$json" | jq -r '.provider')
+
+  local asst_label="Claude"
+  [ "$provider" = "gemini" ] && asst_label="Gemini"
+
   local start_time end_time
   start_time=$(echo "$json" | jq -r '.time_range.start')
   end_time=$(echo "$json" | jq -r '.time_range.end')
@@ -345,8 +436,9 @@ EOF
     echo ""
     echo "## 對話紀錄"
     echo ""
-    echo "$json" | jq -r '.conversation[] |
-      "### [\(.index)] User\n\(.user)\n\n### [\(.index)] Claude\n\(.assistant)\n"'
+    echo "$json" | jq -r --arg asst "$asst_label" '.conversation[] |
+      "### [\(.index)] User\n\(.user)\n\n### [\(.index)] \($asst)\n\(.assistant)\n" +
+      (if (.tools | length) > 0 then "#### Tools\n- " + (.tools | join("\n- ")) + "\n\n" else "" end)'
   fi
 }
 

--- a/ccs-viewer.sh
+++ b/ccs-viewer.sh
@@ -285,14 +285,27 @@ HELP
   fi
 
   # ── Session metadata ──
-  local full_sid sid mod_date topic status dir project
-  full_sid=$(basename "$jsonl" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
-  sid=$(echo "$full_sid" | cut -c1-8)
+  local full_sid sid mod_date topic status dir project provider
+  provider=$(_ccs_get_provider "$jsonl")
+  if [ "$provider" = "gemini" ]; then
+    full_sid=$(jq -r '.sessionId // empty' "$jsonl" 2>/dev/null)
+    [ -z "$full_sid" ] && full_sid=$(basename "$jsonl" | sed 's/\.json$//')
+  else
+    full_sid=$(basename "$jsonl" | sed 's/\.jsonl$//')
+  fi
+  if [ "$provider" = "gemini" ]; then
+    sid=$(echo "$full_sid" | awk -F- '{print $(NF)}' | cut -c1-8)
+  else
+    sid=$(echo "$full_sid" | cut -c1-8)
+  fi
   mod_date=$(stat -c "%y" "$jsonl" | cut -d. -f1)
 
-  dir=$(basename "$(dirname "$jsonl")")
-  project=$(echo "$dir" | sed "s/^${_CCS_HOME_ENCODED}-*//; s/-/\//g")
-  [ -z "$project" ] && project="~(home)"
+  if [ "$provider" = "gemini" ]; then
+    project=$(basename "$(dirname "$(dirname "$jsonl")")")
+  else
+    dir=$(basename "$(dirname "$jsonl")")
+    project=$(_ccs_friendly_project_name "$dir")
+  fi
   topic=$(_ccs_topic_from_jsonl "$jsonl")
 
   if _ccs_is_archived "$jsonl"; then
@@ -307,53 +320,15 @@ HELP
   fi
 
   # ── Build filtered pairs index ──
-  # Read both user and assistant entries in one pass to detect interrupted prompts
   local -a real_to_raw=()
   local -a prompts=()
-  local -a has_response=()  # "1" = has assistant text, "0" = interrupted/no text
-  local raw_idx=0 pending_real=-1
-
-  # Response status: "1" = has response, "resend" = user re-sent, "0" = truly no response
   local -a resp_status=()
-  local pending_real=-1 got_assistant=false
 
-  while IFS=$'\t' read -r role is_meta content; do
-    if [ "$role" = "U" ]; then
-      raw_idx=$((raw_idx + 1))
-      # Previous pending prompt: user sent another before getting assistant text
-      if [ "$pending_real" -ge 0 ]; then
-        resp_status[$pending_real]="resend"  # re-sent (will get response via continuation)
-      fi
-      # Filter meta/system
-      [ "$is_meta" = "true" ] && { pending_real=-1; continue; }
-      case "$content" in
-        '<local-command'*|'<command-name'*|'<system-'*) pending_real=-1; continue ;;
-      esac
-      [[ "$content" =~ ^[[:space:]]*/exit ]] && { pending_real=-1; continue; }
-      [[ "$content" =~ ^[[:space:]]*/quit ]] && { pending_real=-1; continue; }
-      [ -z "${content// /}" ] && { pending_real=-1; continue; }
-      real_to_raw+=("$raw_idx")
-      prompts+=("$content")
-      pending_real=$(( ${#real_to_raw[@]} - 1 ))
-    elif [ "$role" = "A" ] && [ "$pending_real" -ge 0 ]; then
-      # Got assistant text for the pending prompt
-      resp_status[$pending_real]="1"
-      pending_real=-1
-    fi
-  done < <(jq -r '
-    if .type == "user" and (.message.content | type == "string") then
-      ["U", (.isMeta // false | tostring), (.message.content | .[:100] | gsub("\n"; " "))] | @tsv
-    elif .type == "assistant" then
-      (.message.content | if type == "array" then
-        [.[] | select(.type == "text") | .text] | join("")
-      else . end) as $t |
-      if ($t | length) > 0 then ["A", "false", ""] | @tsv else empty end
-    else empty end
-  ' "$jsonl" 2>/dev/null)
-  # Handle last pending prompt
-  if [ "$pending_real" -ge 0 ]; then
-    resp_status[$pending_real]="0"
-  fi
+  while IFS=$'\t' read -r ri has_resp is_meta content; do
+    real_to_raw+=("$ri")
+    prompts+=("$content")
+    [ "$has_resp" = "true" ] && resp_status+=("1") || resp_status+=("0")
+  done < <(_ccs_build_pairs_index "$jsonl")
 
   local real_count=${#real_to_raw[@]}
 

--- a/ccs-viewer.sh
+++ b/ccs-viewer.sh
@@ -31,7 +31,7 @@ HELP
   local open_files=()
   while IFS= read -r -d '' f; do
     _ccs_is_archived "$f" || open_files+=("$f")
-  done < <(find "$projects_dir" -maxdepth 2 -name "*.jsonl" -mmin -$((7 * 1440)) ! -path "*/subagents/*" -print0 2>/dev/null)
+  done < <(find "$projects_dir" -maxdepth 2 \( -name "*.jsonl" -o -name "*.json" \) -mmin -$((7 * 1440)) ! -path "*/subagents/*" -print0 2>/dev/null)
 
   # Split fresh / stale
   local fresh_rows="" stale_count=0
@@ -99,7 +99,7 @@ HELP
     topic="-"
     if [ -n "$sid" ]; then
       local jsonl
-      jsonl=$(find "$projects_dir" -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null | head -1)
+      jsonl=$(find "$projects_dir" -maxdepth 2 \( -name "${sid}.jsonl" -o -name "${sid}.json" \) 2>/dev/null | head -1)
       [ -n "$jsonl" ] && topic=$(_ccs_topic_from_jsonl "$jsonl")
     fi
 
@@ -384,7 +384,12 @@ HELP
     printf "\033[1;32m━━ Response ━━\033[0m\n"
     echo "$assistant_text" | head -30
     echo
-    printf "\033[90mResume: claude --resume %s\033[0m\n" "$full_sid"
+    local provider=$(_ccs_get_provider "$jsonl")
+    if [ "$provider" = "gemini" ]; then
+      printf "\033[90mResume: gemini --session %s\033[0m\n" "$full_sid"
+    else
+      printf "\033[90mResume: claude --resume %s\033[0m\n" "$full_sid"
+    fi
     return 0
   fi
 
@@ -490,6 +495,11 @@ HELP
   done
 
   clear
-  printf "\033[90mResume: claude --resume %s\033[0m\n" "$full_sid"
+  local provider=$(_ccs_get_provider "$jsonl")
+  if [ "$provider" = "gemini" ]; then
+    printf "\033[90mResume: gemini --session %s\033[0m\n" "$full_sid"
+  else
+    printf "\033[90mResume: claude --resume %s\033[0m\n" "$full_sid"
+  fi
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -167,7 +167,7 @@ ccs-recap --project    # 僅當前專案
 
 ## ccs-resume-prompt [session-id-prefix]
 
-從 JSONL session 自動產生精簡 bootstrap prompt（< 2000 tokens），設計用來貼入全新 session 無縫接手。
+從 JSON/JSONL session 自動產生精簡 bootstrap prompt（< 2000 tokens），設計用來貼入全新 session 無縫接手。
 
 包含：project context、git 狀態、最近對話摘要、最近操作的檔案。
 
@@ -210,7 +210,7 @@ ccs-crash --idle-window N      # Path 2 window（分鐘，預設 1440）
 
 判斷 session 是否仍在執行使用兩種方法：
 
-1. **精確匹配**：`ps` 抓 `--resume <session-id>`（適用 `claude --resume` 啟動的 session）
+1. **精確匹配**：`ps` 抓 `--resume <session-id>` 或 `--session <session-id>`（適用 `claude --resume` 或 `gemini --session` 啟動的 session）
 2. **cwd 匹配**：比對 Code CLI process (如 claude) 的工作目錄與 session 的 project 路徑（適用 Happy 啟動或 terminal 直接開的 session）。路徑使用正規化比對（`/._` 統一為 `-`）解決 Code CLI 工具路徑編碼歧義。
 
 Hung detection 僅對精確匹配的 session 生效，cwd 匹配因無法確定 process 對應哪個 session，不做 hung 判斷。
@@ -256,7 +256,7 @@ Done: 14 sessions archived.
 - **最後活動：** 09:38（9m ago）
 - **最後訊息：** 好
 - **Git：** master (4 uncommitted files)
-- **Resume：** `claude --resume b9acc81f-...`
+- **Resume：** `claude --resume b9acc81f-...` 或 `gemini --session b9acc81f-...`
 - **Detail：** `ccs-session b9acc81f`
 
 ---

--- a/docs/superpowers/plans/2026-04-13-gemini-cli-session-support.md
+++ b/docs/superpowers/plans/2026-04-13-gemini-cli-session-support.md
@@ -1,0 +1,286 @@
+# Gemini CLI Session Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure `ccs-dashboard` commands provide full support for Gemini CLI sessions (`.json` format) alongside existing Claude Code sessions (`.jsonl` format).
+
+**Architecture:** Abstract the session reading logic in `ccs-core.sh` to handle both `.jsonl` (Claude) and `.json` (Gemini) formats transparently by detecting the provider via file extension. Then, update downstream `jq` pipelines to normalize Gemini's JSON array format into a JSONL stream before processing, or adjust the queries to handle both. Finally, replace hardcoded glob patterns to find both file types.
+
+**Tech Stack:** Bash, jq
+
+---
+
+## Phase 1: Core Infrastructure (CRITICAL)
+
+### Task 1: Add `_ccs_get_provider` & Update `_ccs_topic_from_jsonl`
+
+**Files:**
+- Modify: `ccs-core.sh`
+- Modify: `tests/test-core.sh`
+
+- [ ] **Step 1: Add `_ccs_get_provider` to `ccs-core.sh`**
+
+Add this helper right above `_ccs_is_archived()`:
+```bash
+_ccs_get_provider() {
+  local f="$1"
+  if [[ "$f" == *.json ]]; then
+    echo "gemini"
+  else
+    echo "claude"
+  fi
+}
+```
+
+- [ ] **Step 2: Refactor `_ccs_topic_from_jsonl` to support Gemini**
+
+Replace `_ccs_topic_from_jsonl()` in `ccs-core.sh` (around line 63):
+```bash
+_ccs_topic_from_jsonl() {
+  local f="$1"
+  local topic=""
+  local provider=$(_ccs_get_provider "$f")
+  
+  if grep -q "change_title" "$f" 2>/dev/null; then
+    # Both formats can be filtered with standard jq if we unpack Gemini arrays
+    if [ "$provider" = "gemini" ]; then
+      topic=$(jq -r '.[] | select(.type == "tool_use" and .name == "mcp__happy__change_title") | .input.title' "$f" 2>/dev/null | tail -1)
+    else
+      topic=$(grep "change_title" "$f" 2>/dev/null | jq -r '
+        .message.content[]? |
+        select(.type == "tool_use" and .name == "mcp__happy__change_title") |
+        .input.title' 2>/dev/null | tail -1)
+    fi
+  fi
+  if [ -z "$topic" ]; then
+    # Find first real user message
+    if [ "$provider" = "gemini" ]; then
+      topic=$(jq -r '
+        .[] | select(.type == "user" and (.message.content | type == "string")
+          and ((.isMeta // false) == false)
+          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+          and (.message.content | test("^\\s*$") | not))
+        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+      ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
+    else
+      topic=$(jq -r '
+        select(.type == "user" and (.message.content | type == "string")
+          and ((.isMeta // false) == false)
+          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+          and (.message.content | test("^\\s*$") | not))
+        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+      ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
+    fi
+  fi
+  [ -z "$topic" ] && topic="-"
+  echo "$topic"
+}
+```
+
+- [ ] **Step 3: Update `tests/test-core.sh` to add Gemini mock**
+
+Append to `tests/test-core.sh`:
+```bash
+H="$TEST_DIR/gemini-topic.json"
+cat > "$H" <<'JSON'
+[{"type":"user","message":{"content":"gemini topic"},"timestamp":"2026-04-13T09:00:00Z"},{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},"timestamp":"2026-04-13T09:01:00Z"}]
+JSON
+assert_eq "gemini basic topic" "gemini topic" "$(_ccs_topic_from_jsonl "$H")"
+```
+
+- [ ] **Step 4: Run test and Commit**
+
+Run: `bash tests/test-core.sh`
+Expected: PASS
+Command: `git add ccs-core.sh tests/test-core.sh && git commit -m "feat(core): add _ccs_get_provider and update _ccs_topic_from_jsonl for Gemini support"`
+
+### Task 2: Update `_ccs_is_archived` & `_ccs_detect_crash`
+
+**Files:**
+- Modify: `ccs-core.sh`
+
+- [ ] **Step 1: Modify `_ccs_is_archived`**
+
+At the very top of `_ccs_is_archived()` in `ccs-core.sh`, add:
+```bash
+  local f="$1"
+  if [ "$(_ccs_get_provider "$f")" = "gemini" ]; then
+    return 1 # Gemini doesn't use standard archive markers yet
+  fi
+```
+
+- [ ] **Step 2: Modify `_ccs_detect_crash`**
+
+In `_ccs_detect_crash()`, after getting `mtime` for Claude (`local mtime=$(stat -c %Y "$f")`), add logic to read Gemini's `lastUpdated` or fallback to `mtime`:
+```bash
+      # Use jq to extract last timestamp if possible, fallback to mtime
+      if [[ "$f" == *.json ]]; then
+         local last_ts=$(jq -r '.[-1].timestamp // empty' "$f" 2>/dev/null)
+         if [ -n "$last_ts" ]; then
+           mtime=$(date -d "$last_ts" +%s 2>/dev/null || stat -c %Y "$f")
+         else
+           mtime=$(stat -c %Y "$f")
+         fi
+      else
+         mtime=$(stat -c %Y "$f")
+      fi
+```
+
+- [ ] **Step 3: Commit**
+
+Command: `git add ccs-core.sh && git commit -m "feat(core): support Gemini in _ccs_is_archived and _ccs_detect_crash"`
+
+---
+
+## Phase 2: Core Commands (HIGH)
+
+### Task 3: Normalizing `_ccs_overview_session_data`
+
+**Files:**
+- Modify: `ccs-overview.sh`
+
+- [ ] **Step 1: Refactor `_ccs_overview_session_data()`**
+
+Modify `_ccs_overview_session_data()` in `ccs-overview.sh` to unpack Gemini JSON arrays before running the `jq` pipeline. Change the first `jq -c` call to:
+
+```bash
+  local provider=$(_ccs_get_provider "$jsonl")
+  local jq_filter
+  if [ "$provider" = "gemini" ]; then
+    jq_filter='.[] | select(.type == "user" and (.message.content | type == "string"))'
+  else
+    jq_filter='select(.type == "user" and (.message.content | type == "string"))'
+  fi
+
+  local last_raw_idx
+  last_raw_idx=$(jq -c "$jq_filter" "$jsonl" 2>/dev/null \
+```
+
+Do the same for `todos_json`:
+```bash
+  local todos_filter
+  if [ "$provider" = "gemini" ]; then
+    todos_filter='.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
+  else
+    todos_filter='select(.type == "assistant") | .message.content[]? | select(.type == "tool_use" and .name == "TodoWrite") | [.input.todos[]? | {content, status}]'
+  fi
+  todos_json=$(jq -c "$todos_filter" "$jsonl" 2>/dev/null | tail -1)
+```
+
+- [ ] **Step 2: Commit**
+
+Command: `git add ccs-overview.sh && git commit -m "feat(overview): normalize Gemini JSON for _ccs_overview_session_data"`
+
+### Task 4: Normalizing `_ccs_health_events`
+
+**Files:**
+- Modify: `ccs-health.sh`
+
+- [ ] **Step 1: Update `_ccs_health_events`**
+
+In `ccs-health.sh`, `_ccs_health_events()` currently uses `jq -s 'reduce .[] as $line...'`. For a Gemini `.json` file, which is already an array, `jq -s` wraps it in another array `[[...]]`. We need to unwrap it or conditionally pipe.
+
+Change the jq invocation:
+```bash
+  local provider=$(_ccs_get_provider "$f")
+  local pipe_cmd="cat"
+  if [ "$provider" = "gemini" ]; then
+    pipe_cmd="jq -c .[]"
+  fi
+
+  eval "$pipe_cmd '$f'" 2>/dev/null | jq -s --arg sid "$sid" '
+    reduce .[] as $line (
+```
+
+- [ ] **Step 2: Run test and Commit**
+
+Run: `bash tests/test-health.sh`
+Expected: PASS
+Command: `git add ccs-health.sh && git commit -m "feat(health): support Gemini JSON in _ccs_health_events"`
+
+### Task 5: Normalizing `_ccs_session_stats`
+
+**Files:**
+- Modify: `ccs-review.sh`
+
+- [ ] **Step 1: Update `_ccs_session_stats`**
+
+In `ccs-review.sh`, apply the same `pipe_cmd` trick for both `rounds` and `char_count`.
+```bash
+  local provider=$(_ccs_get_provider "$jsonl")
+  local pipe_cmd="cat"
+  if [ "$provider" = "gemini" ]; then
+    pipe_cmd="jq -c .[]"
+  fi
+
+  local rounds
+  rounds=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '[.[] | select(.type == "user" and (.message.content | type == "string"))] | length' 2>/dev/null)
+
+  local first_ts last_ts
+  first_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | head -1)
+  last_ts=$(eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -r 'select(.timestamp) | .timestamp' 2>/dev/null | tail -1)
+```
+
+Apply `eval "$pipe_cmd '$jsonl'" 2>/dev/null | jq -s '...` for `char_count` as well.
+Update `_ccs_tool_use_stats()` in `ccs-review.sh` with the same `pipe_cmd` normalization.
+
+- [ ] **Step 2: Run test and Commit**
+
+Run: `bash tests/test-review.sh`
+Expected: PASS
+Command: `git add ccs-review.sh && git commit -m "feat(review): support Gemini JSON in _ccs_session_stats"`
+
+---
+
+## Phase 3 & 4: Handoff/Resume & Glob Replacement
+
+### Task 6: Hardcoded `find ... *.jsonl` Globs
+
+**Files:**
+- Modify: `ccs-ops.sh`, `ccs-core.sh`, `ccs-health.sh`
+
+- [ ] **Step 1: Replace Globs**
+
+Run a systematic replacement for `find` commands looking for `.jsonl` files.
+Instead of `-name "*.jsonl"`, use `\( -name "*.jsonl" -o -name "*.json" \)`
+
+Example in `ccs-core.sh` (`_ccs_resolve_jsonl()`):
+```bash
+find "$projects_dir" -maxdepth 2 \( -name "${prefix}*.jsonl" -o -name "${prefix}*.json" \) ! -path "*/subagents/*" 2>/dev/null | head -1
+```
+
+Apply this in `_ccs_collect_sessions` (`ccs-ops.sh`), `_ccs_health_events` (if it loops), and any other `find` queries.
+
+- [ ] **Step 2: Commit**
+
+Command: `git add ccs-core.sh ccs-ops.sh && git commit -m "feat(core): replace hardcoded .jsonl globs with dual support"`
+
+### Task 7: Handoff & Resume
+
+**Files:**
+- Modify: `ccs-dashboard.sh`
+- Modify: `ccs-handoff.sh`
+
+- [ ] **Step 1: Update `ccs-resume-prompt`**
+
+In `ccs-dashboard.sh`, `ccs-resume-prompt` uses `claude --resume`. 
+Add a check for provider:
+```bash
+      "ccs-resume-prompt")
+        file=$(_ccs_resolve_jsonl "$2")
+        [ -z "$file" ] && return 1
+        local provider=$(_ccs_get_provider "$file")
+        local sid
+        if [ "$provider" = "gemini" ]; then
+          sid=$(basename "$file" .json | cut -c1-8)
+          echo "gemini --session $sid"
+        else
+          sid=$(basename "$file" .jsonl | cut -c1-8)
+          echo "claude --resume $sid"
+        fi
+        ;;
+```
+
+- [ ] **Step 2: Commit**
+
+Command: `git add ccs-dashboard.sh && git commit -m "feat(dashboard): support Gemini in ccs-resume-prompt"`

--- a/docs/superpowers/plans/2026-04-14-fix-gemini-session-support.md
+++ b/docs/superpowers/plans/2026-04-14-fix-gemini-session-support.md
@@ -1,0 +1,86 @@
+# Gemini CLI Session Support Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Gemini CLI session support in `ccs-dashboard` by aligning the collector and shell helpers with the actual Gemini JSON format (v0.35.2+) and adding `gemini` process detection for accurate crash reporting.
+
+**Architecture:** Update the Python collector to parse Gemini's object-based structure and ISO timestamps. Enhance shell helpers to detect `gemini` processes and handle the specific JSON schema for topics and status.
+
+**Tech Stack:** Bash, Python 3, jq
+
+---
+
+### Task 1: Fix Gemini Collector (`internal/ccs_collect.py`)
+
+**Files:**
+- Modify: `internal/ccs_collect.py`
+
+- [ ] **Step 1: Update Gemini topic extraction**
+
+Update `get_gemini_topic` to handle the `messages` array, `type: "gemini"`, and `toolCalls` structure.
+
+- [ ] **Step 2: Update Gemini file processing (timestamps & types)**
+
+Update `process_gemini_file` to handle ISO string timestamps and the object-based structure.
+
+- [ ] **Step 3: Run collector manually to verify**
+
+Run: `python3 internal/ccs_collect.py | grep "|G|"`
+Expected: Show Gemini sessions with correct `ago` and `topic`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ccs_collect.py
+git commit -m "fix(collector): support Gemini v0.35+ JSON format and ISO timestamps"
+```
+
+---
+
+### Task 2: Update Crash Detection for Gemini Processes
+
+**Files:**
+- Modify: `ccs-core.sh`
+
+- [ ] **Step 1: Add `gemini` process detection**
+
+Modify `_ccs_detect_crash()` to include `gemini` in `pgrep` and `running_sids`.
+
+- [ ] **Step 2: Fix Gemini `mtime` extraction in crash detection**
+
+Update the logic to parse `lastUpdated` as an ISO string using `date -d`.
+
+- [ ] **Step 3: Run crash detection check**
+
+Run: `source ./ccs-dashboard.sh && ccs-crash --json`
+Expected: Gemini sessions currently running are NOT marked as crashed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ccs-core.sh
+git commit -m "fix(core): add gemini process detection and fix ISO timestamp parsing in ccs-crash"
+```
+
+---
+
+### Task 3: Align Core Helpers with Gemini Object Format
+
+**Files:**
+- Modify: `ccs-core.sh`
+
+- [ ] **Step 1: Update `_ccs_topic_from_jsonl` for Object Format**
+
+Update `_ccs_topic_from_jsonl` to use the correct `jq` filters for the Gemini object structure (`.messages[]`, `.type == "gemini"`, etc.).
+
+- [ ] **Step 2: Verify with `ccs-active`**
+
+Run: `source ./ccs-dashboard.sh && ccs-active`
+Expected: Gemini topics are correctly displayed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ccs-core.sh
+git commit -m "fix(core): update _ccs_topic_from_jsonl to support Gemini object-based structure"
+```

--- a/internal/ccs_collect.py
+++ b/internal/ccs_collect.py
@@ -197,7 +197,8 @@ def process_gemini_file(filepath):
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
             data = json.load(f)
-    except Exception:
+    except Exception as e:
+        print(f"DEBUG: Failed to load {filepath}: {e}", file=sys.stderr)
         return None
         
     filename = os.path.basename(filepath)
@@ -205,10 +206,11 @@ def process_gemini_file(filepath):
         sid = data.get('sessionId', filename.replace('.json', ''))
         last_updated_val = data.get('lastUpdated', 0)
     else:
+        print(f"DEBUG: Data in {filepath} is not a dict: {type(data)}", file=sys.stderr)
         sid = filename.replace('.json', '')
         last_updated_val = 0
         
-    display_sid = sid.split('-')[-1][:8] if '-' in sid else sid[:8]
+    display_sid = sid[:8]
     
     if last_updated_val is None: last_updated_val = 0
     
@@ -240,7 +242,8 @@ def process_gemini_file(filepath):
     if ago_mins < 0: ago_mins = 0
     
     is_archived = data.get('archived') is True
-    status, color = get_status_and_color(ago_mins, is_archived)    ago_str = get_ago_str(ago_mins)
+    status, color = get_status_and_color(ago_mins, is_archived)
+    ago_str = get_ago_str(ago_mins)
     topic = get_gemini_topic(data)
     
     # Project is the dir name above 'chats'

--- a/internal/ccs_collect.py
+++ b/internal/ccs_collect.py
@@ -141,20 +141,50 @@ def collect_claude_sessions(show_all):
 
 def get_gemini_topic(data):
     topic = "-"
-    messages = data.get('messages', [])
+    if isinstance(data, list):
+        messages = data
+    elif isinstance(data, dict):
+        messages = data.get('messages', [])
+    else:
+        return topic
+
     for msg in reversed(messages):
-        if msg.get('role') == 'model':
+        # Handle tool calls for title changes
+        # Type can be 'model', 'assistant', or 'gemini'
+        role = msg.get('role', msg.get('type', ''))
+        if role in ['model', 'assistant', 'gemini']:
+            # Check content for toolCall (v0.34 and earlier)
             for content in msg.get('content', []):
-                if content.get('type') == 'toolCall' and content.get('name') == 'mcp__happy__change_title':
+                if isinstance(content, dict) and content.get('type') == 'toolCall' and content.get('name') == 'mcp__happy__change_title':
                     args = content.get('args', {})
+                    topic_str = args.get('title', '')
+                    if topic_str:
+                        return topic_str.replace('\n', ' ').replace('\t', ' ').replace('|', ':')
+            # Check toolCalls array (v0.35+)
+            for tc in msg.get('toolCalls', []):
+                if tc.get('name') == 'mcp__happy__change_title':
+                    args = tc.get('args', {})
                     topic_str = args.get('title', '')
                     if topic_str:
                         return topic_str.replace('\n', ' ').replace('\t', ' ').replace('|', ':')
 
     for msg in messages:
-        if msg.get('role') == 'user':
-            for content in msg.get('content', []):
-                if content.get('type') == 'text':
+        # Check role or type for user
+        role = msg.get('role', msg.get('type', ''))
+        if role == 'user':
+            content_list = msg.get('content', [])
+            if isinstance(content_list, str):
+                # Handle old format where content might be a string
+                text = content_list.strip()
+                if text and not text.startswith('/'):
+                    import re
+                    clean_text = re.sub(r'<[^>]+>', '', text).strip()
+                    if clean_text:
+                        return clean_text[:120].replace('\n', ' ').replace('\t', ' ').replace('|', ':')
+            elif isinstance(content_list, list):
+                for content in content_list:
+                    if not isinstance(content, dict): continue
+                    # Handle text directly or with type:'text'
                     text = content.get('text', '').strip()
                     if text and not text.startswith('/'):
                         import re
@@ -171,35 +201,52 @@ def process_gemini_file(filepath):
         return None
         
     filename = os.path.basename(filepath)
-    sid = data.get('sessionId', filename.replace('.json', ''))
+    if isinstance(data, dict):
+        sid = data.get('sessionId', filename.replace('.json', ''))
+        last_updated_val = data.get('lastUpdated', 0)
+    else:
+        sid = filename.replace('.json', '')
+        last_updated_val = 0
+        
     display_sid = sid.split('-')[-1][:8] if '-' in sid else sid[:8]
     
-    last_updated = data.get('lastUpdated', 0)
-    if last_updated is None: last_updated = 0
+    if last_updated_val is None: last_updated_val = 0
     
-    now = time.time() * 1000 
-    
-    if last_updated == 0:
+    mtime = 0
+    if isinstance(last_updated_val, str):
         try:
-            last_updated = os.path.getmtime(filepath) * 1000
+            from datetime import datetime
+            # Handle Z suffix for older Python versions
+            iso_str = last_updated_val.replace('Z', '+00:00')
+            dt = datetime.fromisoformat(iso_str)
+            mtime = dt.timestamp()
+        except (ValueError, ImportError):
+            mtime = 0
+    else:
+        try:
+            # Assume it's a number (ms)
+            mtime = float(last_updated_val) / 1000.0
+        except (ValueError, TypeError):
+            mtime = 0
+            
+    if mtime <= 0:
+        try:
+            mtime = os.path.getmtime(filepath)
         except OSError:
             return None
     
-    try:
-        last_updated = float(last_updated)
-    except (ValueError, TypeError):
-        last_updated = 0
-        
-    ago_mins = int((now - last_updated) / 60000)
+    now = time.time()
+    ago_mins = int((now - mtime) / 60)
     if ago_mins < 0: ago_mins = 0
     
-    is_archived = False 
-    status, color = get_status_and_color(ago_mins, is_archived)
-    ago_str = get_ago_str(ago_mins)
+    is_archived = data.get('archived') is True
+    status, color = get_status_and_color(ago_mins, is_archived)    ago_str = get_ago_str(ago_mins)
     topic = get_gemini_topic(data)
     
     # Project is the dir name above 'chats'
-    project = os.path.basename(os.path.dirname(os.path.dirname(filepath)))
+    parent_dir = os.path.dirname(os.path.dirname(filepath))
+    project = os.path.basename(parent_dir)
+    if not project: project = "unknown"
     
     return {
         'provider': 'G', 'filepath': filepath, 'project': project,

--- a/tests/e2e/e2e-helper.sh
+++ b/tests/e2e/e2e-helper.sh
@@ -17,8 +17,9 @@
 setup_e2e_dir() {
   local name="${1:?missing e2e test name}"
   setup_test_dir "$name"
-  mkdir -p "$TEST_DIR/projects"
+  mkdir -p "$TEST_DIR/projects" "$TEST_DIR/gemini"
   export CCS_PROJECTS_DIR="$TEST_DIR/projects"
+  export CCS_GEMINI_DIR="$TEST_DIR/gemini"
 }
 
 # create_mock_session SLUG SID

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -232,11 +232,9 @@ cat > "$G_INTERLEAVED" <<'JSON'
 JSON
 
 result=$(_ccs_build_pairs_index "$G_INTERLEAVED")
-# Should be:
-# 1    First msg
-# 2    Second msg
-assert_contains "G_INTERLEAVED index 1" "$result" $'1\tFirst msg'
-assert_contains "G_INTERLEAVED index 2" "$result" $'2\tSecond msg'
+# Output format: ri\thas_resp\tis_meta\tpreview
+assert_contains "G_INTERLEAVED index 1" "$result" "1	true	false	First msg"
+assert_contains "G_INTERLEAVED index 2" "$result" "2	false	false	Second msg"
 
 echo ""
 echo "=== _ccs_get_pair: Gemini duck-typing content ==="

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -76,4 +76,13 @@ assert_eq "G: isMeta skipped, real msg used" \
   "real msg " \
   "$(_ccs_topic_from_jsonl "$G")"
 
+# Case H: Gemini basic array format
+H="$TEST_DIR/gemini-topic.json"
+cat > "$H" <<'JSON'
+[{"type":"user","message":{"content":"gemini topic"},"timestamp":"2026-04-13T09:00:00Z"},{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},"timestamp":"2026-04-13T09:01:00Z"}]
+JSON
+assert_eq "H: gemini basic topic" \
+  "gemini topic " \
+  "$(_ccs_topic_from_jsonl "$H")"
+
 test_summary

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -85,4 +85,52 @@ assert_eq "H: gemini basic topic" \
   "gemini topic " \
   "$(_ccs_topic_from_jsonl "$H")"
 
+echo ""
+echo "=== _ccs_resolve_jsonl: Gemini search path ==="
+
+# Create a mock Gemini project structure
+MOCK_GEMINI="$TEST_DIR/mock-gemini"
+mkdir -p "$MOCK_GEMINI/tmp/test-project/chats"
+cat > "$MOCK_GEMINI/tmp/test-project/chats/session-2026-04-13T08-51-abc12345.json" <<'JSON'
+{"sessionId":"abc12345","messages":[{"type":"user","content":[{"text":"hello"}],"timestamp":"2026-04-13T08:51:00Z"}]}
+JSON
+
+# Test: resolve by prefix finds Gemini session
+CCS_GEMINI_DIR="$MOCK_GEMINI" \
+  result=$(_ccs_resolve_jsonl "session-2026-04-13T08-51-abc")
+assert_contains "resolve Gemini session by prefix" \
+  "$result" "abc12345.json"
+
+# Test: resolve Claude session still works (real projects dir)
+result=$(_ccs_resolve_jsonl "b52e8a02" 2>/dev/null) || true
+if [ -n "$result" ]; then
+  assert_contains "resolve Claude session unaffected" \
+    "$result" "b52e8a02"
+else
+  # CI/clean environment: no real sessions, just verify no crash
+  printf '  PASS: resolve Claude session (no real data, no crash)\n'
+  PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "=== _ccs_gemini_chats_dir ==="
+
+# Create mock projects.json
+mkdir -p "$MOCK_GEMINI"
+cat > "$MOCK_GEMINI/projects.json" <<JSON
+{"projects":{"$TEST_DIR/fake-project":"test-project"}}
+JSON
+CCS_GEMINI_DIR="$MOCK_GEMINI" \
+  result=$(_ccs_gemini_chats_dir "$TEST_DIR/fake-project")
+assert_eq "gemini chats dir resolves" \
+  "$MOCK_GEMINI/tmp/test-project/chats" \
+  "$result"
+
+# Non-existent project returns empty
+CCS_GEMINI_DIR="$MOCK_GEMINI" \
+  result=$(_ccs_gemini_chats_dir "/nonexistent/path" 2>/dev/null) || true
+assert_eq "non-existent project returns empty" \
+  "" \
+  "$result"
+
 test_summary

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -133,4 +133,127 @@ assert_eq "non-existent project returns empty" \
   "" \
   "$result"
 
+echo ""
+echo "=== _ccs_build_pairs_index: Gemini support ==="
+G_PAIRS="$TEST_DIR/gemini-pairs.json"
+cat > "$G_PAIRS" <<'JSON'
+{
+  "messages": [
+    {
+      "type": "user",
+      "content": [{"text": "Hello world"}],
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "type": "assistant",
+      "content": [{"type": "text", "text": "Hi there!"}],
+      "timestamp": "2026-04-14T10:01:00Z"
+    },
+    {
+      "type": "user",
+      "content": [{"text": "What is 2+2?"}],
+      "timestamp": "2026-04-14T10:02:00Z"
+    }
+  ]
+}
+JSON
+
+result=$(_ccs_build_pairs_index "$G_PAIRS")
+assert_contains "G_PAIRS: find first prompt" "$result" "Hello world"
+assert_contains "G_PAIRS: find second prompt" "$result" "What is 2+2?"
+
+echo ""
+echo "=== _ccs_get_pair: Gemini support ==="
+G_TOOLS="$TEST_DIR/gemini-tools.json"
+cat > "$G_TOOLS" <<'JSON'
+{
+  "messages": [
+    {
+      "type": "user",
+      "content": [{"text": "Read the file"}],
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "type": "assistant",
+      "content": [
+        {"type": "toolCall", "name": "read_file", "args": {"file_path": "foo.txt"}}
+      ],
+      "timestamp": "2026-04-14T10:01:00Z"
+    }
+  ]
+}
+JSON
+
+# Pair 1: User message
+result=$(_ccs_get_pair "$G_TOOLS" 1 | head -1)
+assert_eq "G_TOOLS pair 1 user" '{"role":"user","text":"Read the file"}' "$result"
+
+# Pair 1: Assistant tool call mapping
+result=$(_ccs_get_pair "$G_TOOLS" 1 | tail -1)
+assert_contains "G_TOOLS pair 1 assistant mapping" "$result" "📖 Read foo.txt"
+
+echo ""
+echo "=== _ccs_get_pair: activate_skill mapping ==="
+G_SKILL="$TEST_DIR/gemini-skill.json"
+cat > "$G_SKILL" <<'JSON'
+{
+  "messages": [
+    {
+      "type": "user",
+      "content": [{"text": "Activate skill"}],
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "type": "assistant",
+      "content": [
+        {"type": "toolCall", "name": "activate_skill", "args": {"name": "test-driven-development"}}
+      ],
+      "timestamp": "2026-04-14T10:01:00Z"
+    }
+  ]
+}
+JSON
+
+result=$(_ccs_get_pair "$G_SKILL" 1 | tail -1)
+assert_contains "G_SKILL assistant mapping" "$result" "🤖 Skill: test-driven-development"
+
+echo ""
+echo "=== _ccs_build_pairs_index: Gemini interleaved messages ==="
+G_INTERLEAVED="$TEST_DIR/gemini-interleaved.json"
+cat > "$G_INTERLEAVED" <<'JSON'
+{
+  "messages": [
+    { "role": "system", "content": [{"text": "You are a helper"}] },
+    { "role": "user", "content": [{"text": "First msg"}] },
+    { "role": "model", "content": [{"text": "Response 1"}] },
+    { "role": "user", "content": [{"text": "Second msg"}] }
+  ]
+}
+JSON
+
+result=$(_ccs_build_pairs_index "$G_INTERLEAVED")
+# Should be:
+# 1    First msg
+# 2    Second msg
+assert_contains "G_INTERLEAVED index 1" "$result" $'1\tFirst msg'
+assert_contains "G_INTERLEAVED index 2" "$result" $'2\tSecond msg'
+
+echo ""
+echo "=== _ccs_get_pair: Gemini duck-typing content ==="
+G_DUCK="$TEST_DIR/gemini-duck.json"
+cat > "$G_DUCK" <<'JSON'
+{
+  "messages": [
+    { "role": "user", "content": [{"text": "User msg"}] },
+    { "role": "model", "content": [
+      { "text": "Think first" },
+      { "toolCall": { "name": "run_shell_command", "args": { "command": "ls -la" } } }
+    ] }
+  ]
+}
+JSON
+
+result=$(_ccs_get_pair "$G_DUCK" 1 | tail -1)
+assert_contains "G_DUCK assistant text" "$result" "Think first"
+assert_contains "G_DUCK assistant tool" "$result" "$ ls -la"
 test_summary

--- a/tests/test-gemini-robust.sh
+++ b/tests/test-gemini-robust.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# tests/test-gemini-robust.sh — Robust Gemini parsing tests
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source tests/fixture-helper.sh
+source ccs-core.sh
+
+setup_test_dir "gemini-robust"
+
+echo "=== _ccs_build_pairs_index: multi-part user content ==="
+G_MULTI="$TEST_DIR/gemini-multi.json"
+cat > "$G_MULTI" <<'JSON'
+{
+  "messages": [
+    {
+      "type": "user",
+      "content": [
+        {"text": "Part 1"},
+        {"text": "Part 2"}
+      ],
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "type": "assistant",
+      "content": [{"type": "text", "text": "Hi"}],
+      "timestamp": "2026-04-14T10:01:00Z"
+    }
+  ]
+}
+JSON
+
+result=$(_ccs_build_pairs_index "$G_MULTI")
+# Should be exactly one line for the user message
+line_count=$(echo "$result" | grep -c $'\t' || echo 0)
+assert_eq "G_MULTI: exactly one index line" "1" "$line_count"
+assert_contains "G_MULTI: parts joined" "$result" "Part 1 Part 2"
+
+echo ""
+echo "=== _ccs_get_pair: Robust role/type and content format ==="
+G_ROBUST="$TEST_DIR/gemini-robust.json"
+cat > "$G_ROBUST" <<'JSON'
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "String content",
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "role": "model",
+      "content": "Model response string",
+      "timestamp": "2026-04-14T10:01:00Z"
+    },
+    {
+      "type": "user",
+      "content": [{"text": "Array content"}],
+      "timestamp": "2026-04-14T10:02:00Z"
+    },
+    {
+      "type": "assistant",
+      "toolCalls": [
+        {"name": "read_file", "args": {"file_path": "bar.txt"}}
+      ],
+      "timestamp": "2026-04-14T10:03:00Z"
+    }
+  ]
+}
+JSON
+
+# Pair 1: role: "user", content: "string"
+result=$(_ccs_get_pair "$G_ROBUST" 1 | head -1)
+assert_eq "G_ROBUST pair 1 user (string)" '{"role":"user","text":"String content"}' "$result"
+
+# Pair 1: role: "model", content: "string"
+result=$(_ccs_get_pair "$G_ROBUST" 1 | tail -1)
+assert_eq "G_ROBUST pair 1 assistant (string)" '{"role":"assistant","text":"Model response string"}' "$result"
+
+# Pair 2: type: "user", content: array
+result=$(_ccs_get_pair "$G_ROBUST" 2 | head -1)
+assert_eq "G_ROBUST pair 2 user (array)" '{"role":"user","text":"Array content"}' "$result"
+
+# Pair 2: type: "assistant", toolCalls (not in content)
+result=$(_ccs_get_pair "$G_ROBUST" 2 | tail -1)
+assert_contains "G_ROBUST pair 2 assistant toolCalls" "$result" "📖 Read bar.txt"
+
+echo ""
+echo "=== _ccs_topic_from_jsonl: Gemini toolCall title ==="
+G_TOPIC="$TEST_DIR/gemini-topic-tool.json"
+cat > "$G_TOPIC" <<'JSON'
+{
+  "messages": [
+    {
+      "type": "user",
+      "content": [{"text": "Ignored prompt"}],
+      "timestamp": "2026-04-14T10:00:00Z"
+    },
+    {
+      "type": "assistant",
+      "toolCalls": [
+        {"name": "mcp__happy__change_title", "args": {"title": "Correct Title"}}
+      ],
+      "timestamp": "2026-04-14T10:01:00Z"
+    }
+  ]
+}
+JSON
+
+assert_eq "G_TOPIC: toolCall title" \
+  "Correct Title" \
+  "$(_ccs_topic_from_jsonl "$G_TOPIC")"
+
+test_summary

--- a/tests/test-health.sh
+++ b/tests/test-health.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+source ccs-core.sh
 source ccs-health.sh
 
 pass=0 fail=0

--- a/tests/test-ops.sh
+++ b/tests/test-ops.sh
@@ -93,4 +93,38 @@ else
   PASS=$((PASS + 1))
 fi
 
+echo ""
+echo "=== _ccs_archive_session: Gemini safety ==="
+
+# Claude JSONL: should append last-prompt marker
+CLAUDE_F="$TEST_DIR/claude-session.jsonl"
+cat > "$CLAUDE_F" <<'JSONL'
+{"type":"user","message":{"content":"hello"},"timestamp":"2026-04-14T09:00:00Z"}
+JSONL
+_ccs_archive_session "$CLAUDE_F"
+if tail -1 "$CLAUDE_F" | grep -q '"last-prompt"'; then
+  printf '  PASS: Claude session gets last-prompt marker\n'
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: Claude session missing last-prompt marker\n'
+  FAIL=$((FAIL + 1))
+fi
+
+# Gemini JSON: should NOT be modified
+GEMINI_F="$TEST_DIR/gemini-session.json"
+cat > "$GEMINI_F" <<'JSON'
+{"sessionId":"test","messages":[{"type":"user","content":[{"text":"hi"}]}]}
+JSON
+local_before=$(wc -c < "$GEMINI_F")
+_ccs_archive_session "$GEMINI_F"
+local_after=$(wc -c < "$GEMINI_F")
+if [ "$local_before" = "$local_after" ]; then
+  printf '  PASS: Gemini session not modified by archive\n'
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: Gemini session was modified (size: %s → %s)\n' \
+    "$local_before" "$local_after"
+  FAIL=$((FAIL + 1))
+fi
+
 test_summary

--- a/tests/test-ops.sh
+++ b/tests/test-ops.sh
@@ -110,20 +110,17 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# Gemini JSON: should NOT be modified
+# Gemini JSON: should get archived flag
 GEMINI_F="$TEST_DIR/gemini-session.json"
 cat > "$GEMINI_F" <<'JSON'
 {"sessionId":"test","messages":[{"type":"user","content":[{"text":"hi"}]}]}
 JSON
-local_before=$(wc -c < "$GEMINI_F")
 _ccs_archive_session "$GEMINI_F"
-local_after=$(wc -c < "$GEMINI_F")
-if [ "$local_before" = "$local_after" ]; then
-  printf '  PASS: Gemini session not modified by archive\n'
+if jq -e '.archived == true' "$GEMINI_F" >/dev/null 2>&1; then
+  printf '  PASS: Gemini session gets archived:true flag\n'
   PASS=$((PASS + 1))
 else
-  printf '  FAIL: Gemini session was modified (size: %s → %s)\n' \
-    "$local_before" "$local_after"
+  printf '  FAIL: Gemini session missing archived flag\n'
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/test-review.sh
+++ b/tests/test-review.sh
@@ -69,7 +69,7 @@ assert_eq "D: has conversation" "true" "$(echo "$review_json" | jq 'has("convers
 assert_eq "D: conversation length" "2" "$(echo "$review_json" | jq '.conversation | length')"
 assert_eq "D: todos length" "2" "$(echo "$review_json" | jq '.todos | length')"
 assert_eq "D: summary is null" "null" "$(echo "$review_json" | jq -r '.summary')"
-assert_contains "D: recent_files has Read" "$(echo "$review_json" | jq -r '.recent_files[]')" "R /style.css"
+assert_contains "D: recent_files has Read" "$(echo "$review_json" | jq -r '.recent_files[]')" "📖 Read /style.css"
 
 echo "=== _ccs_review_md: markdown output ==="
 


### PR DESCRIPTION
## Background
隨著 Gemini CLI 的引入，Code CLI Sessions 的儲存格式從單一的 JSON Lines (.jsonl) 變為雙格式並行。本 PR 解決了 #45，實作了底層解析邏輯的抽象化，確保 dashboard 跨模組指令能完整支援兩種 Provider。

## Changes

### Phase 1-2: Core Infrastructure & Commands (`e310804`)
- **Provider 偵測：** 新增 `_ccs_get_provider` 根據副檔名動態判斷 session 類型。
- **解析管道正規化：** 更新 `jq` 處理管線，透過條件式 piping 統一處理 Claude (stream) 與 Gemini (top-level array) 格式。
- **安全性強化：** 移除解析循環中不安全的 `eval` 呼叫，改用安全的 shell piping 以防止路徑注入攻擊。
- **核心模組更新：** 修復 `ccs-core.sh`, `ccs-health.sh`, `ccs-overview.sh`, `ccs-review.sh`, `ccs-handoff.sh` 中超過 10 個核心 helper 的解析錯誤。
- **UI/UX 優化：** 在 `ccs-status` 與 `ccs-details` 顯示中，針對 Gemini session 自動產出 `gemini --session` 的續接指令。

### Phase 3-4: Residual Fixes (`e1e7de7`)
Review 後發現 Issue #45 checklist 中有 3 個遺漏項目，已補齊：
- **`_ccs_archive_session` safety (MEDIUM)：** Gemini `.json` 為 JSON Array 格式，直接 append JSONL marker 會破壞語法。新增 provider 檢查，Gemini sessions 跳過 archive marker。
- **搜尋路徑擴展 (HIGH)：** `_ccs_resolve_jsonl()` 原本僅搜尋 `~/.claude/projects`，現已擴展至 `~/.gemini/tmp/*/chats/`。新增 `_ccs_gemini_chats_dir` helper 透過 `~/.gemini/projects.json` 映射 project path → Gemini chats 目錄。
- **`ccs-feature` / `ccs-project` 搜尋路徑統一 (LOW)：** 將 `ccs-feature.sh` 中 8 處硬編碼的 `find "$HOME/.claude/projects"` 改為 `_ccs_resolve_jsonl`；`ccs-project.sh` 的 `_ccs_project_collect` 與 total count 加入 Gemini chats 搜尋。

### Phase 5: Gemini CLI v0.35+ Support Audit & "Deep Scan" Fixes (`dc083bd`, `5a816a0`)
根據 #45 的完整相容性稽核，進一步修復了 Gemini CLI v0.35+ 的 JSON 物件結構相容性：
- **Robust JSON Parsing**: 實作 "Duck-typing" 解析器，正確處理 Gemini v0.35+ 的物件格式與 multi-part `content` 陣列。
- **Unified Tool Mapping**: 將 Gemini 指令 (`read_file`, `replace` 等) 映射至標準圖示 (`📖 Read`, `✏️ Edit`)。
- **Sequential Indexing**: 修正 Gemini session 索引邏輯，確保與互動式檢視器及 `resume-prompt` 同步（改用 1, 2, 3... 序號而非 raw array index）。
- **Native Archiving Support**: 支援手動封存 Gemini sessions，透過 `ccs-crash --clean` 注入 `"archived": true` 屬性。
- **進程偵測優化**: 精確識別 `gemini` 原生進程及 Happy Coder (Node.js) 包裝進程。
- **深度稽核修正 (Deep Scan)**:
    - **`ccs-overview`**: 徹底解決 `jq` 解析 `null` 欄位導致的崩潰問題，並修正 SID 顯示（顯示 UUID 前 8 碼而非 `session-`）。
    - **`ccs-recap` / `ccs-checkpoint`**: 補齊 Gemini 的輪數計算、待辦事項 (Todos) 提取與逾期 (Deadline) 警示。
    - **Regression Tests (`5a816a0`)**: 修復了因 `_ccs_build_pairs_index` 格式更新導致的舊有測試回歸問題。

## Code Review Summary
經過 `code-reviewer` 代理人的深度審查，本 PR 已完成以下修正：
- **[CRITICAL]** 已修復 `ccs-health.sh` 與 `ccs-review.sh` 中的 `eval` 漏洞。
- **[IMPORTANT]** 已補齊 `_ccs_build_pairs_index`, `_ccs_get_pair`, `_ccs_recent_files_md` 等核心函數對 Gemini 陣列格式的支援。
- **[CONSISTENCY]** 確保所有 `jq` filter 均能正確處理 top-level array 的解包。

## Issue #45 Checklist Coverage
| Item | Status |
|------|:------:|
| `_ccs_get_provider()` | ✅ |
| `_ccs_topic_from_jsonl()` | ✅ |
| `_ccs_is_archived()` | ✅ |
| `_ccs_detect_crash()` | ✅ |
| `_ccs_overview_session_data()` | ✅ `dc083bd` |
| `_ccs_health_events()` | ✅ |
| `_ccs_session_stats()` / `_ccs_tool_use_stats()` | ✅ |
| `find ... *.jsonl` hardcoded (15+ places) | ✅ |
| `ccs-resume-prompt` Gemini support | ✅ |
| `_ccs_archive_session()` Gemini safety | ✅ `0cc3973` |
| `_ccs_resolve_jsonl()` search `~/.gemini/` | ✅ `0cc3973` |
| `ccs-feature` / `ccs-project` search paths | ✅ `0cc3973` |

## Updated Test Report
執行 `tests/run-all.sh` 最終結果如下：
- **Total:** 12 Suites, 187+ Tests
- **Status:** ✅ **ALL PASSED**

| Feature | Provider | Status | Result / Evidence |
| :--- | :--- | :--- | :--- |
| **Active List** | Claude / Gemini | ✅ PASS | Both listed with correct topics and `[G]` / `[C]` tags. |
| **Crash Detection**| Gemini | ✅ PASS | Correctly detects running `gemini` processes and Happy Coder wrappers. |
| **Manual Archive** | Gemini | ✅ PASS | `ccs-crash --clean` successfully hides sessions by injecting `.archived=true`. |
| **Resume Prompt** | Gemini | ✅ PASS | Generates context-rich prompt with correct turn history and tool usage. |
| **Review Report** | Gemini | ✅ PASS | Statistics (rounds, duration, tokens) are accurately calculated from JSON object. |
| **Project View** | Gemini | ✅ PASS | `ccs-project` correctly aggregates stats across both providers. |
| **Cross-Session Overview** | Gemini | ✅ PASS | No `jq` errors; correct SID and Topic display. |
| **Indexing Integrity** | Claude / Gemini | ✅ PASS | Sequential indexing fixed for interleaved and multi-part messages. |
