### PR TITLE
fix: handle array-content user messages in all session views

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -125,11 +125,11 @@ _ccs_topic_from_jsonl() {
       ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
     else
       topic=$(jq -r '
-        select(.type == "user" and (.message.content | type == "string")
-          and ((.isMeta // false) == false)
-          and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
-          and (.message.content | test("^\\s*$") | not))
-        | .message.content | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
+        select(.type == "user" and ((.isMeta // false) == false))
+        | (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') as $txt
+        | select($txt | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+        | select($txt | test("^\\s*$") | not)
+        | $txt | gsub("<[^>]+>"; "") | gsub("^\\s+|\\s+$"; "")
       ' "$f" 2>/dev/null | head -1 | tr '\n' ' ' | cut -c1-120)
     fi
   fi
@@ -198,13 +198,16 @@ _ccs_build_pairs_index() {
       | select($txt | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
       | select($txt | test("^\\s*$") | not)'
   else
-    jq_user_filter='select(.value.type == "user" and (.value.message.content | type == "string"))
+    jq_user_filter='select(.value.type == "user")
       | select(.value.isMeta != true)
-      | select(.value.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
-      | select(.value.message.content | test("^\\s*$") | not)'
+      | (.value.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') as $txt
+      | select($txt | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit") | not)
+      | select($txt | test("^\\s*$") | not)'
   fi
 
-  jq -r "
+  local jq_flags="-r"
+  [ "$provider" = "claude" ] && jq_flags="-rs"
+  jq $jq_flags "
     (if type == \"array\" then . else .messages // [] end)
     | to_entries as \$all
     | [ \$all[] | select(.value.type == \"user\" or .value.role == \"user\") ] as \$all_users
@@ -270,8 +273,8 @@ _ccs_get_pair() {
     ' "$jsonl" 2>/dev/null
   else
     jq -c '
-      if .type == "user" and (.message.content | type == "string") then
-        {role: "user", text: .message.content}
+      if .type == "user" then
+        {role: "user", text: (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"')}
       elif .type == "assistant" then
         (.message.content | if type == "array" then
           [.[] | select(.type == "text") | .text] | join("\n")
@@ -340,7 +343,7 @@ _ccs_conversation_md() {
   if [ "$provider" = "gemini" ]; then
     jq_filter='(if type == "array" then . else .messages // [] end)[]? | select(.type == "user" or .role == "user") | [((.isMeta // false) | tostring), ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | .[:80] | gsub("\n"; " "))] | @tsv'
   else
-    jq_filter='select(.type == "user" and (.message.content | type == "string")) | [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] | @tsv'
+    jq_filter='select(.type == "user") | [(.isMeta // false | tostring), ((.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') | .[:80] | gsub("\n"; " "))] | @tsv'
   fi
 
   while IFS=$'\t' read -r is_meta content; do

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -5,6 +5,12 @@
 # Computed at source time — used to strip $HOME prefix from JSONL directory names.
 _CCS_HOME_ENCODED=$(echo "$HOME" | sed 's/\//-/g')
 _CCS_DASHBOARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# jq expression: extract text from a message content value.
+# Pipe the content field to this: .message.content | <_CCS_JQ_EXTRACT_TEXT>
+# Handles legacy string and new array-of-content-blocks format.
+_CCS_JQ_EXTRACT_TEXT='(if type == "array" then [.[]? | select(.type == "text") | .text] | join(" ") elif type == "string" then . else "" end)'
+
 #
 # Helpers:
 #   _ccs_session_row        — parse JSONL session → tab-separated row

--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -487,7 +487,7 @@ HELP
 
     local total_prompts
     local provider=$(_ccs_get_provider "$jsonl")
-    local jq_filter='select(.type == "user" and (.message.content | type == "string"))'
+    local jq_filter='select(.type == "user" and (.message.content | (type == "string" or type == "array")))'
     total_prompts=$( (
       if [ "$provider" = "gemini" ]; then
         jq -c ".[]" "$jsonl" 2>/dev/null

--- a/ccs-handoff.sh
+++ b/ccs-handoff.sh
@@ -331,7 +331,7 @@ HELP
   if [ "$provider" = "gemini" ]; then
     jq_filter='(if type == "array" then . else .messages // [] end)[]? | select(.type == "user" or .role == "user") | [((.isMeta // false) | tostring), ((.content // .message.content) | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | .[:80] | gsub("\n"; " "))] | @tsv'
   else
-    jq_filter='select(.type == "user" and (.message.content | type == "string")) | [(.isMeta // false | tostring), (.message.content | .[:80] | gsub("\n"; " "))] | @tsv'
+    jq_filter='select(.type == "user") | [(.isMeta // false | tostring), ((.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') | .[:80] | gsub("\n"; " "))] | @tsv'
   fi
 
   while IFS=$'\t' read -r is_meta content; do

--- a/ccs-ops.sh
+++ b/ccs-ops.sh
@@ -610,8 +610,9 @@ _ccs_recap_collect() {
       if [ "$provider" = "gemini" ]; then
         preview=$(jq -r '.messages[] | select(.type == "user" or .role == "user") | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end | gsub("\n"; " ") | .[:80]' "$jsonl" 2>/dev/null | tail -1)
       else
-        preview=$(jq -r 'select(.type == "user" and .isMeta != true) |
-          .message.content | if type == "string" then . else "" end |
+        preview=$(jq -r '
+          select(.type == "user" and .isMeta != true) |
+          (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') |
           gsub("\n"; " ") | .[:80]' "$jsonl" 2>/dev/null | tail -1)
       fi
 
@@ -737,7 +738,7 @@ _ccs_recap_collect() {
       if [ "$provider" = "gemini" ]; then
         jq_dl_filter='.messages[] | select((.type == "user" or .role == "user") and .isMeta != true) | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end'
       else
-        jq_dl_filter='select(.type == "user" and .isMeta != true) | .message.content | if type == "string" then . else "" end'
+        jq_dl_filter='select(.type == "user" and .isMeta != true) | (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"')'
       fi
 
       dl_text=$(jq -r "$jq_dl_filter" "$jsonl" 2>/dev/null |
@@ -1244,7 +1245,7 @@ _ccs_checkpoint_collect() {
         if [ "$provider" = "gemini" ]; then
           jq_msg_filter='.messages[] | select((.type == "user" or .role == "user") and .isMeta != true) | .content | if type == "array" then [.[]? | select(.text) | .text] | join(" ") else . end'
         else
-          jq_msg_filter='select(.type == "user" and (.message.content | type == "string") and ((.isMeta // false) == false)) | .message.content'
+          jq_msg_filter='select(.type == "user" and ((.isMeta // false) == false)) | (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"')'
         fi
 
         if jq -r "$jq_msg_filter" "$jsonl" 2>/dev/null \

--- a/ccs-review.sh
+++ b/ccs-review.sh
@@ -102,7 +102,7 @@ _ccs_session_stats() {
       ] | add // 0
     ' "$jsonl" 2>/dev/null)
   else
-    rounds=$(jq -s '[.[] | select(.type == "user" and (.message.content | type == "string") and .isMeta != true and (.message.content | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit|^\\s*$") | not))] | length' "$jsonl" 2>/dev/null)
+    rounds=$(jq -s '[.[] | select(.type == "user" and .isMeta != true) | select((.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"') | test("^<local-command|^<command-name|^<system-|^\\s*/exit|^\\s*/quit|^\\s*$") | not)] | length' "$jsonl" 2>/dev/null)
     first_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | head -1)
     last_ts=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl" 2>/dev/null | tail -1)
 
@@ -116,8 +116,8 @@ _ccs_session_stats() {
 
     char_count=$(jq -s '
       [.[] |
-        if .type == "user" and (.message.content | type == "string") then
-          (.message.content | length)
+        if .type == "user" then
+          (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"' | length)
         elif .type == "assistant" then
           ([.message.content[]? | select(.type == "text") | .text | length] | add // 0)
         else 0 end
@@ -249,8 +249,8 @@ _ccs_review_json() {
         ')
       else
         tools_text=$(jq -c '
-          if .type == "user" and (.message.content | type == "string") then
-            {role: "user", text: .message.content}
+          if .type == "user" then
+            {role: "user", text: (.message.content | '"${_CCS_JQ_EXTRACT_TEXT}"')}
           elif .type == "assistant" then
             (.message.content | if type == "array" then
               [.[] | select(.type == "tool_use") |

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -302,4 +302,41 @@ cat > "$RESUMED" <<'JSONL'
 JSONL
 assert_archived "resumed after /exit -> open" "$RESUMED" "open"
 
+echo "=== _ccs_build_pairs_index: Claude array-content ==="
+
+CLAUDE_ARR="$TEST_DIR/claude-array.jsonl"
+cat > "$CLAUDE_ARR" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"help me fix this"}]},"timestamp":"2026-06-01T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a.py"}},{"type":"text","text":"I see the issue."}]},"timestamp":"2026-06-01T10:01:00Z"}
+{"type":"user","message":{"content":[{"type":"text","text":"looks good, proceed"}]},"timestamp":"2026-06-01T10:05:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Done."}]},"timestamp":"2026-06-01T10:10:00Z"}
+JSONL
+
+arr_index=$(_ccs_build_pairs_index "$CLAUDE_ARR")
+assert_eq "CLAUDE_ARR: pair count" "2" "$(echo "$arr_index" | wc -l | tr -d ' ')"
+assert_contains "CLAUDE_ARR: preview 1" "$arr_index" "help me fix this"
+assert_contains "CLAUDE_ARR: preview 2" "$arr_index" "looks good, proceed"
+
+echo "=== _ccs_get_pair: Claude array-content ==="
+
+arr_pair1=$(_ccs_get_pair "$CLAUDE_ARR" 1)
+assert_eq "CLAUDE_ARR: pair1 user text" \
+  "help me fix this" \
+  "$(echo "$arr_pair1" | jq -r 'select(.role == "user") | .text')"
+assert_contains "CLAUDE_ARR: pair1 asst text" \
+  "$(echo "$arr_pair1" | jq -r 'select(.role == "assistant") | .text')" \
+  "I see the issue."
+
+echo "=== _ccs_topic_from_jsonl: Claude array-content ==="
+
+assert_eq "CLAUDE_ARR: topic from array" \
+  "help me fix this " \
+  "$(_ccs_topic_from_jsonl "$CLAUDE_ARR")"
+
+echo "=== _ccs_conversation_md: Claude array-content ==="
+
+conv_md=$(_ccs_conversation_md "$CLAUDE_ARR" 5)
+assert_contains "CLAUDE_ARR: conv has user" "$conv_md" "help me fix this"
+assert_contains "CLAUDE_ARR: conv has asst" "$conv_md" "I see the issue"
+
 test_summary

--- a/tests/test-handoff.sh
+++ b/tests/test-handoff.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 source tests/fixture-helper.sh
+source ccs-core.sh
 source ccs-handoff.sh
 
 echo "=== ccs-handoff flag handling ==="

--- a/tests/test-review.sh
+++ b/tests/test-review.sh
@@ -164,4 +164,24 @@ assert_eq "weekly: has range" "2026-03-24" "$(echo "$weekly_json" | jq -r '.rang
 assert_eq "weekly: session count" "1" "$(echo "$weekly_json" | jq '.aggregate_stats.total_sessions')"
 assert_eq "weekly: has sessions array" "true" "$(echo "$weekly_json" | jq 'has("sessions")')"
 
+echo "=== _ccs_session_stats: array-content Claude session ==="
+
+E="$TEST_DIR/array-stats.jsonl"
+cat > "$E" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"implement auth"}]},"timestamp":"2026-06-01T10:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/auth.py"}},{"type":"text","text":"Reading auth module."}]},"timestamp":"2026-06-01T10:05:00Z"}
+{"type":"user","message":{"content":[{"type":"text","text":"looks good"}]},"timestamp":"2026-06-01T10:10:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Done."}]},"timestamp":"2026-06-01T10:15:00Z"}
+JSONL
+
+stats_e=$(_ccs_session_stats "$E")
+assert_eq "E: array rounds" "2" "$(echo "$stats_e" | jq -r '.rounds')"
+assert_eq "E: array char_count > 0" "true" "$(echo "$stats_e" | jq '.char_count > 0')"
+
+echo "=== _ccs_review_json: array-content conversation ==="
+
+review_e=$(_ccs_review_json "$E")
+assert_eq "E: conv length" "2" "$(echo "$review_e" | jq '.conversation | length')"
+assert_eq "E: first user text" "implement auth" "$(echo "$review_e" | jq -r '.conversation[0].user')"
+
 test_summary

--- a/tests/test-review.sh
+++ b/tests/test-review.sh
@@ -176,7 +176,7 @@ JSONL
 
 stats_e=$(_ccs_session_stats "$E")
 assert_eq "E: array rounds" "2" "$(echo "$stats_e" | jq -r '.rounds')"
-assert_eq "E: array char_count > 0" "true" "$(echo "$stats_e" | jq '.char_count > 0')"
+assert_eq "E: char_count" "49" "$(echo "$stats_e" | jq '.char_count')"
 
 echo "=== _ccs_review_json: array-content conversation ==="
 


### PR DESCRIPTION
## 解決問題

修復 Claude Code 新版 transcript 格式（user message `content` 為 array-of-content-blocks）在各 session view 中被靜默丟棄的問題（fixes #51）。

同時修復 #52：`_ccs_build_pairs_index` 對 Claude JSONL 使用 `jq -r` 而非 `-rs`，導致每行各自處理、`to_entries` 接收空陣列，`conversation` 永遠為空。

## 變更內容

**共享輔助工具（`ccs-core.sh`）：**
- 新增 `_CCS_JQ_EXTRACT_TEXT` bash 變數，包含 jq expression snippet，統一處理 string 與 array-of-content-blocks 格式

**`ccs-core.sh` 修復（4 個位置）：**
- `_ccs_topic_from_jsonl`：支援 array content 主題提取
- `_ccs_build_pairs_index`：Claude provider 改用 `-rs` flag（Bug #52 修復）+ 更新 user filter
- `_ccs_get_pair`：array content user record 提取
- `_ccs_conversation_md`：array content 對話顯示

**其他檔案修復（8 個位置）：**
- `ccs-review.sh`：rounds 計數、char_count、tools builder
- `ccs-handoff.sh`：jq_filter 對話預覽
- `ccs-dashboard.sh`：`total_prompts` 計數（type broadening）
- `ccs-ops.sh`：session preview、deadline 偵測、blocked 偵測

## 測試

TDD：先寫 failing tests，再實作修復。

## Test Plan

- [x] `bash tests/test-core.sh` → 35/35 passed（含 8 個 CLAUDE_ARR 新測試）
- [x] `bash tests/test-review.sh` → 40/40 passed（含 2 個 E-series 新測試）
- [x] `bash tests/test-handoff.sh` → 5/5 passed（無 regression）
- [x] Gemini code paths untouched（diff 驗證）
- [x] `_CCS_JQ_EXTRACT_TEXT` 值與規格吻合（byte-identical 驗證）
- [x] `_ccs_build_pairs_index` Claude JSONL 不再回傳空 conversation

🤖 Generated with Claude Code via agent-pager