### PR TITLE
feat: add ccs-archive command and increase status threshold

### DIFF
--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -80,14 +80,14 @@ HELP
     
     local prov="${cols[0]:-}"
     local proj="${cols[1]:-}"
+    local resolved=""
     if [ "$prov" = "C" ]; then
-      # Claude: use encoded dirname
       local _dname=$(basename "$(dirname "$filepath")")
-      _status_projects+=("$(_ccs_resolve_project_path "$_dname" 2>/dev/null)")
+      resolved=$(_ccs_resolve_project_path "$_dname" 2>/dev/null)
     else
-      # Gemini: project name IS the relative project path in ccs_collect.py
-      _status_projects+=("$(_ccs_resolve_project_path "$proj" 2>/dev/null)")
+      resolved=$(_ccs_resolve_project_path "$proj" 2>/dev/null)
     fi
+    _status_projects+=("${resolved:-$proj}")
   done <<< "$sorted_rows"
 
   # Crash detection

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -327,6 +327,39 @@ _ccs_crash_clean_all() {
   printf '\n\033[1mDone:\033[0m %d sessions archived.\n' "$archived"
 }
 
+# ── ccs-archive <SID> — manually mark a session as archived/finished ──
+ccs-archive() {
+  if [ -z "$1" ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    cat <<'HELP'
+ccs-archive <SID>  — manually mark a session as archived/finished
+[personal tool, not official Code CLI]
+
+Appends the termination marker to a session file so it no longer
+appears in Active/Fresh lists. Supports both Claude and Gemini.
+
+Example:
+  ccs-archive 7fe51800
+HELP
+    return 0
+  fi
+
+  local sid="$1"
+  local f
+  f=$(_ccs_resolve_jsonl "$sid")
+  if [ -z "$f" ]; then
+    printf "\033[31mError:\033[0m Session not found: %s\n" "$sid"
+    return 1
+  fi
+
+  printf "Archiving %s (%s)...\n" "$sid" "$(_ccs_get_provider "$f")"
+  if _ccs_archive_session "$f"; then
+    printf "\033[32mSuccess.\033[0m Session marked as archived.\n"
+  else
+    printf "\033[31mFailed\033[0m to archive session.\n"
+    return 1
+  fi
+}
+
 # ── ccs-crash — detect sessions interrupted by crash or unexpected reboot ──
 ccs-crash() {
   local mode="md" reboot_window=30 idle_window=10080 show_all=false


### PR DESCRIPTION
## Description
本 PR 解決了 Session 在 Happy Coder UI 已關閉但 Dashboard 仍持續顯示為 Active 的同步問題。

## Changes
1.  **新增 `ccs-archive <SID>` 指令**：提供手動標記 Session 為已結束 (Archived) 的機制。這會向 `.jsonl` 檔案追加 `last-prompt` 標記，或在 Gemini `.json` 中注入 `archived: true`。
2.  **放寬 `ccs-status` Active 門檻**：將 Active Session 的顯示門檻從 1 天提高到 **7 天**，使其與 `ccs-active` 指令的預設行為一致，方便追蹤跨週任務。

## Use Case
當 Session 因為非預期關閉或 UI 狀態不一致而殘留在 Dashboard 時，可以使用：
```bash
ccs-archive <SID>
```
來手動清理。

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>