### PR TITLE
refactor(core): relocate ccs_collect.py and fix archived /exit detection

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -79,7 +79,7 @@ _ccs_session_row() {
   local f="$1"
   local script_dir
   script_dir="$_CCS_DASHBOARD_DIR"
-  python3 "$script_dir/internal/ccs_collect.py" --file "$f" 2>/dev/null
+  python3 "$script_dir/ccs_collect.py" --file "$f" 2>/dev/null
 }
 
 # ── Helper: resolve topic from JSONL (Happy title or first user msg) ──
@@ -468,7 +468,7 @@ HELP
   local script_dir
   script_dir="$_CCS_DASHBOARD_DIR"
   
-  local collect_cmd="python3 \"$script_dir/internal/ccs_collect.py\""
+  local collect_cmd="python3 \"$script_dir/ccs_collect.py\""
   $show_all && collect_cmd="${collect_cmd} --all"
 
   eval "$collect_cmd" | awk -F'|' -v max_mins="$mins" -v show_all="$show_all" '
@@ -520,7 +520,7 @@ HELP
   local open_files=()
   local sorted_rows=""
   
-  sorted_rows=$(python3 "$script_dir/internal/ccs_collect.py" | awk -F'|' -v max_mins="$mins" '
+  sorted_rows=$(python3 "$script_dir/ccs_collect.py" | awk -F'|' -v max_mins="$mins" '
     $3 <= max_mins && $4 != "archived" { print $0 }
   ')
 
@@ -1318,7 +1318,7 @@ _ccs_collect_sessions() {
     _out_files+=("$filepath")
     _out_projects+=("$encoded_dir")
     _out_rows+=("$(printf '%s\t%s\t%d\t%s\t%s\t%s\t%s' "$prov" "$proj" "$ago" "$status" "$color" "$display" "$badge")")
-  done < <(python3 "$script_dir/internal/ccs_collect.py" $show_all)
+  done < <(python3 "$script_dir/ccs_collect.py" $show_all)
 }
 
 # Helper: format "N ago" from minutes

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -34,8 +34,9 @@ def check_claude_archived(filepath):
                 last_line = json.loads(lines[-1])
                 if last_line.get('type') == 'user':
                     content = last_line.get('message', {}).get('content', '')
-                    if isinstance(content, str) and ('local-command-stdout' in content) and ('ya!' in content or 'Goodbye!' in content):
-                        return True
+                    if isinstance(content, str) and 'local-command-stdout' in content:
+                        if any('<command-name>/exit</command-name>' in l for l in lines[-3:]):
+                            return True
             except json.JSONDecodeError:
                 pass
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -23,6 +23,19 @@ SKIP_LIVE=(
 #   test-ops.sh
 #   test-status.sh
 
+for t in test_*.py; do
+  [ -f "$t" ] || continue
+  echo ""
+  echo "══ $t ══"
+  total=$((total + 1))
+  if python3 "$t" -v 2>&1; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    failed_tests+=("$t")
+  fi
+done
+
 for t in test-*.sh; do
   # Check skip list
   skip=false

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for ccs_collect.py: check_claude_archived."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ccs_collect import check_claude_archived
+
+
+def _write_jsonl(path, lines):
+    with open(path, 'w') as f:
+        for line in lines:
+            f.write(json.dumps(line, separators=(',', ':')) + '\n')
+
+
+ASSISTANT_DONE = {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}, "timestamp": "2026-06-20T10:00:00Z"}
+CAVEAT = {"type": "user", "message": {"content": "<local-command-caveat>Caveat</local-command-caveat>"}, "timestamp": "2026-06-20T10:00:01Z"}
+EXIT_CMD = {"type": "user", "message": {"content": "<command-name>/exit</command-name> <command-message>exit</command-message>"}, "timestamp": "2026-06-20T10:00:02Z"}
+
+
+def _exit_stdout(farewell):
+    return {"type": "user", "message": {"content": f"<local-command-stdout>{farewell}</local-command-stdout>"}, "timestamp": "2026-06-20T10:00:03Z"}
+
+
+class TestCheckClaudeArchived(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _path(self, name):
+        return os.path.join(self.tmp, name + '.jsonl')
+
+    def test_exit_goodbye(self):
+        p = self._path('exit_goodbye')
+        _write_jsonl(p, [ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('Goodbye!')])
+        self.assertTrue(check_claude_archived(p))
+
+    def test_exit_see_ya(self):
+        p = self._path('exit_see_ya')
+        _write_jsonl(p, [ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('See ya!')])
+        self.assertTrue(check_claude_archived(p))
+
+    def test_exit_bye(self):
+        p = self._path('exit_bye')
+        _write_jsonl(p, [ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('Bye!')])
+        self.assertTrue(check_claude_archived(p))
+
+    def test_exit_catch_you_later(self):
+        p = self._path('exit_catch_you_later')
+        _write_jsonl(p, [ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('Catch you later!')])
+        self.assertTrue(check_claude_archived(p))
+
+    def test_abrupt_end_not_archived(self):
+        p = self._path('abrupt')
+        _write_jsonl(p, [
+            ASSISTANT_DONE,
+            {"type": "system", "subtype": "stop_hook_summary", "timestamp": "2026-06-20T10:00:01Z"},
+        ])
+        self.assertFalse(check_claude_archived(p))
+
+    def test_resumed_after_exit_not_archived(self):
+        p = self._path('resumed')
+        _write_jsonl(p, [
+            ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('Bye!'),
+            {"type": "user", "message": {"content": "actually keep going"}, "timestamp": "2026-06-20T10:05:00Z"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "resuming"}]}, "timestamp": "2026-06-20T10:05:01Z"},
+        ])
+        self.assertFalse(check_claude_archived(p))
+
+    def test_last_prompt_no_resume_archived(self):
+        p = self._path('last_prompt')
+        _write_jsonl(p, [
+            ASSISTANT_DONE,
+            {"type": "last-prompt", "timestamp": "2026-06-20T10:00:01Z"},
+        ])
+        self.assertTrue(check_claude_archived(p))
+
+    def test_empty_file_not_archived(self):
+        p = self._path('empty')
+        open(p, 'w').close()
+        self.assertFalse(check_claude_archived(p))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 動機

`ccs_collect.py` 被 Multi-Provider PR #41（Gemini CLI 執行）誤放在 `internal/`，
而 `internal/` 是 gitignore 的 local-only 設計文件目錄。

同一個 PR 也引入了 archived 判定的 drift：Python Check 1 還在用 farewell-word
比對（`ya!` / `Goodbye!`），但 bash 版已在 9421f56 改為偵測 `/exit` command。

## 變更

**搬移（refactor）：**
- `internal/ccs_collect.py` → `ccs_collect.py`（repo root，與 `ccs-project-render.py` 同層）
- 更新 `ccs-core.sh` 4 個呼叫點的路徑
- `internal/` 從此可完全 local-only，gitignore 規則正確

**修正 archived 邏輯（fix）：**
- Python `check_claude_archived` Check 1 改為偵測 `<command-name>/exit</command-name>`
  存在於最後 3 行，與 bash `_ccs_is_archived` 邏輯對齊
- 移除舊 farewell-word 比對（`ya!` / `Goodbye!`）

**測試：**
- 新增 `tests/test_collect.py`：8 個 Python unittest
  - 涵蓋隨機 farewell（Goodbye!, See ya!, Bye!, Catch you later!）
  - abrupt end、resumed-after-exit、last-prompt、空檔
- `tests/run-all.sh` 新增 Python test loop

## 驗收確認

- [x] Python Check 1 改用 `/exit` command 偵測，與 bash 對齊
- [x] `test_collect.py` 8/8 pass，涵蓋隨機 farewell 情境
- [x] `tests/run-all.sh` 全套 13/15 pass（2 個既存失敗不變）
- [x] bash `_ccs_is_archived` 的 7 處呼叫點行為不變（test-core.sh 全綠）

Closes #59