### PR TITLE
feat(dispatch): pluggable backend with agent-pager fallback (stage 1)

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -163,6 +163,16 @@ _ccs_dispatch_finish() {
   rm -f "$prompt_f"
 }
 
+# agent-pager backend — STAGE 1 STUB.
+# Stage 2 will write a local-channel inbound launch and map the worker
+# lifecycle back into jobs.jsonl. Until then this always fails so the
+# dispatcher falls back to headless.
+_ccs_dispatch_spawn_agentpager() {
+  echo "ccs-dispatch: agent-pager backend not yet implemented (stage 2)," \
+       "falling back to headless" >&2
+  return 2
+}
+
 _ccs_dispatch_spawn_headless() {
   local job_id="$1" project_dir="$2" prompt="$3"
   local timeout_secs="$4" mode="$5"

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -61,14 +61,15 @@ _ccs_dispatch_jsonl_append() {
   echo "$1" >> "$dispatch_dir/jobs.jsonl"
 }
 
-# Read latest record for a job_id (append-latest-wins)
+# Read merged record for a job_id (reduce-merge: all fields, later wins)
 _ccs_dispatch_jsonl_latest() {
   local job_id="$1"
   local dispatch_dir
   dispatch_dir="$(_ccs_dispatch_dir)"
   local f="$dispatch_dir/jobs.jsonl"
   [ -f "$f" ] || return 1
-  grep "\"job_id\":\"${job_id}\"" "$f" | tail -1
+  grep "\"job_id\":\"${job_id}\"" "$f" \
+    | jq -s 'reduce .[] as $r ({}; . + $r)'
 }
 
 _ccs_dispatch_finish() {
@@ -98,6 +99,8 @@ _ccs_dispatch_finish() {
   local project created_at
   project=$(echo "$initial" | jq -r '.project // "unknown"')
   created_at=$(echo "$initial" | jq -r '.created_at // "unknown"')
+  local backend
+  backend=$(echo "$initial" | jq -r '.backend // "headless"')
   local finished_at
   finished_at=$(date -Iseconds)
 
@@ -120,6 +123,7 @@ _ccs_dispatch_finish() {
     echo "- **Task:** $task"
     echo "- **Status:** $status"
     echo "- **Exit code:** $exit_code"
+    echo "- **Backend:** $backend"
     echo "- **Created:** $created_at"
     echo "- **Finished:** $finished_at"
     [ -n "$duration_s" ] && echo "- **Duration:** $duration_s"
@@ -339,6 +343,8 @@ HELP
     prompt="$(_ccs_dispatch_context "$project")Task: $task"
   fi
 
+  local backend
+  backend=$(_ccs_dispatch_resolve_backend)
   local job_id
   job_id=$(_ccs_dispatch_job_id)
   _ccs_dispatch_jsonl_append "$(jq -nc \
@@ -347,12 +353,21 @@ HELP
     --arg t "$task" \
     --argjson ctx "$context" \
     --arg m "$mode" \
+    --arg be "$backend" \
     --arg ca "$(date -Iseconds)" \
-    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, status:"running", created_at:$ca}'
+    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, status:"running", created_at:$ca}'
   )"
 
   local spawn_rc=0
-  _ccs_dispatch_spawn "$job_id" "$project" "$prompt" "$timeout_secs" "$mode" || spawn_rc=$?
+  _ccs_dispatch_spawn "$job_id" "$project" "$prompt" \
+    "$timeout_secs" "$mode" "$backend" || spawn_rc=$?
+
+  if [ "${_CCS_DISPATCH_LAST_BACKEND:-$backend}" != "$backend" ]; then
+    _ccs_dispatch_jsonl_append "$(jq -nc \
+      --arg jid "$job_id" \
+      --arg be "$_CCS_DISPATCH_LAST_BACKEND" \
+      '{job_id:$jid, backend:$be, fallback:true}')"
+  fi
 
   if [ "$mode" = "sync" ]; then
     local dispatch_dir
@@ -447,7 +462,9 @@ _ccs_jobs_show_list() {
   local tlen="$CCS_DISPATCH_TASK_DISPLAY_LEN"
 
   local deduped
-  deduped=$(jq -s 'group_by(.job_id) | map(last) | sort_by(.created_at) | reverse' "$jobs_file")
+  deduped=$(jq -s \
+    'group_by(.job_id) | map(reduce .[] as $r ({}; . + $r))
+     | sort_by(.created_at) | reverse' "$jobs_file")
 
   if [ "$show_all" = "false" ]; then
     deduped=$(echo "$deduped" | jq ".[0:$limit]")
@@ -459,7 +476,7 @@ _ccs_jobs_show_list() {
   echo "========================"
 
   echo "$deduped" | jq -r --argjson tl "$tlen" '
-    .[] | "\(.job_id)  \(.status | .[0:9] | . + " " * (9 - length))  \(.task | .[0:$tl])"
+    .[] | "\(.job_id)  \((.backend // "?") | .[0:10] | . + " " * (10 - length))  \(.status | .[0:9] | . + " " * (9 - length))  \(.task | .[0:$tl])"
   '
 }
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -163,7 +163,7 @@ _ccs_dispatch_finish() {
   rm -f "$prompt_f"
 }
 
-_ccs_dispatch_spawn() {
+_ccs_dispatch_spawn_headless() {
   local job_id="$1" project_dir="$2" prompt="$3"
   local timeout_secs="$4" mode="$5"
   local dispatch_dir script_dir
@@ -204,6 +204,25 @@ _ccs_dispatch_spawn() {
     echo $! > "$dispatch_dir/pids/${job_id}.pid"
     disown
   fi
+}
+
+# Dispatcher: pick backend, route, fall back to headless on agent-pager failure.
+# Optional $6 = pre-resolved backend (avoids double-resolve from ccs-dispatch).
+_ccs_dispatch_spawn() {
+  local job_id="$1" project_dir="$2" prompt="$3"
+  local timeout_secs="$4" mode="$5"
+  local backend="${6:-$(_ccs_dispatch_resolve_backend)}"
+
+  _CCS_DISPATCH_LAST_BACKEND="$backend"
+  if [ "$backend" = "agentpager" ]; then
+    if _ccs_dispatch_spawn_agentpager \
+         "$job_id" "$project_dir" "$prompt" "$timeout_secs" "$mode"; then
+      return 0
+    fi
+    _CCS_DISPATCH_LAST_BACKEND="headless"  # agent-pager failed -> fell back
+  fi
+  _ccs_dispatch_spawn_headless \
+    "$job_id" "$project_dir" "$prompt" "$timeout_secs" "$mode"
 }
 
 _ccs_dispatch_lazy_cleanup() {

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -12,6 +12,33 @@ CCS_DISPATCH_SUMMARY_LINES="${CCS_DISPATCH_SUMMARY_LINES:-30}"
 CCS_DISPATCH_SUMMARY_MAX_CHARS="${CCS_DISPATCH_SUMMARY_MAX_CHARS:-200}"
 CCS_DISPATCH_MAX_CONCURRENT_WARN="${CCS_DISPATCH_MAX_CONCURRENT_WARN:-3}"
 
+# ── Backend selection ──
+# Returns 0 if the agent-pager backend is usable, 1 otherwise.
+# Stage 1: daemon active + spool dir exists. Stage 2 will additionally
+# require the merged local channel.
+_ccs_dispatch_agentpager_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  systemctl --user is-active --quiet agent-pager.service 2>/dev/null || return 1
+  [ -d "${AGENT_PAGER_DIR:-$HOME/.agent-pager}" ] || return 1
+  return 0
+}
+
+# Echoes the backend to use: "headless" or "agentpager".
+# CCS_DISPATCH_BACKEND: auto (default) | agentpager | headless.
+_ccs_dispatch_resolve_backend() {
+  local choice="${CCS_DISPATCH_BACKEND:-auto}"
+  case "$choice" in
+    headless|agentpager) printf '%s\n' "$choice" ;;
+    auto)
+      if _ccs_dispatch_agentpager_available; then
+        printf 'agentpager\n'
+      else
+        printf 'headless\n'
+      fi ;;
+    *) printf 'headless\n' ;;
+  esac
+}
+
 # ── Data directory ──
 _ccs_dispatch_dir() {
   local dir

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -37,4 +37,23 @@ out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$SCRIPT_DIR/tmp/nonexistent-spo
 assert_eq "auto + active + no spool -> headless" "headless" "$out"
 
 rm -rf "$mock_dir" "$spool"
+
+echo "=== dispatcher routes to headless (behavior unchanged) ==="
+mock_dir2="$SCRIPT_DIR/tmp/test-dispatch-backend-bin2"
+proj="$SCRIPT_DIR/tmp/test-dispatch-backend-proj"
+mkdir -p "$mock_dir2" "$proj"
+printf '#!/bin/bash\necho "mock result: $*"\n' > "$mock_dir2/claude"
+chmod +x "$mock_dir2/claude"
+# force headless; dispatcher must produce a completed .md exactly like before
+out=$(CCS_DISPATCH_BACKEND=headless PATH="$mock_dir2:$PATH" \
+  ccs-dispatch --sync --project "$proj" "route test" 2>&1)
+jid=$(echo "$out" | grep -oP 'd-\d{8}-\d{6}-[a-f0-9]{4}' | head -1)
+dd="$(_ccs_dispatch_dir)"
+assert_contains "headless dispatch created .md" "$(ls "$dd/results/" 2>/dev/null)" "${jid}.md"
+st=$(_ccs_dispatch_jsonl_latest "$jid" | jq -r '.status')
+assert_eq "headless dispatch completed" "completed" "$st"
+# function-level: headless helper exists and is what dispatcher calls
+assert_eq "spawn_headless defined" "function" "$(type -t _ccs_dispatch_spawn_headless)"
+rm -rf "$mock_dir2" "$proj"
+
 test_summary

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -76,16 +76,13 @@ assert_contains "fallback warning emitted" "$err" "falling back to headless"
 # backend tracking reflects the fallback
 assert_eq "LAST_BACKEND reflects fallback" "headless" "$_CCS_DISPATCH_LAST_BACKEND"
 # job still completes via headless
+out_file="$SCRIPT_DIR/tmp/test-dispatch-backend-out3"
 CCS_DISPATCH_BACKEND=agentpager PATH="$mock_dir3:$PATH" \
-  ccs-dispatch --sync --project "$proj3" "fallback test 2" >/dev/null 2>&1
-dd="$(_ccs_dispatch_dir)"
-if [ -f "$dd/jobs.jsonl" ]; then
-  latest_jid=$(tac "$dd/jobs.jsonl" | grep -oP '"job_id":"[^"]+"' | head -1 | cut -d'"' -f4)
-  if [ -n "$latest_jid" ]; then
-    st=$(_ccs_dispatch_jsonl_latest "$latest_jid" | jq -r '.status')
-    assert_eq "fell-back job completed" "completed" "$st"
-  fi
-fi
-rm -rf "$mock_dir3" "$proj3" "$tmplog"*
+  ccs-dispatch --sync --project "$proj3" "fallback test 2" > "$out_file" 2>/dev/null
+jid=$(grep -oP 'd-\d{8}-\d{6}-[a-f0-9]{4}' "$out_file" | head -1)
+st=$(_ccs_dispatch_jsonl_latest "$jid" | jq -r '.status')
+assert_eq "fell-back job completed" "completed" "$st"
+assert_eq "LAST_BACKEND reflects fallback" "headless" "$_CCS_DISPATCH_LAST_BACKEND"
+rm -rf "$mock_dir3" "$proj3" "$tmplog"* "$out_file"
 
 test_summary

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -85,4 +85,25 @@ assert_eq "fell-back job completed" "completed" "$st"
 assert_eq "LAST_BACKEND reflects fallback" "headless" "$_CCS_DISPATCH_LAST_BACKEND"
 rm -rf "$mock_dir3" "$proj3" "$tmplog"* "$out_file"
 
+echo "=== jobs record + display backend ==="
+mock_dir4="$SCRIPT_DIR/tmp/test-dispatch-backend-bin4"
+proj4="$SCRIPT_DIR/tmp/test-dispatch-backend-proj4"
+mkdir -p "$mock_dir4" "$proj4"
+printf '#!/bin/bash\necho "mock result: $*"\n' > "$mock_dir4/claude"
+chmod +x "$mock_dir4/claude"
+jid=$(CCS_DISPATCH_BACKEND=headless PATH="$mock_dir4:$PATH" \
+  ccs-dispatch --sync --project "$proj4" "backend field test" 2>/dev/null \
+  | grep -oP 'd-\d{8}-\d{6}-[a-f0-9]{4}' | head -1)
+dd="$(_ccs_dispatch_dir)"
+# merged record carries backend (initial record) + status (finish record)
+merged=$(grep "\"job_id\":\"$jid\"" "$dd/jobs.jsonl" \
+  | jq -s 'reduce .[] as $r ({}; . + $r)')
+assert_eq "jsonl backend recorded" "headless" "$(echo "$merged" | jq -r '.backend')"
+assert_eq "jsonl status preserved" "completed" "$(echo "$merged" | jq -r '.status')"
+# .md shows backend
+assert_contains ".md shows backend" "$(cat "$dd/results/${jid}.md")" "Backend:"
+# list shows backend column
+assert_contains "ccs-jobs list shows backend" "$(ccs-jobs 2>/dev/null)" "headless"
+rm -rf "$mock_dir4" "$proj4"
+
 test_summary

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-backend.sh — backend resolver + fallback (stage 1)
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+echo "=== resolve_backend: env override ==="
+out=$(CCS_DISPATCH_BACKEND=headless _ccs_dispatch_resolve_backend)
+assert_eq "explicit headless" "headless" "$out"
+out=$(CCS_DISPATCH_BACKEND=agentpager _ccs_dispatch_resolve_backend)
+assert_eq "explicit agentpager" "agentpager" "$out"
+out=$(CCS_DISPATCH_BACKEND=bogus _ccs_dispatch_resolve_backend)
+assert_eq "invalid -> headless" "headless" "$out"
+
+echo "=== resolve_backend: auto detection ==="
+mock_dir="$SCRIPT_DIR/tmp/test-dispatch-backend-bin"
+mkdir -p "$mock_dir"
+# daemon inactive (systemctl exit 3) -> headless
+printf '#!/bin/bash\nexit 3\n' > "$mock_dir/systemctl"
+chmod +x "$mock_dir/systemctl"
+out=$(CCS_DISPATCH_BACKEND=auto PATH="$mock_dir:$PATH" _ccs_dispatch_resolve_backend)
+assert_eq "auto + daemon inactive -> headless" "headless" "$out"
+
+# daemon active + spool dir exists -> agentpager
+printf '#!/bin/bash\nexit 0\n' > "$mock_dir/systemctl"
+chmod +x "$mock_dir/systemctl"
+spool="$SCRIPT_DIR/tmp/test-dispatch-backend-spool"
+mkdir -p "$spool"
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$spool" PATH="$mock_dir:$PATH" \
+  _ccs_dispatch_resolve_backend)
+assert_eq "auto + active + spool -> agentpager" "agentpager" "$out"
+
+# daemon active but spool missing -> headless
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$SCRIPT_DIR/tmp/nonexistent-spool" \
+  PATH="$mock_dir:$PATH" _ccs_dispatch_resolve_backend)
+assert_eq "auto + active + no spool -> headless" "headless" "$out"
+
+rm -rf "$mock_dir" "$spool"
+test_summary

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 source "$SCRIPT_DIR/tests/fixture-helper.sh"
 source "$SCRIPT_DIR/ccs-dashboard.sh"
 
+# Initialize backend tracking variable
+_CCS_DISPATCH_LAST_BACKEND=""
+
 echo "=== resolve_backend: env override ==="
 out=$(CCS_DISPATCH_BACKEND=headless _ccs_dispatch_resolve_backend)
 assert_eq "explicit headless" "headless" "$out"
@@ -55,5 +58,34 @@ assert_eq "headless dispatch completed" "completed" "$st"
 # function-level: headless helper exists and is what dispatcher calls
 assert_eq "spawn_headless defined" "function" "$(type -t _ccs_dispatch_spawn_headless)"
 rm -rf "$mock_dir2" "$proj"
+
+echo "=== agentpager backend stub falls back to headless ==="
+mock_dir3="$SCRIPT_DIR/tmp/test-dispatch-backend-bin3"
+proj3="$SCRIPT_DIR/tmp/test-dispatch-backend-proj3"
+mkdir -p "$mock_dir3" "$proj3"
+printf '#!/bin/bash\necho "mock result: $*"\n' > "$mock_dir3/claude"
+chmod +x "$mock_dir3/claude"
+# force agentpager; stub fails -> dispatcher falls back to headless
+# Capture stderr/stdout to temp file to avoid subshell (which loses variable assignments)
+tmplog="$SCRIPT_DIR/tmp/test-dispatch-backend-log3"
+CCS_DISPATCH_BACKEND=agentpager PATH="$mock_dir3:$PATH" \
+  ccs-dispatch --sync --project "$proj3" "fallback test" \
+  >"$tmplog.out" 2>"$tmplog.err"
+err=$(cat "$tmplog.err")
+assert_contains "fallback warning emitted" "$err" "falling back to headless"
+# backend tracking reflects the fallback
+assert_eq "LAST_BACKEND reflects fallback" "headless" "$_CCS_DISPATCH_LAST_BACKEND"
+# job still completes via headless
+CCS_DISPATCH_BACKEND=agentpager PATH="$mock_dir3:$PATH" \
+  ccs-dispatch --sync --project "$proj3" "fallback test 2" >/dev/null 2>&1
+dd="$(_ccs_dispatch_dir)"
+if [ -f "$dd/jobs.jsonl" ]; then
+  latest_jid=$(tac "$dd/jobs.jsonl" | grep -oP '"job_id":"[^"]+"' | head -1 | cut -d'"' -f4)
+  if [ -n "$latest_jid" ]; then
+    st=$(_ccs_dispatch_jsonl_latest "$latest_jid" | jq -r '.status')
+    assert_eq "fell-back job completed" "completed" "$st"
+  fi
+fi
+rm -rf "$mock_dir3" "$proj3" "$tmplog"*
 
 test_summary


### PR DESCRIPTION
## 背景

ccs-dashboard 原本規劃的「完整 dashboard」願景包含 session lifecycle 管理。`ccs-dispatch` 目前用 `claude -p`（headless、走 Pool 2、封閉 fire-and-forget），無法監控進度或中途互動。本 PR 是 mission control 整合的**階段 1**：把 dispatch 執行後端抽象成可插拔結構，為階段 2 接上 agent-pager 的 Pool 1 互動 worker 鋪路。

## 改了什麼

階段 1 全部集中在 `ccs-dispatch.sh`（+ 新測試 `tests/test-dispatch-backend.sh`），headless 行為**對外完全不變**：

- **backend resolver**：新 env `CCS_DISPATCH_BACKEND`（`auto` / `agentpager` / `headless`），`auto` 偵測 agent-pager daemon + spool 目錄
- **pluggable dispatcher**：原 `claude -p` 邏輯抽成 `headless` 後端，`_ccs_dispatch_spawn` 變 dispatcher
- **agent-pager 後端 stub + fallback**：階段 1 為 stub（`return 2` 觸發 fallback 回 headless），真正實作留階段 2
- **jobs 記錄 backend**：`jobs.jsonl` / 結果 `.md` / `ccs-jobs` 列表都帶 backend；jsonl dedup 改 reduce-merge，在 append-latest-wins 下同時保留 backend 與 status

## Progressive enhancement

ccs-dashboard 是 MIT 開源，不硬依賴 agent-pager（內部工具）。無 agent-pager 時自動 fallback 回 `claude -p`，行為與現狀一致。

## Test plan

- [x] backend resolver（env 覆寫 + auto 偵測 + invalid → headless）
- [x] dispatcher 路由 headless（零回歸）
- [x] agentpager stub → fallback 鏈（無條件 assert job 經 headless 完成）
- [x] jobs.jsonl backend 欄位 + `.md` + 列表顯示
- [x] 全測試套件 17/17 pass，既有 `test-dispatch.sh` 零回歸
- [x] 向後相容：無 backend 欄位的舊 record 顯示 `?` / 預設 headless

## Review

4 個 task 各經 spec + quality review（subagent-driven-development）。Task 3 review 抓到一個 test assertion 被 silent-skip guards 弱化（fallback 壞掉也會 pass），已修成無條件 assert。最終 whole-branch review（最高階模型）結論 **Ready to merge**：無 Critical / Important blocking、零回歸、向後相容、無 hardcoded credential。

## Stage 2 follow-up（不阻塞本 PR）

`_ccs_jobs_sync_status` 仍用 `tail -1`，屬 async-fallback-crash 的 corner case，併階段 2 修。階段 2 將實作真正的 agent-pager 後端（寫 local-channel inbound、worker 完成判定、out.stream 回流）。

🤖 Generated with [Claude Code](https://claude.com/claude-code) via agent-pager
