### PR TITLE
fix(overview): extract last message from array-content user messages

### DIFF
--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -21,34 +21,66 @@ _ccs_overview_session_data() {
     jq_deadline_filter='select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
   fi
 
-  # --- Last Exchange (last non-meta user-assistant pair) ---
-  # _ccs_get_pair expects a 1-based index into ALL user prompts (including meta).
-  # We need to find the raw index of the last non-meta, non-system user prompt.
-  # Strategy: enumerate all user prompts with their raw 1-based index,
-  # filter out meta/system, take the last one's raw index.
+  # --- Last Exchange (last non-meta user prompt + following assistant) ---
   local user_text="" asst_text=""
-  local last_raw_idx
-  last_raw_idx=$(jq -c "$jq_user_filter" "$jsonl" 2>/dev/null \
-    | jq -sc '
-      [to_entries[] | {
-        raw_idx: (.key + 1),
-        is_meta: (.value.isMeta // false),
-        content: .value.content
-      }]
-      | [.[] | select(
-          .is_meta == false
-          and (.content | type == "string")
-          and (.content | test("^\\s*/exit|^\\s*/quit|^<local-command|^<command-name|^<system-") | not)
-          and (.content | test("^\\s*$") | not)
-        )]
-      | last | .raw_idx // 0
-    ')
-
-  if [ -n "$last_raw_idx" ] && [ "$last_raw_idx" -gt 0 ]; then
-    local pair_json
-    pair_json=$(_ccs_get_pair "$jsonl" "$last_raw_idx")
-    user_text=$(echo "$pair_json" | head -1 | jq -r '.text // ""' 2>/dev/null | head -1 | cut -c1-120)
-    asst_text=$(echo "$pair_json" | tail -1 | jq -r '.text // ""' 2>/dev/null | head -2 | cut -c1-200)
+  if [ "$provider" = "gemini" ]; then
+    # Gemini path: unchanged (out of scope for issue #50).
+    local last_raw_idx
+    last_raw_idx=$(jq -c "$jq_user_filter" "$jsonl" 2>/dev/null \
+      | jq -sc '
+        [to_entries[] | {
+          raw_idx: (.key + 1),
+          is_meta: (.value.isMeta // false),
+          content: .value.content
+        }]
+        | [.[] | select(
+            .is_meta == false
+            and (.content | type == "string")
+            and (.content | test("^\\s*/exit|^\\s*/quit|^<local-command|^<command-name|^<system-") | not)
+            and (.content | test("^\\s*$") | not)
+          )]
+        | last | .raw_idx // 0
+      ')
+    if [ -n "$last_raw_idx" ] && [ "$last_raw_idx" -gt 0 ]; then
+      local pair_json
+      pair_json=$(_ccs_get_pair "$jsonl" "$last_raw_idx")
+      user_text=$(echo "$pair_json" | head -1 | jq -r '.text // ""' 2>/dev/null | head -1 | cut -c1-120)
+      asst_text=$(echo "$pair_json" | tail -1 | jq -r '.text // ""' 2>/dev/null | head -2 | cut -c1-200)
+    fi
+  else
+    # Claude path: self-contained, array-aware (issue #50). New Claude Code
+    # transcripts store user content as content-block arrays; extract the
+    # last non-meta prompt with real text plus the assistant text that follows.
+    local le_json
+    # Two-stage: per-line normalize first so a truncated/garbled final line
+    # (common in crash-interrupted sessions) drops out instead of aborting
+    # the whole slurp and blanking the last message.
+    le_json=$(jq -c '.' "$jsonl" 2>/dev/null | jq -sc '
+      def utext: (.message.content
+        | if type == "array" then [.[]? | select(.type == "text") | .text] | join("\n")
+          else (. // "") end);
+      . as $all
+      | ([ to_entries[]
+           | select(.value.type == "user")
+           | {pos: .key, is_meta: (.value.isMeta // false), text: (.value | utext)} ]
+         | map(select(
+             .is_meta == false
+             and (.text | test("^\\s*/exit|^\\s*/quit|^<local-command|^<command-name|^<system-") | not)
+             and (.text | test("^\\s*$") | not)))
+         | last) as $u
+      | if $u == null then {user: "", assistant: ""}
+        else {
+          user: $u.text,
+          assistant: ([ $all[($u.pos + 1):][]
+                        | select(.type == "assistant")
+                        | (.message.content
+                           | if type == "array" then [.[]? | select(.type == "text") | .text] | join("\n")
+                             else (. // "") end) ]
+                      | map(select(length > 0)) | first // "")
+        }
+        end' 2>/dev/null)
+    user_text=$(echo "$le_json" | jq -r '.user // ""' 2>/dev/null | head -1 | cut -c1-120)
+    asst_text=$(echo "$le_json" | jq -r '.assistant // ""' 2>/dev/null | head -2 | cut -c1-200)
   fi
 
   # --- Todos (last TodoWrite) ---

--- a/tests/test-overview.sh
+++ b/tests/test-overview.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# tests/test-overview.sh — _ccs_overview_session_data last-exchange extraction
+# Run: bash tests/test-overview.sh
+#
+# Regression for issue #50: new Claude Code transcripts store user message
+# content as an array of content blocks (text / tool_result), not a string.
+# last_exchange.user must extract the real prompt text from array content,
+# while ignoring pure tool_result user messages.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+source "$ROOT/tests/fixture-helper.sh"
+source "$ROOT/ccs-core.sh"
+source "$ROOT/ccs-overview.sh"
+
+setup_test_dir "overview"
+
+echo "=== _ccs_overview_session_data: array-content user messages (issue #50) ==="
+
+# Session with array-content user prompts + a trailing tool_result-only
+# user message (the modern Claude Code transcript format).
+ARR="$TEST_DIR/arr-session.jsonl"
+cat > "$ARR" <<'JSONL'
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"first array question"}]},"timestamp":"2026-06-01T09:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"answer 1"}]},"timestamp":"2026-06-01T09:01:00Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"deploy the fix"}]},"timestamp":"2026-06-01T09:02:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]},"timestamp":"2026-06-01T09:03:00Z"}
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_x","type":"tool_result","content":"Todos modified"}]},"timestamp":"2026-06-01T09:04:00Z"}
+JSONL
+
+out_arr=$(_ccs_overview_session_data "$ARR")
+last_user_arr=$(echo "$out_arr" | jq -r '.last_exchange.user')
+
+# The last REAL prompt is "deploy the fix"; the trailing tool_result-only
+# user message must NOT be treated as the last prompt.
+assert_eq "array-content: last real prompt extracted" \
+  "deploy the fix" "$last_user_arr"
+assert_not_contains "array-content: tool_result not surfaced as prompt" \
+  "$last_user_arr" "Todos modified"
+
+echo ""
+echo "=== _ccs_overview_session_data: legacy string-content (regression) ==="
+
+# Old-format session: user content is a plain string.
+STR="$TEST_DIR/str-session.jsonl"
+cat > "$STR" <<'JSONL'
+{"type":"user","message":{"role":"user","content":"old string question"},"timestamp":"2026-06-01T09:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"old answer"}]},"timestamp":"2026-06-01T09:01:00Z"}
+JSONL
+
+out_str=$(_ccs_overview_session_data "$STR")
+last_user_str=$(echo "$out_str" | jq -r '.last_exchange.user')
+assert_eq "string-content: last prompt still extracted (regression)" \
+  "old string question" "$last_user_str"
+
+echo ""
+echo "=== _ccs_overview_session_data: truncated final line (crash tail) ==="
+
+# Crash-interrupted sessions often have a half-written final line. The
+# valid prior records (incl. the last real prompt) must still be read.
+TRUNC="$TEST_DIR/trunc-session.jsonl"
+{
+  echo '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"the real last prompt"}]},"timestamp":"2026-06-01T09:00:00Z"}'
+  echo '{"type":"assistant","message":{"content":[{"type":"text","text":"working on it"}]},"timestamp":"2026-06-01T09:01:00Z"}'
+  printf '%s' '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"par'
+} > "$TRUNC"
+
+out_trunc=$(_ccs_overview_session_data "$TRUNC")
+last_user_trunc=$(echo "$out_trunc" | jq -r '.last_exchange.user')
+assert_eq "truncated-tail: recovers last valid prompt" \
+  "the real last prompt" "$last_user_trunc"
+
+echo ""
+echo "=== _ccs_overview_session_data: interrupted turn + tool_use skip ==="
+
+# Last prompt followed by a tool_use-only assistant, a tool_result, then a
+# text assistant: the surfaced assistant text must skip the empty tool_use
+# turn. Then a final prompt with no assistant (interrupted) -> assistant "".
+MIX="$TEST_DIR/mix-session.jsonl"
+cat > "$MIX" <<'JSONL'
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"run the build"}]},"timestamp":"2026-06-01T09:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"make"}}]},"timestamp":"2026-06-01T09:01:00Z"}
+{"type":"user","message":{"role":"user","content":[{"tool_use_id":"t1","type":"tool_result","content":"built"}]},"timestamp":"2026-06-01T09:02:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"build succeeded"}]},"timestamp":"2026-06-01T09:03:00Z"}
+JSONL
+
+out_mix=$(_ccs_overview_session_data "$MIX")
+assert_eq "tool_use-skip: surfaces text assistant not empty tool_use turn" \
+  "build succeeded" "$(echo "$out_mix" | jq -r '.last_exchange.assistant')"
+assert_eq "tool_use-skip: last prompt is the real text prompt" \
+  "run the build" "$(echo "$out_mix" | jq -r '.last_exchange.user')"
+
+# Interrupted: session ends on a real prompt with no assistant after.
+INTR="$TEST_DIR/intr-session.jsonl"
+cat > "$INTR" <<'JSONL'
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"first"}]},"timestamp":"2026-06-01T09:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"reply"}]},"timestamp":"2026-06-01T09:01:00Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"interrupted prompt"}]},"timestamp":"2026-06-01T09:02:00Z"}
+JSONL
+
+out_intr=$(_ccs_overview_session_data "$INTR")
+assert_eq "interrupted: last prompt extracted" \
+  "interrupted prompt" "$(echo "$out_intr" | jq -r '.last_exchange.user')"
+assert_eq "interrupted: assistant empty (no turn after prompt)" \
+  "" "$(echo "$out_intr" | jq -r '.last_exchange.assistant')"
+
+test_summary


### PR DESCRIPTION
## 背景

dev server 重開後跑 `ccs-crash` 查 crashed sessions，發現 17 筆「最後訊息」全部空白，進而查出 `ccs-overview` / `ccs-crash` 對新版 Claude Code transcript 抽不到 user prompt。

## 根因

新版 Claude Code transcript（觀察於 CC `2.1.159`）的 user message `.message.content` 是 **array**（content blocks: `text` / `tool_result`），舊版是 string。`_ccs_overview_session_data` 的 Claude last-exchange 只認 string content，且第二段 raw_idx 計算讀錯欄位（`.value.content` 應為 `.value.message.content`），導致幾乎所有新 session 的最後訊息都顯示空白。

## 修法（窄修 / Path A）

只把 `_ccs_overview_session_data` 的 Claude last-exchange 改成**自包含、array-aware**：

- 從 array text blocks 或 string 抽取 user prompt text，略過純 `tool_result` 的 user message
- 直接取該 prompt 之後第一個非空的 assistant text
- 先 per-line normalize（`jq -c '.'`）再 slurp，使 crash-interrupted session 常見的**被截斷最後一行**會被丟棄，而非讓整個結果變空白
- **刻意不動** `_ccs_get_pair` 與其他 8 處 string-only enumerator，避免 conversation / handoff / review 的 index 一致性 regression

更廣的 array content 全面支援與一個 review builder 既有 bug 另立 follow-up：#51、#52。

## 測試結果

- [x] 新增 `tests/test-overview.sh`，8 assertions 全綠（array 抽取、tool_result 略過、string 回歸、truncated-tail recover、tool_use-skip、interrupted）
- [x] 全套 `run-all.sh` 無新增 regression（既有 `test-review.sh` / `test-status.sh` 2 個失敗為 pre-existing，本分支對該兩檔 diff 為空）
- [x] 真實 session 驗證：`5561883a` / `bbfb46aa` / `faa61888` 最後訊息皆正確顯示（修前全空）
- [x] `git diff` 僅 `ccs-overview.sh` + 新測試；`_ccs_get_pair` 零改動（零 blast radius）

## Code Review Report

由獨立 reviewer（capable tier）複審，結論 **APPROVE WITH NITS，無 BLOCKER**。

**正確性**（reviewer 實際建 transcript 跑函式逐項驗證，非只讀 code）：array text 抽取、tool_result 略過、`$u==null` 防呆、slice index、assistant 跳過純 tool_use 取後續 text，皆正確；gemini path 與 `_ccs_get_pair` 確認 byte-identical 未動。

**已採納並修正**：
- SHOULD — 原單一 `jq -sc` slurp 遇畸形/截斷行會整個 abort → 最後訊息空白。改為兩段式 `jq -c '.' | jq -sc`，恢復 graceful degradation（已加 `truncated-tail` 測試守護）。

**已評估後暫緩（記錄於此）**：
- NIT — multi-text-block 時 `head -1` 只取首行：沿用原 code 既有顯示慣例，非本次 regression，暫不改以控制範圍。
- NIT — gemini path smoke test：gemini 分支本次完全未動，補測試屬獨立工作，留待 follow-up。

**測試品質**：reviewer 確認為真實行為測試（非 mock 自證），fixture 反映真實 transcript 格式，並已被 `run-all.sh` 的 glob 自動納入。

## 關聯

- Closes #50
- Follow-up：#51（array content 全面支援）、#52（review conversation builder = 0）
