### PR TITLE
fix(core): detect /exit by command, not farewell word

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -53,13 +53,17 @@ _ccs_is_archived() {
   fi
   # Check 1: /exit pattern (handles missing last-prompt after resume→/exit)
   # The /exit sequence writes 3 user events at the very end: caveat, command, stdout.
-  # Key signal: last line is a user event containing "Goodbye!" or "See ya!" (exit stdout).
-  # No assistant event should follow a real /exit.
+  # The stdout farewell is RANDOMIZED by the CLI (Goodbye!, See ya!, Bye!, Catch
+  # you later!, ...), so key on the /exit command in the tail, not the farewell
+  # word. Signal: last line is the user stdout event AND the /exit command sits in
+  # the last 3 lines. No assistant event follows a real /exit (a resume would
+  # append one, pushing the last line off the stdout and the command out of tail).
   local _last_type _last_content
   _last_type=$(tail -1 "$f" 2>/dev/null | python3 -c "import sys,json; d=json.loads(next(sys.stdin)); print(d.get('type',''))" 2>/dev/null)
   if [ "$_last_type" = "user" ]; then
     _last_content=$(tail -1 "$f" 2>/dev/null | python3 -c "import sys,json; d=json.loads(next(sys.stdin)); c=d.get('message',{}).get('content',''); print(c[:200] if isinstance(c,str) else str(c)[:200])" 2>/dev/null)
-    if [[ "$_last_content" == *"local-command-stdout"*"ya!"* ]] || [[ "$_last_content" == *"local-command-stdout"*"Goodbye!"* ]]; then
+    if [[ "$_last_content" == *"local-command-stdout"* ]] \
+       && tail -3 "$f" 2>/dev/null | grep -qF '<command-name>/exit</command-name>'; then
       return 0
     fi
   fi

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -254,4 +254,52 @@ JSON
 result=$(_ccs_get_pair "$G_DUCK" 1 | tail -1)
 assert_contains "G_DUCK assistant text" "$result" "Think first"
 assert_contains "G_DUCK assistant tool" "$result" "$ ls -la"
+
+echo ""
+echo "=== _ccs_is_archived: /exit detection across randomized farewells ==="
+
+# _ccs_is_archived returns an exit code; map it to archived/open for assert_eq.
+assert_archived() { # $1 desc  $2 file  $3 expected(archived|open)
+  local got
+  if _ccs_is_archived "$2"; then got=archived; else got=open; fi
+  assert_eq "$1" "$3" "$got"
+}
+
+# A clean /exit ends in 3 user events; the stdout farewell is randomized by the
+# CLI (Goodbye!, See ya!, Bye!, Catch you later!, ...), so detection must key on
+# the /exit command, not the farewell word (regression: was Goodbye!/ya! only).
+_mk_exit() { # $1 file  $2 farewell
+  cat > "$1" <<JSONL
+{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]},"timestamp":"2026-06-19T09:00:00Z"}
+{"type":"user","message":{"content":"<local-command-caveat>Caveat</local-command-caveat>"},"timestamp":"2026-06-19T09:00:01Z"}
+{"type":"user","message":{"content":"<command-name>/exit</command-name> <command-message>exit</command-message>"},"timestamp":"2026-06-19T09:00:02Z"}
+{"type":"user","message":{"content":"<local-command-stdout>$2</local-command-stdout>"},"timestamp":"2026-06-19T09:00:03Z"}
+JSONL
+}
+
+for fw in "Goodbye!" "See ya!" "Bye!" "Catch you later!"; do
+  EF="$TEST_DIR/exit-${fw// /_}.jsonl"
+  _mk_exit "$EF" "$fw"
+  assert_archived "exit farewell '$fw' -> archived" "$EF" "archived"
+done
+
+# Negative: abrupt end (assistant + telemetry, no /exit) -> open
+ABRUPT="$TEST_DIR/abrupt.jsonl"
+cat > "$ABRUPT" <<'JSONL'
+{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]},"timestamp":"2026-06-19T09:00:00Z"}
+{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-06-19T09:00:01Z"}
+{"type":"system","subtype":"turn_duration","timestamp":"2026-06-19T09:00:02Z"}
+JSONL
+assert_archived "abrupt end (no /exit) -> open" "$ABRUPT" "open"
+
+# Negative: /exit then resumed (assistant after) -> open
+RESUMED="$TEST_DIR/resumed-after-exit.jsonl"
+cat > "$RESUMED" <<'JSONL'
+{"type":"user","message":{"content":"<command-name>/exit</command-name> <command-message>exit</command-message>"},"timestamp":"2026-06-19T09:00:00Z"}
+{"type":"user","message":{"content":"<local-command-stdout>Bye!</local-command-stdout>"},"timestamp":"2026-06-19T09:00:01Z"}
+{"type":"user","message":{"content":"actually keep going"},"timestamp":"2026-06-19T09:05:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"resuming"}]},"timestamp":"2026-06-19T09:05:01Z"}
+JSONL
+assert_archived "resumed after /exit -> open" "$RESUMED" "open"
+
 test_summary


### PR DESCRIPTION
## 摘要

修正 `_ccs_is_archived`（`ccs-core.sh` Check 1）的 /exit 偵測 bug。原本只比對
`/exit` 問候語字串 `Goodbye!` 和 `ya!`，但 claude CLI 的問候語是隨機的（還有
`Bye!`、`Catch you later!`），導致用這些問候語乾淨退出的 session 被誤判為 open，
在 `ccs-status` / `ccs-overview` 顯示為 active。

實測一個 live 專案：27 個乾淨退出裡有 13 個（48%）問候語比對不到。

## 修正方式

改成比對 tail 裡的 `<command-name>/exit</command-name>` 指令標記，而非問候語字串：

- 指令標記跨 CLI 版本穩定，問候語會變
- 比舊版更嚴謹：不會再被其他 slash 指令輸出（如 `/help`）中剛好出現的 `Goodbye!` 誤判
- 保留最後一行 stdout 檢查，確保 resume 後的 session（`/exit` 後又有 assistant）正確判為 open

## Test plan

- [x] `bash tests/test-core.sh` — 27/27 pass，新增 `_ccs_is_archived` 覆蓋：4 種問候語
  （Goodbye! / See ya! / Bye! / Catch you later!）+ abrupt-end 負面 + resume-after-exit 負面
- [x] `bash tests/run-all.sh` — 無新增 regression（既有 3 個 failing test 在 master 上同樣存在，與本 PR 無關）

## 背景

調查 `ccs-status` 顯示一批 session 假 active 時發現。那批假 active 的真正成因是
process 被外部直接中斷（完全無 /exit 序列），屬另一個問題（需 process 存活偵測，
待後續處理）。本 PR 只修「乾淨退出但問候語沒比對到」這個獨立的偵測 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code) via agent-pager
