### PR TITLE
fix(dashboard): fix crash expiry in ccs-status --md (issue #64)

### DIFF
--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -70,7 +70,7 @@ HELP
   local script_dir
   script_dir="$_CCS_DASHBOARD_DIR"
   local sorted_rows=""
-  sorted_rows=$(python3 "$script_dir/internal/ccs_collect.py" | awk -F'|' -v max_mins="$((7 * 1440))" '
+  sorted_rows=$(python3 "$script_dir/ccs_collect.py" | awk -F'|' -v max_mins="$((7 * 1440))" '
     $3 <= max_mins && $4 != "archived" { print $0 }
   ')
   while IFS='|' read -r -a cols; do
@@ -110,12 +110,12 @@ HELP
     mod=$(stat -c "%Y" "$f")
     ago=$(( (now - mod) / 60 ))
     full_sid=$(basename "$f" | sed -e "s/\.jsonl$//" -e "s/\.json$//")
-    if [ -n "${crash_full[$full_sid]+x}" ] && [ "$ago" -lt 10080 ]; then
+    if [ -n "${crash_full[$full_sid]+x}" ] && [ "$ago" -lt 4320 ]; then
       crashed_files+=("$f")
-    elif [ "$ago" -lt 10080 ]; then
-      fresh_files+=("$f")
-    else
+    elif [ -n "${crash_full[$full_sid]+x}" ] || [ "$ago" -ge 10080 ]; then
       stale_files+=("$f")
+    else
+      fresh_files+=("$f")
     fi
   done
 


### PR DESCRIPTION
## 摘要

修復 `tests/test-status.sh` E2E crash expiry 段落持續失敗（issue #64），
讓 `run-all.sh` 不再每次回報 failure 而掩蓋真正的新問題。

**修改了什麼：**
- `ccs-dashboard.sh:73`：`internal/ccs_collect.py`（不存在）→ `ccs_collect.py`（正確路徑）
- `ccs-dashboard.sh:113–119`：crash 分類加入 3 天（4320 min）過期門檻：
  - 新 crash（< 4320 min）→ `crashed_files`
  - 過期 crash（>= 4320 min）→ `stale_files`（demoted）
  - 正常 session（< 10080 min）→ `fresh_files`

---

## Root Cause

兩個並存的 bug：

**Bug 1（主因）：** `ccs-dashboard.sh:73` 呼叫 `internal/ccs_collect.py`，但該路徑不存在。
`sorted_rows` 靜默為空 → `open_files` 空 → D2/D3 完全進不了輸出。

**Bug 2（次因）：** crash 分類邏輯只有 10080-min（7 天）單一門檻，
無法區分「新 crash」與「過期 crash」，D1（5000 min crash）誤進 `crashed_files`。

---

## Test Report

```
bash tests/run-all.sh
════════════════════════
Total: 16  Passed: 16  Failed: 0  Skipped: 1
```

| Test Suite | Result |
|---|---|
| test_collect.py | 25/25 ✅ |
| test-checkpoint-improvements.sh | 14/14 ✅ |
| test-core.sh | 35/35 ✅ |
| test-crash-clean-by-id.sh | 26/26 ✅ |
| test-crash-detect.sh | SKIP (live data, expected) |
| test-dispatch.sh | pass ✅ |
| test-friendly-name.sh | 9/9 ✅ |
| test-gemini-robust.sh | 7/7 ✅ |
| test-handoff.sh | 5/5 ✅ |
| test-health.sh | 73/73 ✅ |
| test-liveness.sh | 17/17 ✅ |
| test-ops.sh | 5/5 ✅ |
| test-overview.sh | 8/8 ✅ |
| test-project.sh | 37/37 ✅ |
| test-resurrect.sh | 7/7 ✅ |
| test-review.sh | 40/40 ✅ |
| **test-status.sh** | **9/9 ✅**（D1/D2/D3 全通過）|

修復前：test-status.sh 6 passed, 3 failed

---

## Code Review Findings

透過 10-angle code review（line-by-line scan、removed-behavior、cross-file tracer、
bash pitfalls、simplification、altitude 等），共確認 2 個 non-blocking 問題。

### 發現 1：Stale 標籤說「> 7 days」但過期 crash 只有 3–7 天 [cosmetic, non-blocking]

**位置：** `ccs-dashboard.sh:215`（terminal）, `ccs-dashboard.sh:394`（markdown）

**說明：** 4320-min 門檻修改後，crashed + 過期（3–7 天）的 session 進入 `stale_files`，
但 stale section 標籤仍顯示「untouched > 7 days」，對這些 session 不正確。

**影響：** 僅顯示層面；使用者可能對 3–7 天過期 crash 的計數產生誤解，不影響功能。

**建議：** 後續 follow-up issue 修改標籤，或為 `stale_files` 加上 crash-demoted 計數區分。

### 發現 2：4320（3 天過期門檻）在 3 個檔案重複 hardcode [maintainability, non-blocking]

**位置：** `ccs-dashboard.sh:113`、`ccs-overview.sh:987`、`ccs-ops.sh:84`

**說明：** 沒有共用的 named constant，未來修改門檻需要同時改 3 個地方。
`ccs-health.sh` 已有 `CCS_HEALTH_DURATION_RED=4320` 的 env-var 模式可以參考。

**建議：** 後續 follow-up 抽出 `CCS_CRASH_EXPIRY_MINS` 常數（不影響此 PR 範疇）。

---

## Test Plan

- [x] `bash tests/run-all.sh` — 16 passed, 0 failed
- [x] `bash tests/test-status.sh` — D1/D2/D3 assertions 全通過
- [x] Crash expiry E2E：D1（5000 min）→ stale ✅，D2（100 min）→ crashed ✅，D3 → active ✅
- [x] 無 regression（其餘 15 個 test suite 全通過）