### PR TITLE
feat(canary): warn when unverified claude CLI version detected in JSONL

### DIFF
--- a/ccs-canary-versions.txt
+++ b/ccs-canary-versions.txt
@@ -1,0 +1,7 @@
+# claude CLI versions verified with ccs-dashboard.
+# When a new version is confirmed working, add it here.
+2.1.177
+2.1.178
+2.1.179
+2.1.183
+2.1.185

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -295,6 +295,33 @@ def collect_gemini_sessions(show_all):
                 if s: sessions.append(s)
     return sessions
 
+def load_verified_versions(versions_file=None):
+    """Load known-good claude CLI versions from ccs-canary-versions.txt."""
+    if versions_file is None:
+        versions_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'ccs-canary-versions.txt'
+        )
+    versions = set()
+    try:
+        with open(versions_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    versions.add(line)
+    except FileNotFoundError:
+        pass
+    return versions
+
+
+def check_version_canary(sessions, verified_versions):
+    """Return sorted list of unverified claude CLI versions found in sessions."""
+    seen = set()
+    for s in sessions:
+        if s.get('provider') == 'C' and s.get('version'):
+            seen.add(s['version'])
+    return sorted(v for v in seen if v not in verified_versions)
+
+
 def main():
     show_all = '--all' in sys.argv or '-a' in sys.argv
     file_arg = None
@@ -316,7 +343,12 @@ def main():
         sessions.extend(collect_gemini_sessions(show_all))
     
     sessions.sort(key=lambda x: (x['project'], x['ago_mins']))
-    
+
+    if not file_arg:
+        verified = load_verified_versions()
+        for v in check_version_canary(sessions, verified):
+            print(f"⚠️  claude {v} 尚未驗證，偵測可能失準", file=sys.stderr)
+
     for s in sessions:
         # 11 columns pipe-separated format:
         # prov | proj | ago | status | color | display_proj | sid | ago_str | topic | badge | filepath

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -54,6 +54,23 @@ def check_claude_archived(filepath):
         pass
     return False
 
+def get_claude_version(filepath):
+    """Return the claude CLI version from the first 20 JSONL events, or None."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for i, line in enumerate(f):
+                if i >= 20:
+                    break
+                try:
+                    v = json.loads(line).get('version')
+                    if v:
+                        return str(v)
+                except json.JSONDecodeError:
+                    continue
+    except Exception:
+        pass
+    return None
+
 def get_claude_topic(filepath):
     topic = "-"
     try:
@@ -115,12 +132,13 @@ def process_claude_file(filepath):
     status, color = get_status_and_color(ago_mins, is_archived)
     ago_str = get_ago_str(ago_mins)
     topic = get_claude_topic(filepath)
-    
+    version = get_claude_version(filepath)
+
     return {
         'provider': 'C', 'filepath': filepath, 'project': project,
         'ago_mins': ago_mins, 'status': status, 'color': color,
         'display_project': project, 'sid': sid, 'ago_str': ago_str,
-        'topic': topic, 'badge': ''
+        'topic': topic, 'badge': '', 'version': version or ''
     }
 
 def collect_claude_sessions(show_all):

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from ccs_collect import check_claude_archived, get_claude_version, process_claude_file
+from ccs_collect import (
+    check_claude_archived, get_claude_version, process_claude_file,
+    load_verified_versions, check_version_canary,
+)
 
 
 def _write_jsonl(path, lines):
@@ -154,6 +157,50 @@ class TestProcessClaudeFileVersion(unittest.TestCase):
         result = process_claude_file(p)
         self.assertIsNotNone(result)
         self.assertEqual(result['version'], '')
+
+
+class TestVersionCanary(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_check_version_canary_unverified(self):
+        sessions = [
+            {'provider': 'C', 'version': '2.1.195'},
+            {'provider': 'C', 'version': '2.1.185'},
+        ]
+        result = check_version_canary(sessions, {'2.1.185'})
+        self.assertEqual(result, ['2.1.195'])
+
+    def test_check_version_canary_all_verified(self):
+        sessions = [{'provider': 'C', 'version': '2.1.185'}]
+        self.assertEqual(check_version_canary(sessions, {'2.1.185'}), [])
+
+    def test_check_version_canary_ignores_gemini(self):
+        sessions = [{'provider': 'G', 'version': '1.0.0'}]
+        self.assertEqual(check_version_canary(sessions, set()), [])
+
+    def test_check_version_canary_ignores_empty_version(self):
+        sessions = [{'provider': 'C', 'version': ''}]
+        self.assertEqual(check_version_canary(sessions, set()), [])
+
+    def test_check_version_canary_deduplicates(self):
+        sessions = [
+            {'provider': 'C', 'version': '2.1.195'},
+            {'provider': 'C', 'version': '2.1.195'},
+        ]
+        result = check_version_canary(sessions, set())
+        self.assertEqual(result, ['2.1.195'])
+
+    def test_load_verified_versions_parses_file(self):
+        vf = os.path.join(self.tmp, 'versions.txt')
+        with open(vf, 'w') as f:
+            f.write('# comment\n2.1.185\n2.1.177\n\n')
+        self.assertEqual(load_verified_versions(vf), {'2.1.185', '2.1.177'})
+
+    def test_load_verified_versions_missing_file(self):
+        vf = os.path.join(self.tmp, 'nonexistent.txt')
+        self.assertEqual(load_verified_versions(vf), set())
 
 
 if __name__ == '__main__':

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from ccs_collect import check_claude_archived
+from ccs_collect import check_claude_archived, get_claude_version, process_claude_file
 
 
 def _write_jsonl(path, lines):
@@ -82,6 +82,78 @@ class TestCheckClaudeArchived(unittest.TestCase):
         p = self._path('empty')
         open(p, 'w').close()
         self.assertFalse(check_claude_archived(p))
+
+
+class TestGetClaudeVersion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _path(self, name):
+        return os.path.join(self.tmp, name + '.jsonl')
+
+    def test_version_on_first_event(self):
+        p = self._path('has_version')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hello"}, "version": "2.1.185"},
+        ])
+        self.assertEqual(get_claude_version(p), "2.1.185")
+
+    def test_version_on_later_event(self):
+        p = self._path('version_later')
+        _write_jsonl(p, [
+            {"type": "system", "subtype": "init"},
+            {"type": "user", "message": {"content": "hello"}, "version": "2.1.177"},
+        ])
+        self.assertEqual(get_claude_version(p), "2.1.177")
+
+    def test_no_version_field(self):
+        p = self._path('no_version')
+        _write_jsonl(p, [{"type": "user", "message": {"content": "hello"}}])
+        self.assertIsNone(get_claude_version(p))
+
+    def test_empty_file(self):
+        p = self._path('empty')
+        open(p, 'w').close()
+        self.assertIsNone(get_claude_version(p))
+
+    def test_only_first_20_lines_scanned(self):
+        p = self._path('version_deep')
+        lines = [{"type": "user", "message": {"content": f"msg{i}"}} for i in range(21)]
+        lines[20]["version"] = "2.1.999"  # line 21 (0-indexed), beyond scan window
+        _write_jsonl(p, lines)
+        self.assertIsNone(get_claude_version(p))
+
+
+class TestProcessClaudeFileVersion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.proj_dir = os.path.join(self.tmp, 'myproject')
+        os.makedirs(self.proj_dir)
+
+    def _path(self, name):
+        return os.path.join(self.proj_dir, name + '.jsonl')
+
+    def test_version_included_in_result(self):
+        p = self._path('sess1')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hi"}, "version": "2.1.185",
+             "timestamp": "2026-01-01T00:00:00Z"},
+        ])
+        result = process_claude_file(p)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['version'], '2.1.185')
+
+    def test_missing_version_is_empty_string(self):
+        p = self._path('sess2')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hi"},
+             "timestamp": "2026-01-01T00:00:00Z"},
+        ])
+        result = process_claude_file(p)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['version'], '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 功能說明

當 ccs-dashboard 解析 Claude session JSONL 時，若遇到「未驗證清單」內的 claude CLI 版本，在 stderr 印一行警告，讓使用者在撞到 silent regression 前就得知偵測可能失準。

實作 issue #56 的 B 層（version canary，passive）。不含 `ccs-doctor` live self-test（方案 A）。

## 實作內容

**`ccs_collect.py`：**
- `get_claude_version(filepath)` — 讀 JSONL 前 20 行，取 `version` 欄位
- `process_claude_file` return dict 加入 `'version': str` 欄位
- `load_verified_versions(versions_file=None)` — 讀 `ccs-canary-versions.txt`
- `check_version_canary(sessions, verified)` — 回傳未驗證版本清單（sorted）
- `main()` full-scan 路徑：遇未驗證版本 → stderr 一行警告

**`ccs-canary-versions.txt`（新建）：**
初始已驗證版本：2.1.177, 2.1.178, 2.1.179, 2.1.183, 2.1.185

**警告格式：**
```
⚠️  claude X.Y.Z 尚未驗證，偵測可能失準
```

## Test Report

```
python3 tests/test_collect.py -v

22 tests passed:
  TestCheckClaudeArchived (8 existing)
  TestGetClaudeVersion (5 new)
  TestProcessClaudeFileVersion (2 new)
  TestVersionCanary (7 new)

bash tests/run-all.sh
Total: 15  Passed: 14  Failed: 1 (test-status.sh, pre-existing on master)  Skipped: 1
```

## Code Review Report

**Task 1（version extraction）：** Spec ✅ · Approved
- `get_claude_version` 放在 brief 指定位置（`check_claude_archived` 和 `get_claude_topic` 之間）
- Boundary test `test_only_first_20_lines_scanned` 精確測試 `i >= 20` guard

**Task 2（canary warning）：** Spec ✅ · Approved
- warning format、full-scan guard、stdout 格式全符合 spec
- `ccs-canary-versions.txt` 內容與 spec 逐字對齊

**Final whole-branch review：** Ready to merge: Yes
- No Critical / Important issues
- Minor（全 leave）：
  - `if v:` 在 `get_claude_version` 跳過 `"0"`（real versions 為 semver，不影響）
  - `sorted()` 為 lexicographic（僅影響警告順序，不影響正確性）
  - `test_collect.py` module docstring 仍寫 `check_claude_archived`（post-merge 清理）
  - 新 test class 未加 `addCleanup`（與既有 `TestCheckClaudeArchived` pattern 一致）

## Linked Issues

- Closes #56 (B 層 version canary)