### PR TITLE
feat(core): detect orphaned sessions via count-aware process liveness

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -704,6 +704,94 @@ _ccs_get_boot_epoch() {
   return 1
 }
 
+# ── Helper: last-activity epoch for a session file ──
+# Claude JSONL: file mtime. Gemini/exported JSON: prefer the in-file timestamp
+# (lastUpdated / last array element), fall back to file mtime.
+_ccs_session_mtime() {
+  local f="$1" mtime last_ts
+  if [[ "$f" == *.json ]]; then
+    last_ts=$(jq -r 'if type == "array" then .[-1].timestamp else .lastUpdated end // empty' "$f" 2>/dev/null)
+    if [ -n "$last_ts" ]; then
+      mtime=$(date -d "$last_ts" +%s 2>/dev/null || stat -c "%Y" "$f" 2>/dev/null)
+    else
+      mtime=$(stat -c "%Y" "$f" 2>/dev/null)
+    fi
+  else
+    mtime=$(stat -c "%Y" "$f" 2>/dev/null)
+  fi
+  echo "$mtime"
+}
+
+# ── Helper: classify session liveness by process budget (pure, no pgrep) ──
+# Decides, per (provider,cwd) group, which sessions are backed by a live entry
+# process and which are orphaned. Pure: reads records from stdin + a count file,
+# writes verdicts to stdout. No process queries -> fully unit-testable.
+#
+# Usage: _ccs_liveness_classify <countfile>
+#   stdin:  one record per line, TAB-separated:
+#             sid <TAB> group_key <TAB> mtime_epoch <TAB> is_exact(0|1)
+#           group_key is opaque (caller uses provider + normalized cwd).
+#           is_exact=1 means the sid has a --resume/--session process (alive).
+#   countfile (arg1): per-group live entry-process counts, TAB-separated:
+#             group_key <TAB> proc_count
+#   stdout: one line per input sid:  sid <TAB> alive|dead
+#
+# Allocation per group:
+#   1. exact-sid sessions are always alive and each consumes one process slot
+#   2. remaining slots = max(0, proc_count - exact_count)
+#   3. remaining slots go to the most-recent (mtime desc) non-exact sessions
+#   4. leftover non-exact sessions are dead (no backing process)
+# Over-counting processes only keeps more sessions alive (conservative); the
+# count source (pgrep -x) never misses a real local entry process, so a
+# genuinely live idle session is not killed.
+_ccs_liveness_classify() {
+  local countfile="$1"
+  awk -F'\t' -v countfile="$countfile" '
+    BEGIN {
+      while ((getline line < countfile) > 0) {
+        n = split(line, a, "\t")
+        if (n >= 2) cnt[a[1]] = a[2] + 0
+      }
+    }
+    {
+      grp = $2
+      idx[grp]++
+      i = idx[grp]
+      gsid[grp, i] = $1
+      gmt[grp, i]  = $3 + 0
+      gex[grp, i]  = $4 + 0
+      if ($4 + 0 == 1) excount[grp]++
+    }
+    END {
+      for (grp in idx) {
+        n = idx[grp]
+        rem = (cnt[grp] + 0) - (excount[grp] + 0)
+        if (rem < 0) rem = 0
+        ne = 0
+        for (i = 1; i <= n; i++) {
+          if (gex[grp, i] == 1) {
+            print gsid[grp, i] "\talive"
+          } else {
+            neidx[++ne] = i
+          }
+        }
+        # insertion sort non-exact indices by mtime descending
+        for (i = 2; i <= ne; i++) {
+          key = neidx[i]; j = i - 1
+          while (j >= 1 && gmt[grp, neidx[j]] < gmt[grp, key]) {
+            neidx[j + 1] = neidx[j]; j--
+          }
+          neidx[j + 1] = key
+        }
+        for (k = 1; k <= ne; k++) {
+          print gsid[grp, neidx[k]] "\t" (k <= rem ? "alive" : "dead")
+        }
+        delete neidx
+      }
+    }
+  '
+}
+
 # ── Helper: detect crash-interrupted sessions ──
 # Usage: declare -A crash_map; _ccs_detect_crash crash_map [--reboot-window N] [--idle-window N] [--hung-threshold N] [files_array] [projects_array]
 # crash_map[session_id] = "high:reboot" | "high:reboot-idle" | "high:non-reboot" | "high:non-reboot-idle" | "high:hung"
@@ -751,39 +839,77 @@ _ccs_detect_crash() {
   # Method 1: session IDs from --resume or --session args
   local running_sids=""
   running_sids=$(ps -eo args 2>/dev/null | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' | sort -u)
-  # Method 2: normalized cwds of all claude or gemini processes
-  # Claude Code encodes paths by replacing /._  with -, so we normalize both sides
-  # to alphanumeric segments joined by - for comparison.
-  local running_cwds_normalized=""
-  running_cwds_normalized=$({
-    for p in $(pgrep -u "$(id -u)" -f "claude.*--output-format" 2>/dev/null) \
-             $(pgrep -u "$(id -u)" -x "claude" 2>/dev/null) \
-             $(pgrep -u "$(id -u)" -x "gemini" 2>/dev/null) \
-             $(pgrep -u "$(id -u)" -f "gemini" 2>/dev/null) \
-             $(pgrep -u "$(id -u)" -f "happy-coder" 2>/dev/null); do
-      readlink "/proc/$p/cwd" 2>/dev/null
+  # Method 2: per-(provider,cwd) live entry-process counts.
+  # A single session spawns many helper processes (launcher bash, Bash-tool
+  # children), so only the comm=claude / comm=gemini entry process is a reliable
+  # 1:1 proxy for a live session. Count them per normalized cwd; the count-aware
+  # allocator (_ccs_liveness_classify) then decides which same-cwd sessions are
+  # backed by a process and which are orphaned (e.g. left behind by /clear or an
+  # external kill). Normalize the cwd the same way project dirs are normalized so
+  # the keys match record keys built from _cd_projects.
+  # Assumption: a process's cwd normalizes to the same key as its session's
+  # project dir. readlink resolves symlinks, so a session launched through a
+  # symlinked path may not match and would be treated as orphaned (over-counting
+  # can't rescue a key *mismatch*) — acceptable: such launches are rare and the
+  # prior loose suffix match had the same readlink basis.
+  local _uid; _uid=$(id -u)
+  local running_cwd_counts=""
+  running_cwd_counts=$({
+    local p cwd norm
+    for p in $(pgrep -u "$_uid" -x claude 2>/dev/null); do
+      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
+      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+      [ -n "$norm" ] && printf 'C:%s\n' "$norm"
     done
-  } | sort -u | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+    for p in $(pgrep -u "$_uid" -x gemini 2>/dev/null); do
+      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
+      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+      [ -n "$norm" ] && printf 'G:%s\n' "$norm"
+    done
+  } | sort | uniq -c | awk '{print $2 "\t" $1}')
 
   local count=${#_cd_files[@]}
   local i
+
+  # ── Pre-pass: count-aware process-liveness allocation ──
+  # Emit a record per non-archived candidate and let _ccs_liveness_classify decide
+  # which same-cwd sessions are backed by a live entry process. Sessions that lose
+  # the per-cwd budget are orphans (no process) -> eligible for crash flagging
+  # below. Replaces the old binary "any process in cwd -> all alive" check, which
+  # masked dead sessions sharing a cwd with a live one (e.g. /clear leftovers).
+  # All candidates compete (regardless of age) so the budget reflects reality;
+  # the main loop still gates flagging by idle window / recency.
+  declare -A _dead_by_liveness=()
+  local _lv_sid _lv_verdict
+  while IFS=$'\t' read -r _lv_sid _lv_verdict; do
+    [ "$_lv_verdict" = "dead" ] && _dead_by_liveness["$_lv_sid"]=1
+  done < <(
+    local j jf jsid jmt jprov jnorm jexact
+    for ((j = 0; j < count; j++)); do
+      jf="${_cd_files[$j]}"
+      [ -f "$jf" ] || continue
+      if [[ "$jf" == *.json ]]; then
+        jq -e '.archived == true' "$jf" &>/dev/null && continue
+      else
+        tail -n 1 "$jf" 2>/dev/null | grep -q '"type":"last-prompt"' && continue
+      fi
+      jmt=$(_ccs_session_mtime "$jf")
+      [ -n "$jmt" ] || continue
+      jsid=$(basename "$jf" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
+      if [[ "$jf" == *.json ]]; then jprov="G"; else jprov="C"; fi
+      jnorm=$(printf '%s' "${_cd_projects[$j]}" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+      jexact=0
+      echo "$running_sids" | grep -qw "$jsid" && jexact=1
+      printf '%s\t%s:%s\t%s\t%s\n' "$jsid" "$jprov" "$jnorm" "$jmt" "$jexact"
+    done | _ccs_liveness_classify <(printf '%s\n' "$running_cwd_counts")
+  )
+
   for ((i = 0; i < count; i++)); do
     local f="${_cd_files[$i]}"
     [ -f "$f" ] || continue
 
     local mtime sid
-    if [[ "$f" == *.json ]]; then
-       # Claude format: [..., {"timestamp": "..."}]
-       # Gemini format: {"lastUpdated": "...", "messages": [...]}
-       local last_ts=$(jq -r 'if type == "array" then .[-1].timestamp else .lastUpdated end // empty' "$f" 2>/dev/null)
-       if [ -n "$last_ts" ]; then
-         mtime=$(date -d "$last_ts" +%s 2>/dev/null || stat -c "%Y" "$f" 2>/dev/null)
-       else
-         mtime=$(stat -c "%Y" "$f" 2>/dev/null)
-       fi
-    else
-       mtime=$(stat -c "%Y" "$f" 2>/dev/null)
-    fi
+    mtime=$(_ccs_session_mtime "$f")
     [ -n "$mtime" ] || continue
     sid=$(basename "$f" | sed -e 's/\.jsonl$//' -e 's/\.json$//')
 
@@ -817,21 +943,15 @@ _ccs_detect_crash() {
     [ "$mtime" -ge "$idle_window_start" ] || continue
     [ "$boot_epoch" -eq 0 ] || [ "$mtime" -ge "$reboot_upper" ] || continue
 
-    # Check if process is still running
-    # Method 1: exact session ID match (--resume sessions) — precise
-    # Method 2: cwd match (Happy-launched sessions without --resume) — approximate
-    local is_running_exact=false is_running_cwd=false
-    if echo "$running_sids" | grep -qw "$sid"; then
-      is_running_exact=true
-    elif [ -n "${_cd_projects[$i]}" ]; then
-      # Normalize project dir name to match normalized cwds
-      local _proj_normalized
-      _proj_normalized=$(echo "${_cd_projects[$i]}" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
-      
-      # Match normalized project path as a suffix of running CWDs
-      [ -n "$_proj_normalized" ] && echo "$running_cwds_normalized" | grep -qE ".*$_proj_normalized$" &&
-      is_running_cwd=true
-    fi
+    # Is this session backed by a live entry process?
+    # Method 1: exact session ID match (--resume) — precise, needed for hung detection.
+    # Method 2: count-aware cwd allocation (_ccs_liveness_classify pre-pass) — the
+    #   session held a per-cwd process slot among its peers (exact matches pinned
+    #   first, then most-recent mtime). Orphans that lost the budget are recorded
+    #   in _dead_by_liveness.
+    local is_running_exact=false is_alive=true
+    echo "$running_sids" | grep -qw "$sid" && is_running_exact=true
+    [ -n "${_dead_by_liveness[$sid]+x}" ] && is_alive=false
 
     # Skip if modified very recently — likely still active (covers fresh non-resume sessions)
     local age=$(( now - mtime ))
@@ -840,15 +960,15 @@ _ccs_detect_crash() {
     fi
 
     # Hung detection: only for exact process match (--resume).
-    # cwd match is approximate — can't tell which session a process belongs to,
-    # so skip crash detection entirely for cwd-matched sessions.
+    # A live --resume process whose session has been silent past the threshold is
+    # hung; count-aware cwd liveness can't attribute a hang to a specific session.
     if "$is_running_exact" && [ "$age" -ge "$hung_threshold" ]; then
       _crash_out["$sid"]="high:hung"
       continue
     fi
 
-    # Process running (exact or cwd) — not crashed
-    ("$is_running_exact" || "$is_running_cwd") && continue
+    # Backed by a live process (exact match or within cwd budget) — not crashed
+    "$is_alive" && continue
 
     # Check for interrupt signals in last assistant message
     # Mid-execution crash: assistant message started but contains no text content

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -224,12 +224,14 @@ ccs-crash --idle-window N      # Path 2 window（分鐘，預設 1440）
 
 ### Running process 偵測
 
-判斷 session 是否仍在執行使用兩種方法：
+判斷 session 是否仍有 live process，採用 **per-cwd 數量配額**（count-aware）：
 
-1. **精確匹配**：`ps` 抓 `--resume <session-id>` 或 `--session <session-id>`（適用 `claude --resume` 或 `gemini --session` 啟動的 session）
-2. **cwd 匹配**：比對 Code CLI process (如 claude) 的工作目錄與 session 的 project 路徑（適用 Happy 啟動或 terminal 直接開的 session）。路徑使用正規化比對（`/._` 統一為 `-`）解決 Code CLI 工具路徑編碼歧義。
+1. **精確匹配**：`ps` 抓 `--resume <session-id>` 或 `--session <session-id>`（適用 `claude --resume` 或 `gemini --session` 啟動的 session）。精確匹配的 session 一律視為 alive，並佔用一個 process slot。
+2. **數量配額**：以 `pgrep -x claude` / `pgrep -x gemini`（精確 comm）計算每個 cwd 的 entry process 數——一個 session 會衍生多個輔助 process（launcher bash、Bash 工具子程序），唯有 `comm=claude`/`gemini` 的 entry process 才是 1:1 對應 session 的可靠指標。每個 cwd 扣掉精確匹配後的剩餘 slot，依 mtime 由新到舊配給同 cwd 其餘 session；配不到 slot 的 session 視為孤兒（無對應 process，例如被 `/clear` 或外部中斷遺留），落入 Path 2 判定。
 
-Hung detection 僅對精確匹配的 session 生效，cwd 匹配因無法確定 process 對應哪個 session，不做 hung 判斷。
+路徑使用正規化比對（`/._` 統一為 `-`）解決 Code CLI 工具路徑編碼歧義。配置邏輯抽為純函式 `_ccs_liveness_classify`；process 數高估只會多保留 alive，不會誤殺仍有 process 的 idle session。
+
+Hung detection 僅對精確匹配的 session 生效；數量配額無法確定某個 process 屬於哪個 session，不做 hung 判斷。
 
 ### 清理功能
 

--- a/tests/test-liveness.sh
+++ b/tests/test-liveness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# tests/test-liveness.sh — _ccs_liveness_classify (pure allocation) tests
+# Run: bash tests/test-liveness.sh
+#
+# _ccs_liveness_classify is the PURE core of process-liveness detection: given
+# session records + per-group live entry-process counts, it decides which
+# sessions are backed by a live process (alive) and which are orphaned (dead).
+# It does NOT query processes, so it is fully unit-testable with fixtures.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source tests/fixture-helper.sh
+source ccs-core.sh
+
+setup_test_dir "liveness"
+
+# Run classifier: $1 = countfile contents, stdin = records.
+# Echoes verdict lines "sid<TAB>alive|dead".
+_run() { # $1 countfile-contents ; stdin = records
+  local cf="$TEST_DIR/count.tsv"
+  printf '%b' "$1" > "$cf"
+  _ccs_liveness_classify "$cf"
+}
+
+echo "=== _ccs_liveness_classify ==="
+
+# T1: single session, one process -> alive
+out=$(printf 's1\tC:cwd1\t1000\t0\n' | _run 'C:cwd1\t1\n')
+assert_contains "T1: lone session with a process is alive" "$out" "s1	alive"
+
+# T2: two sessions, one process -> newest alive, oldest dead
+out=$(printf 's_old\tC:cwd1\t1000\t0\ns_new\tC:cwd1\t2000\t0\n' | _run 'C:cwd1\t1\n')
+assert_contains "T2: newest of two keeps the slot" "$out" "s_new	alive"
+assert_contains "T2: oldest of two is orphaned" "$out" "s_old	dead"
+
+# T3: two sessions, zero processes -> both dead (group absent from countfile)
+out=$(printf 's1\tC:cwd1\t1000\t0\ns2\tC:cwd1\t2000\t0\n' | _run '')
+assert_contains "T3a: no process -> first dead" "$out" "s1	dead"
+assert_contains "T3b: no process -> second dead" "$out" "s2	dead"
+
+# T4: exact-sid session is always alive and consumes the slot, even if older
+out=$(printf 's_exact\tC:cwd1\t1000\t1\ns_new\tC:cwd1\t2000\t0\n' | _run 'C:cwd1\t1\n')
+assert_contains "T4a: exact-sid pinned alive despite older mtime" "$out" "s_exact	alive"
+assert_contains "T4b: newer non-exact loses to consumed slot" "$out" "s_new	dead"
+
+# T5: exact + spare slot -> exact alive AND newest non-exact alive
+out=$(printf 's_exact\tC:cwd1\t1000\t1\ns_new\tC:cwd1\t3000\t0\ns_mid\tC:cwd1\t2000\t0\n' | _run 'C:cwd1\t2\n')
+assert_contains "T5a: exact alive" "$out" "s_exact	alive"
+assert_contains "T5b: newest non-exact takes spare slot" "$out" "s_new	alive"
+assert_contains "T5c: older non-exact orphaned" "$out" "s_mid	dead"
+
+# T6: provider/group isolation — same cwd, different provider
+out=$(printf 'c1\tC:cwd1\t1000\t0\ng1\tG:cwd1\t1000\t0\n' | _run 'C:cwd1\t1\n')
+assert_contains "T6a: claude session alive (C has a process)" "$out" "c1	alive"
+assert_contains "T6b: gemini session dead (G has no process)" "$out" "g1	dead"
+
+# T7: more processes than sessions -> all alive (never over-kill)
+out=$(printf 's1\tC:cwd1\t1000\t0\ns2\tC:cwd1\t2000\t0\n' | _run 'C:cwd1\t5\n')
+assert_contains "T7a: surplus slots keep s1 alive" "$out" "s1	alive"
+assert_contains "T7b: surplus slots keep s2 alive" "$out" "s2	alive"
+
+# T8: exact_count exceeds proc_count -> exacts still alive, remainder floored at 0
+out=$(printf 'e1\tC:cwd1\t1000\t1\ne2\tC:cwd1\t2000\t1\nn1\tC:cwd1\t3000\t0\n' | _run 'C:cwd1\t1\n')
+assert_contains "T8a: first exact alive" "$out" "e1	alive"
+assert_contains "T8b: second exact alive (exact never killed)" "$out" "e2	alive"
+assert_contains "T8c: non-exact dead (no slots left)" "$out" "n1	dead"
+
+test_summary


### PR DESCRIPTION
## 摘要

實作 #55 的**方向 1**（死卻 active）。`_ccs_detect_crash` 原本把「某 cwd 有任一 live process」當成「同 cwd 全部 session 都活著」，導致被 `/clear` 或外部中斷遺留的孤兒 session 躲在同 cwd 的 live process 後面，持續顯示為 active。改用 count-aware 配置後，這類孤兒會被正確判死。

方向 2（活卻 archived）經調查後拆至 #57（每條訊號都有 subtlety、且目前無穩定重現案例）。

## Root cause 補充

調查發現 `/clear` 是高頻主因之一（非只「外部砍」）：`/clear` 會開一個**新** session JSONL，被 clear 掉的**舊** session 戛然而止、無任何 marker，外觀與 crash 完全相同；process 改寫新 sid、cwd 不變 → 舊 session 被同 cwd 的新 session 遮蔽。`/clear` 與外部砍孤兒 signature 相同，同一修法覆蓋。

## 變更內容

- 新增純函式 `_ccs_liveness_classify`：給定 session records + per-cwd entry-process 計數，配置每個 cwd 的 process slot（exact `--resume` 釘住 → 其餘依 mtime 由新到舊），配不到的判為孤兒。純 stdin/檔案介面，可單元測試。
- `_ccs_detect_crash` 改用 count-aware 配置取代二元 cwd 比對；entry-process 以 `pgrep -x claude` / `pgrep -x gemini`（精確 comm）計數，避免一個 session 的多個輔助 process（launcher bash、Bash-tool 子程序）灌水。
- 抽出 `_ccs_session_mtime` 共用 mtime 邏輯。
- 更新 `docs/commands.md` 的「Running process 偵測」說明。

## Test plan

- [x] 單元測試 `tests/test-liveness.sh`：17/17 pass（exact pin、count budget、mtime 排序、provider 分組、floor 邊界）
- [x] 全測試套件無新增 failing（master 既有 3 個 failing：test-review.sh ×1、test-status.sh ×2，不在本 PR 範圍）
- [x] E2E（實機 live 資料）：孤兒 `f47a78a3`（無 process）正確判死、本 session（有 process）保持 alive、**0 個誤殺**
- [x] 差異測試 vs master：REMOVED=0（無回歸）、NEW=45（以前被二元 cwd 比對遮蔽的孤兒）
- [x] 多 process cwd（argus 2 process）：exact 釘住 → 次新 alive → 更舊判死，配置正確

## Code review

Final gate（capable tier）：0 Critical、0 Major、2 Minor（per-session grep 微效能 → out of scope；symlink-cwd 假設 → 已補一行註解）。Verdict: **ship**。

Ref #55（方向 1）。方向 2 → #57。
