### PR TITLE
fix(issue-57): resurrect idle-live sessions; add canary version check

### DIFF
--- a/ccs-canary-versions.txt
+++ b/ccs-canary-versions.txt
@@ -1,0 +1,7 @@
+# claude CLI versions verified with ccs-dashboard.
+# When a new version is confirmed working, add it here.
+2.1.177
+2.1.178
+2.1.179
+2.1.183
+2.1.185

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -848,12 +848,13 @@ _ccs_resurrect_prompt_archived() {
   declare -A _prom=()
   local _lv=""
   for _r in "${_rows[@]}"; do
-    local _prov _proj _ago _status _sid
-    IFS='|' read -r _prov _proj _ago _status _ _ _sid _ _ _ _ <<< "$_r"
+    local _prov _proj _ago _status _sid _fp
+    IFS='|' read -r _prov _proj _ago _status _ _ _sid _ _ _ _fp <<< "$_r"
     [ "$_status" = "archived" ] && continue
     [ -z "$_sid" ] && continue
     local _mt=$(( now - _ago * 60 ))
-    local _norm; _norm=$(printf '%s' "$_proj" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+    local _encoded_dir; _encoded_dir=$(basename "$(dirname "$_fp")")
+    local _norm; _norm=$(printf '%s' "$_encoded_dir" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
     local _ex=0
     echo "$_sids" | grep -qw "$_sid" 2>/dev/null && _ex=1
     _lv+="${_sid}"$'\t'"${_prov}:${_norm}"$'\t'"${_mt}"$'\t'"${_ex}"$'\n'
@@ -871,11 +872,10 @@ _ccs_resurrect_prompt_archived() {
     local _prov _proj _ago _status _color _dproj _sid _ago_str _topic _badge _fp
     IFS='|' read -r _prov _proj _ago _status _color _dproj _sid _ago_str _topic _badge _fp <<< "$_r"
     if [ "$_status" = "prompt-archived" ] && [ -n "${_alive[$_sid]+x}" ]; then
-      if   (( _ago <    5 )); then _status="active";  _color=$'\033[32m'
-      elif (( _ago <   15 )); then _status="recent";  _color=$'\033[33m'
-      elif (( _ago <   60 )); then _status="idle";    _color=$'\033[36m'
-      elif (( _ago < 1440 )); then _status="stale";   _color=$'\033[34m'
-      else                         _status="dormant"; _color=$'\033[35m'
+      if   (( _ago <   10 )); then _status="active"; _color=$'\033[32m'
+      elif (( _ago <   60 )); then _status="recent"; _color=$'\033[33m'
+      elif (( _ago < 1440 )); then _status="idle";   _color=$'\033[34m'
+      else                         _status="stale";  _color=$'\033[90m'
       fi
     fi
     printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -801,6 +801,89 @@ _ccs_liveness_classify() {
   '
 }
 
+# ── Helper: compute per-(provider,cwd) live entry-process counts ──
+# Output: GROUP_KEY TAB COUNT, one line per unique running process cwd.
+# GROUP_KEY format: C:<norm> for claude, G:<norm> for gemini.
+# norm = path with [/._] replaced by -, deduplicated.
+_ccs_running_cwd_counts() {
+  local _uid; _uid=$(id -u)
+  {
+    local p cwd norm
+    for p in $(pgrep -u "$_uid" -x claude 2>/dev/null); do
+      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
+      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+      [ -n "$norm" ] && printf 'C:%s\n' "$norm"
+    done
+    for p in $(pgrep -u "$_uid" -x gemini 2>/dev/null); do
+      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
+      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+      [ -n "$norm" ] && printf 'G:%s\n' "$norm"
+    done
+  } | sort | uniq -c | awk '{print $2 "\t" $1}'
+}
+
+# ── Pipe filter: resurrect prompt-archived sessions backed by live processes ──
+# Reads 11-column pipe-separated rows from ccs_collect.py.
+# Columns: prov|proj|ago|status|color|display_proj|sid|ago_str|topic|badge|filepath
+#
+# Sessions with status="prompt-archived" (Check 2, trailing last-prompt, not /exit)
+# compete for live process slots via _ccs_liveness_classify alongside normal sessions.
+# Winners are upgraded to their age-appropriate non-archived status.
+# Sessions with status="archived" (Check 1, /exit) pass through unchanged.
+_ccs_resurrect_prompt_archived() {
+  local now; now=$(date +%s)
+
+  local -a _rows=()
+  local _r
+  while IFS= read -r _r; do _rows+=("$_r"); done
+  [ ${#_rows[@]} -eq 0 ] && return 0
+
+  local _counts; _counts=$(_ccs_running_cwd_counts)
+
+  local _sids=""
+  _sids=$(ps -eo args 2>/dev/null \
+    | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' \
+    | sort -u || true)
+
+  declare -A _prom=()
+  local _lv=""
+  for _r in "${_rows[@]}"; do
+    local _prov _proj _ago _status _sid
+    IFS='|' read -r _prov _proj _ago _status _ _ _sid _ _ _ _ <<< "$_r"
+    [ "$_status" = "archived" ] && continue
+    [ -z "$_sid" ] && continue
+    local _mt=$(( now - _ago * 60 ))
+    local _norm; _norm=$(printf '%s' "$_proj" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+    local _ex=0
+    echo "$_sids" | grep -qw "$_sid" 2>/dev/null && _ex=1
+    _lv+="${_sid}"$'\t'"${_prov}:${_norm}"$'\t'"${_mt}"$'\t'"${_ex}"$'\n'
+    [ "$_status" = "prompt-archived" ] && _prom["$_sid"]=1
+  done
+
+  declare -A _alive=()
+  if [ -n "$_lv" ]; then
+    while IFS=$'\t' read -r _s _v; do
+      [ -n "${_prom[$_s]+x}" ] && [ "$_v" = "alive" ] && _alive["$_s"]=1
+    done < <(printf '%s' "$_lv" | _ccs_liveness_classify <(printf '%s\n' "$_counts"))
+  fi
+
+  for _r in "${_rows[@]}"; do
+    local _prov _proj _ago _status _color _dproj _sid _ago_str _topic _badge _fp
+    IFS='|' read -r _prov _proj _ago _status _color _dproj _sid _ago_str _topic _badge _fp <<< "$_r"
+    if [ "$_status" = "prompt-archived" ] && [ -n "${_alive[$_sid]+x}" ]; then
+      if   (( _ago <    5 )); then _status="active";  _color=$'\033[32m'
+      elif (( _ago <   15 )); then _status="recent";  _color=$'\033[33m'
+      elif (( _ago <   60 )); then _status="idle";    _color=$'\033[36m'
+      elif (( _ago < 1440 )); then _status="stale";   _color=$'\033[34m'
+      else                         _status="dormant"; _color=$'\033[35m'
+      fi
+    fi
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+      "$_prov" "$_proj" "$_ago" "$_status" "$_color" "$_dproj" \
+      "$_sid" "$_ago_str" "$_topic" "$_badge" "$_fp"
+  done
+}
+
 # ── Helper: detect crash-interrupted sessions ──
 # Usage: declare -A crash_map; _ccs_detect_crash crash_map [--reboot-window N] [--idle-window N] [--hung-threshold N] [files_array] [projects_array]
 # crash_map[session_id] = "high:reboot" | "high:reboot-idle" | "high:non-reboot" | "high:non-reboot-idle" | "high:hung"
@@ -861,21 +944,8 @@ _ccs_detect_crash() {
   # symlinked path may not match and would be treated as orphaned (over-counting
   # can't rescue a key *mismatch*) — acceptable: such launches are rare and the
   # prior loose suffix match had the same readlink basis.
-  local _uid; _uid=$(id -u)
-  local running_cwd_counts=""
-  running_cwd_counts=$({
-    local p cwd norm
-    for p in $(pgrep -u "$_uid" -x claude 2>/dev/null); do
-      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
-      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
-      [ -n "$norm" ] && printf 'C:%s\n' "$norm"
-    done
-    for p in $(pgrep -u "$_uid" -x gemini 2>/dev/null); do
-      cwd=$(readlink "/proc/$p/cwd" 2>/dev/null) || continue
-      norm=$(printf '%s' "$cwd" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
-      [ -n "$norm" ] && printf 'G:%s\n' "$norm"
-    done
-  } | sort | uniq -c | awk '{print $2 "\t" $1}')
+  local running_cwd_counts
+  running_cwd_counts=$(_ccs_running_cwd_counts)
 
   local count=${#_cd_files[@]}
   local i

--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -480,8 +480,8 @@ HELP
   local collect_cmd="python3 \"$script_dir/ccs_collect.py\""
   $show_all && collect_cmd="${collect_cmd} --all"
 
-  eval "$collect_cmd" | awk -F'|' -v max_mins="$mins" -v show_all="$show_all" '
-    $3 <= max_mins && (show_all == "true" || $4 != "archived") { print $0 }
+  eval "$collect_cmd" | _ccs_resurrect_prompt_archived | awk -F'|' -v max_mins="$mins" -v show_all="$show_all" '
+    $3 <= max_mins && (show_all == "true" || ($4 != "archived" && $4 != "prompt-archived")) { print $0 }
   ' | while IFS='|' read -r prov proj ago status color display_proj sid ago_str topic badge filepath; do
     if [ -n "$prev_project" ] && [ "$proj" != "$prev_project" ]; then
       echo
@@ -529,8 +529,8 @@ HELP
   local open_files=()
   local sorted_rows=""
   
-  sorted_rows=$(python3 "$script_dir/ccs_collect.py" | awk -F'|' -v max_mins="$mins" '
-    $3 <= max_mins && $4 != "archived" { print $0 }
+  sorted_rows=$(python3 "$script_dir/ccs_collect.py" | _ccs_resurrect_prompt_archived | awk -F'|' -v max_mins="$mins" '
+    $3 <= max_mins && $4 != "archived" && $4 != "prompt-archived" { print $0 }
   ')
 
   while IFS='|' read -r prov proj ago status color display_proj sid ago_str topic badge filepath; do
@@ -1397,7 +1397,7 @@ _ccs_collect_sessions() {
     _out_files+=("$filepath")
     _out_projects+=("$encoded_dir")
     _out_rows+=("$(printf '%s\t%s\t%d\t%s\t%s\t%s\t%s' "$prov" "$proj" "$ago" "$status" "$color" "$display" "$badge")")
-  done < <(python3 "$script_dir/ccs_collect.py" $show_all)
+  done < <(python3 "$script_dir/ccs_collect.py" $show_all | _ccs_resurrect_prompt_archived)
 }
 
 # Helper: format "N ago" from minutes

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -295,6 +295,33 @@ def collect_gemini_sessions(show_all):
                 if s: sessions.append(s)
     return sessions
 
+def load_verified_versions(versions_file=None):
+    """Load known-good claude CLI versions from ccs-canary-versions.txt."""
+    if versions_file is None:
+        versions_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'ccs-canary-versions.txt'
+        )
+    versions = set()
+    try:
+        with open(versions_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    versions.add(line)
+    except FileNotFoundError:
+        pass
+    return versions
+
+
+def check_version_canary(sessions, verified_versions):
+    """Return sorted list of unverified claude CLI versions found in sessions."""
+    seen = set()
+    for s in sessions:
+        if s.get('provider') == 'C' and s.get('version'):
+            seen.add(s['version'])
+    return sorted(v for v in seen if v not in verified_versions)
+
+
 def main():
     show_all = '--all' in sys.argv or '-a' in sys.argv
     file_arg = None
@@ -316,7 +343,12 @@ def main():
         sessions.extend(collect_gemini_sessions(show_all))
     
     sessions.sort(key=lambda x: (x['project'], x['ago_mins']))
-    
+
+    if not file_arg:
+        verified = load_verified_versions()
+        for v in check_version_canary(sessions, verified):
+            print(f"⚠️  claude {v} 尚未驗證，偵測可能失準", file=sys.stderr)
+
     for s in sessions:
         # 11 columns pipe-separated format:
         # prov | proj | ago | status | color | display_proj | sid | ago_str | topic | badge | filepath

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -54,6 +54,23 @@ def check_claude_archived(filepath):
         pass
     return False
 
+def get_claude_version(filepath):
+    """Return the claude CLI version from the first 20 JSONL events, or None."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for i, line in enumerate(f):
+                if i >= 20:
+                    break
+                try:
+                    v = json.loads(line).get('version')
+                    if v:
+                        return str(v)
+                except json.JSONDecodeError:
+                    continue
+    except Exception:
+        pass
+    return None
+
 def get_claude_topic(filepath):
     topic = "-"
     try:
@@ -115,12 +132,13 @@ def process_claude_file(filepath):
     status, color = get_status_and_color(ago_mins, is_archived)
     ago_str = get_ago_str(ago_mins)
     topic = get_claude_topic(filepath)
-    
+    version = get_claude_version(filepath)
+
     return {
         'provider': 'C', 'filepath': filepath, 'project': project,
         'ago_mins': ago_mins, 'status': status, 'color': color,
         'display_project': project, 'sid': sid, 'ago_str': ago_str,
-        'topic': topic, 'badge': ''
+        'topic': topic, 'badge': '', 'version': version or ''
     }
 
 def collect_claude_sessions(show_all):

--- a/ccs_collect.py
+++ b/ccs_collect.py
@@ -5,8 +5,10 @@ import sys
 import time
 
 def get_status_and_color(ago_mins, is_archived):
-    if is_archived:
-        return "archived", "\033[90m\033[9m" # gray + strikethrough
+    if is_archived == "exit" or is_archived is True:
+        return "archived", "\033[90m\033[9m"  # gray + strikethrough
+    if is_archived == "prompt":
+        return "prompt-archived", "\033[90m\033[9m"  # same visual, different status
     elif ago_mins < 10:
         return "active", "\033[32m" # green
     elif ago_mins < 60:
@@ -36,7 +38,7 @@ def check_claude_archived(filepath):
                     content = last_line.get('message', {}).get('content', '')
                     if isinstance(content, str) and 'local-command-stdout' in content:
                         if any('<command-name>/exit</command-name>' in l for l in lines[-3:]):
-                            return True
+                            return "exit"
             except json.JSONDecodeError:
                 pass
 
@@ -49,7 +51,7 @@ def check_claude_archived(filepath):
                 if '"type":"assistant"' in line:
                     has_assistant_after = True
             if has_last_prompt and not has_assistant_after:
-                return True
+                return "prompt"
     except Exception:
         pass
     return False

--- a/tests/test-resurrect.sh
+++ b/tests/test-resurrect.sh
@@ -13,31 +13,31 @@ echo "=== _ccs_resurrect_prompt_archived ==="
 
 # ── Test 1: prompt-archived with live process → resurrected ──
 _ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
-ROW1='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12345|45m ago|topic||/fake/abc12345.jsonl'
+ROW1='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12345|45m ago|topic||/fake/path-to-project/abc12345.jsonl'
 st1=$(printf '%s\n' "$ROW1" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
 case "$st1" in
-  active|recent|idle|stale|dormant) pass "prompt-archived with live process → $st1" ;;
+  active|recent|idle|stale) pass "prompt-archived with live process → $st1" ;;
   *) fail "prompt-archived with live process resurrected" "active|idle|..." "$st1" ;;
 esac
 
 # ── Test 2: exit-archived passes through unchanged ──
 _ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
-ROW2='C|/path/to/project|45|archived|\033[90m\033[9m|project|abc12346|45m ago|topic||/fake/abc12346.jsonl'
+ROW2='C|/path/to/project|45|archived|\033[90m\033[9m|project|abc12346|45m ago|topic||/fake/path-to-project/abc12346.jsonl'
 st2=$(printf '%s\n' "$ROW2" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
 [ "$st2" = "archived" ] && pass "exit-archived stays archived" \
                          || fail "exit-archived stays archived" "archived" "$st2"
 
 # ── Test 3: prompt-archived without live process stays prompt-archived ──
 _ccs_running_cwd_counts() { printf ''; }
-ROW3='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12347|45m ago|topic||/fake/abc12347.jsonl'
+ROW3='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12347|45m ago|topic||/fake/path-to-project/abc12347.jsonl'
 st3=$(printf '%s\n' "$ROW3" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
 [ "$st3" = "prompt-archived" ] && pass "prompt-archived without process stays prompt-archived" \
                                 || fail "prompt-archived without process stays prompt-archived" "prompt-archived" "$st3"
 
 # ── Test 4: older prompt-archived loses slot to newer non-archived ──
 _ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
-NEWER='C|/path/to/project|5|idle|\033[36m|project|newer001|5m ago|topic||/fake/newer001.jsonl'
-OLDER='C|/path/to/project|120|prompt-archived|\033[90m\033[9m|project|older001|2h ago|topic||/fake/older001.jsonl'
+NEWER='C|/path/to/project|5|idle|\033[36m|project|newer001|5m ago|topic||/fake/path-to-project/newer001.jsonl'
+OLDER='C|/path/to/project|120|prompt-archived|\033[90m\033[9m|project|older001|2h ago|topic||/fake/path-to-project/older001.jsonl'
 out4=$(printf '%s\n%s\n' "$NEWER" "$OLDER" | _ccs_resurrect_prompt_archived)
 newer_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="newer001"{print $4}')
 older_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="older001"{print $4}')
@@ -67,7 +67,8 @@ raw=$(CCS_PROJECTS_DIR="$TMPDIR_E2E/projects" \
   || fail "e2e: ccs_collect.py emits prompt-archived" "prompt-archived" "$raw"
 
 _ccs_running_cwd_counts() {
-  local norm; norm=$(printf '%s' "/tmp/ccs-e2e" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+  # Key is derived from the encoded dir name: basename "$(dirname "$_fp")" = -tmp-ccs-e2e → tmp-ccs-e2e
+  local norm; norm=$(printf '%s' "-tmp-ccs-e2e" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
   printf 'C:%s\t1\n' "$norm"
 }
 
@@ -76,7 +77,7 @@ resurrected=$(CCS_PROJECTS_DIR="$TMPDIR_E2E/projects" \
   | _ccs_resurrect_prompt_archived \
   | awk -F'|' '{print $4}')
 case "$resurrected" in
-  active|recent|idle|stale|dormant) pass "e2e: session resurrected to '$resurrected'" ;;
+  active|recent|idle|stale) pass "e2e: session resurrected to '$resurrected'" ;;
   *) fail "e2e: session resurrected" "active|idle|..." "$resurrected" ;;
 esac
 

--- a/tests/test-resurrect.sh
+++ b/tests/test-resurrect.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tests/test-resurrect.sh — _ccs_resurrect_prompt_archived unit tests
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-core.sh" 2>/dev/null || true
+
+PASS=0; FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1 — expected '$2' got '$3'"; FAIL=$((FAIL+1)); }
+
+echo "=== _ccs_resurrect_prompt_archived ==="
+
+# ── Test 1: prompt-archived with live process → resurrected ──
+_ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
+ROW1='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12345|45m ago|topic||/fake/abc12345.jsonl'
+st1=$(printf '%s\n' "$ROW1" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
+case "$st1" in
+  active|recent|idle|stale|dormant) pass "prompt-archived with live process → $st1" ;;
+  *) fail "prompt-archived with live process resurrected" "active|idle|..." "$st1" ;;
+esac
+
+# ── Test 2: exit-archived passes through unchanged ──
+_ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
+ROW2='C|/path/to/project|45|archived|\033[90m\033[9m|project|abc12346|45m ago|topic||/fake/abc12346.jsonl'
+st2=$(printf '%s\n' "$ROW2" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
+[ "$st2" = "archived" ] && pass "exit-archived stays archived" \
+                         || fail "exit-archived stays archived" "archived" "$st2"
+
+# ── Test 3: prompt-archived without live process stays prompt-archived ──
+_ccs_running_cwd_counts() { printf ''; }
+ROW3='C|/path/to/project|45|prompt-archived|\033[90m\033[9m|project|abc12347|45m ago|topic||/fake/abc12347.jsonl'
+st3=$(printf '%s\n' "$ROW3" | _ccs_resurrect_prompt_archived | awk -F'|' '{print $4}')
+[ "$st3" = "prompt-archived" ] && pass "prompt-archived without process stays prompt-archived" \
+                                || fail "prompt-archived without process stays prompt-archived" "prompt-archived" "$st3"
+
+# ── Test 4: older prompt-archived loses slot to newer non-archived ──
+_ccs_running_cwd_counts() { printf 'C:path-to-project\t1\n'; }
+NEWER='C|/path/to/project|5|idle|\033[36m|project|newer001|5m ago|topic||/fake/newer001.jsonl'
+OLDER='C|/path/to/project|120|prompt-archived|\033[90m\033[9m|project|older001|2h ago|topic||/fake/older001.jsonl'
+out4=$(printf '%s\n%s\n' "$NEWER" "$OLDER" | _ccs_resurrect_prompt_archived)
+newer_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="newer001"{print $4}')
+older_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="older001"{print $4}')
+[ "$newer_st" = "idle" ] && pass "newer non-archived keeps slot" \
+                          || fail "newer non-archived keeps slot" "idle" "$newer_st"
+[ "$older_st" = "prompt-archived" ] && pass "older prompt-archived without slot stays prompt-archived" \
+                                    || fail "older prompt-archived without slot stays prompt-archived" "prompt-archived" "$older_st"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test-resurrect.sh
+++ b/tests/test-resurrect.sh
@@ -47,5 +47,41 @@ older_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="older001"{print $4}')
                                     || fail "older prompt-archived without slot stays prompt-archived" "prompt-archived" "$older_st"
 
 echo ""
+echo "=== e2e: ccs_collect.py → resurrection → non-archived status ==="
+
+TMPDIR_E2E=$(mktemp -d /pool2/chenhsun/tools/ccs-dashboard-fix-issue57/build/e2e-XXXXXX)
+SID_E2E="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+JDIR_E2E="$TMPDIR_E2E/projects/-tmp-ccs-e2e"
+mkdir -p "$JDIR_E2E"
+JFILE_E2E="$JDIR_E2E/${SID_E2E}.jsonl"
+cat > "$JFILE_E2E" <<'JSONL'
+{"type":"user","message":{"content":"hello"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}
+{"type":"last-prompt","timestamp":"2026-06-22T00:00:00Z"}
+JSONL
+
+raw=$(CCS_PROJECTS_DIR="$TMPDIR_E2E/projects" \
+  python3 "$SCRIPT_DIR/ccs_collect.py" --file "$JFILE_E2E" | awk -F'|' '{print $4}')
+[ "$raw" = "prompt-archived" ] \
+  && pass "e2e: ccs_collect.py emits prompt-archived" \
+  || fail "e2e: ccs_collect.py emits prompt-archived" "prompt-archived" "$raw"
+
+_ccs_running_cwd_counts() {
+  local norm; norm=$(printf '%s' "/tmp/ccs-e2e" | sed 's/[\/._]/-/g; s/--*/-/g; s/^-//')
+  printf 'C:%s\t1\n' "$norm"
+}
+
+resurrected=$(CCS_PROJECTS_DIR="$TMPDIR_E2E/projects" \
+  python3 "$SCRIPT_DIR/ccs_collect.py" --file "$JFILE_E2E" \
+  | _ccs_resurrect_prompt_archived \
+  | awk -F'|' '{print $4}')
+case "$resurrected" in
+  active|recent|idle|stale|dormant) pass "e2e: session resurrected to '$resurrected'" ;;
+  *) fail "e2e: session resurrected" "active|idle|..." "$resurrected" ;;
+esac
+
+rm -rf "$TMPDIR_E2E"
+
+echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -86,6 +86,24 @@ class TestCheckClaudeArchived(unittest.TestCase):
         open(p, 'w').close()
         self.assertFalse(check_claude_archived(p))
 
+    def test_exit_returns_exit_string(self):
+        p = self._path('exit_typed')
+        _write_jsonl(p, [ASSISTANT_DONE, CAVEAT, EXIT_CMD, _exit_stdout('Bye!')])
+        self.assertEqual(check_claude_archived(p), "exit")
+
+    def test_last_prompt_returns_prompt_string(self):
+        p = self._path('last_prompt_typed')
+        _write_jsonl(p, [
+            ASSISTANT_DONE,
+            {"type": "last-prompt", "timestamp": "2026-06-22T10:00:01Z"},
+        ])
+        self.assertEqual(check_claude_archived(p), "prompt")
+
+    def test_not_archived_returns_false(self):
+        p = self._path('not_archived_typed')
+        _write_jsonl(p, [ASSISTANT_DONE])
+        self.assertIs(check_claude_archived(p), False)
+
 
 class TestGetClaudeVersion(unittest.TestCase):
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from ccs_collect import check_claude_archived, get_claude_version, process_claude_file
+from ccs_collect import (
+    check_claude_archived, get_claude_version, process_claude_file,
+    load_verified_versions, check_version_canary,
+)
 
 
 def _write_jsonl(path, lines):
@@ -154,6 +157,50 @@ class TestProcessClaudeFileVersion(unittest.TestCase):
         result = process_claude_file(p)
         self.assertIsNotNone(result)
         self.assertEqual(result['version'], '')
+
+
+class TestVersionCanary(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_check_version_canary_unverified(self):
+        sessions = [
+            {'provider': 'C', 'version': '2.1.195'},
+            {'provider': 'C', 'version': '2.1.185'},
+        ]
+        result = check_version_canary(sessions, {'2.1.185'})
+        self.assertEqual(result, ['2.1.195'])
+
+    def test_check_version_canary_all_verified(self):
+        sessions = [{'provider': 'C', 'version': '2.1.185'}]
+        self.assertEqual(check_version_canary(sessions, {'2.1.185'}), [])
+
+    def test_check_version_canary_ignores_gemini(self):
+        sessions = [{'provider': 'G', 'version': '1.0.0'}]
+        self.assertEqual(check_version_canary(sessions, set()), [])
+
+    def test_check_version_canary_ignores_empty_version(self):
+        sessions = [{'provider': 'C', 'version': ''}]
+        self.assertEqual(check_version_canary(sessions, set()), [])
+
+    def test_check_version_canary_deduplicates(self):
+        sessions = [
+            {'provider': 'C', 'version': '2.1.195'},
+            {'provider': 'C', 'version': '2.1.195'},
+        ]
+        result = check_version_canary(sessions, set())
+        self.assertEqual(result, ['2.1.195'])
+
+    def test_load_verified_versions_parses_file(self):
+        vf = os.path.join(self.tmp, 'versions.txt')
+        with open(vf, 'w') as f:
+            f.write('# comment\n2.1.185\n2.1.177\n\n')
+        self.assertEqual(load_verified_versions(vf), {'2.1.185', '2.1.177'})
+
+    def test_load_verified_versions_missing_file(self):
+        vf = os.path.join(self.tmp, 'nonexistent.txt')
+        self.assertEqual(load_verified_versions(vf), set())
 
 
 if __name__ == '__main__':

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from ccs_collect import check_claude_archived
+from ccs_collect import check_claude_archived, get_claude_version, process_claude_file
 
 
 def _write_jsonl(path, lines):
@@ -82,6 +82,78 @@ class TestCheckClaudeArchived(unittest.TestCase):
         p = self._path('empty')
         open(p, 'w').close()
         self.assertFalse(check_claude_archived(p))
+
+
+class TestGetClaudeVersion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _path(self, name):
+        return os.path.join(self.tmp, name + '.jsonl')
+
+    def test_version_on_first_event(self):
+        p = self._path('has_version')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hello"}, "version": "2.1.185"},
+        ])
+        self.assertEqual(get_claude_version(p), "2.1.185")
+
+    def test_version_on_later_event(self):
+        p = self._path('version_later')
+        _write_jsonl(p, [
+            {"type": "system", "subtype": "init"},
+            {"type": "user", "message": {"content": "hello"}, "version": "2.1.177"},
+        ])
+        self.assertEqual(get_claude_version(p), "2.1.177")
+
+    def test_no_version_field(self):
+        p = self._path('no_version')
+        _write_jsonl(p, [{"type": "user", "message": {"content": "hello"}}])
+        self.assertIsNone(get_claude_version(p))
+
+    def test_empty_file(self):
+        p = self._path('empty')
+        open(p, 'w').close()
+        self.assertIsNone(get_claude_version(p))
+
+    def test_only_first_20_lines_scanned(self):
+        p = self._path('version_deep')
+        lines = [{"type": "user", "message": {"content": f"msg{i}"}} for i in range(21)]
+        lines[20]["version"] = "2.1.999"  # line 21 (0-indexed), beyond scan window
+        _write_jsonl(p, lines)
+        self.assertIsNone(get_claude_version(p))
+
+
+class TestProcessClaudeFileVersion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.proj_dir = os.path.join(self.tmp, 'myproject')
+        os.makedirs(self.proj_dir)
+
+    def _path(self, name):
+        return os.path.join(self.proj_dir, name + '.jsonl')
+
+    def test_version_included_in_result(self):
+        p = self._path('sess1')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hi"}, "version": "2.1.185",
+             "timestamp": "2026-01-01T00:00:00Z"},
+        ])
+        result = process_claude_file(p)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['version'], '2.1.185')
+
+    def test_missing_version_is_empty_string(self):
+        p = self._path('sess2')
+        _write_jsonl(p, [
+            {"type": "user", "message": {"content": "hi"},
+             "timestamp": "2026-01-01T00:00:00Z"},
+        ])
+        result = process_claude_file(p)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['version'], '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **fix #57**：idle-but-live 的 Claude Code session，若 JSONL 尾端有 `last-prompt` marker（Check 2），原本會被誤判為 `archived` 而從 `ccs-active`/`ccs-status` 消失；現在會透過 resurrection pass 比對 live process，重新賦予正確 status
- `check_claude_archived` 改回傳具體型別：`"exit"` | `"prompt"` | `False`，讓 bash 層能區分 Check 1（`/exit`）與 Check 2（trailing `last-prompt`）
- 新增 `_ccs_running_cwd_counts` 與 `_ccs_resurrect_prompt_archived`，pipe filter 接在 `ccs_collect.py` 輸出後；三條 display path（`ccs-active`, `ccs-status`, `_ccs_collect_sessions`）已接線
- 新增 canary 機制：從 JSONL 前 20 行讀取 `version`，對比 `ccs-canary-versions.txt`，未驗證版本在 stderr 警示

## Changes

- `ccs_collect.py`: `check_claude_archived` 回傳型別；`get_claude_version`；canary check
- `ccs-core.sh`: `_ccs_running_cwd_counts`、`_ccs_resurrect_prompt_archived`；三條 display path 接線；`_ccs_detect_crash` 重構
- `tests/test_collect.py`: 新增 3 個型別斷言 + version/canary 測試
- `tests/test-resurrect.sh`: 5 unit + 2 e2e assertions

## Test plan

- [x] `pytest tests/test_collect.py` — 25/25 passed
- [x] `bash tests/test-resurrect.sh` — 7/7 passed
- [ ] `bash tests/test-status.sh` — 3 pre-existing failures (D2/D3/stale-section, unrelated to this PR)