### PR TITLE
docs: restructure README to OSS conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Mission control for your Code CLI Sessions (Claude, Gemini, etc.) — track, review, and hand off across repos.
 
-Code CLI tools (like Claude or Gemini) store conversations as session files, but provide limited built-in tools to review or manage them. ccs-dashboard parses these files so you can see what's going on across all your sessions — either by asking the agent directly or from the command line.
+Code CLI tools store conversations as session files but give you little built-in tooling to review or manage them. ccs-dashboard parses those files so you can see what's happening across every session — by asking the agent in natural language, or straight from the command line.
 
 ## Background
 
@@ -12,23 +12,31 @@ If you use Code CLI Sessions heavily — multiple providers, multiple repos, mul
 
 - **Sessions are invisible.** No built-in way to list, search, or compare sessions. Each terminal is its own silo. Close the tab and the context is gone.
 - **Multi-repo chaos.** Working on a backend fix, a frontend feature, and a docs update simultaneously? Good luck remembering which session was doing what, in which repo.
-- **Zombie processes pile up.** Suspended claude processes (from terminal multiplexers, crashed tabs, or `Ctrl+Z`) silently eat 190-500 MB each. No warning, no cleanup.
+- **Zombie processes pile up.** Suspended `claude` processes (from terminal multiplexers, crashed tabs, or `Ctrl+Z`) silently eat 190-500 MB each. No warning, no cleanup.
 - **Context doesn't transfer.** Starting a new session means re-explaining everything. The old session's knowledge — files touched, decisions made, remaining todos — is trapped in a JSON/JSONL file nobody reads.
 - **No cross-session view.** A single feature might span 5 sessions across 3 days. There's no way to see the full picture without manually digging through logs.
 
-## Before / After
+## Quick start
 
-**Before:** You're left staring at raw JSON/JSONL files.
-
-```
-$ ls ~/.claude/projects/
--home-alice-backend-api/    -home-alice-frontend/    -home-alice-docs/
-$ ls ~/.claude/projects/-home-alice-backend-api/
-3a8f1c42-...jsonl  7b2e9d15-...jsonl  a1c4f8e2-...jsonl
-# Now what? Open each 50MB JSON/JSONL in vim?
+```bash
+git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
+cd ~/tools/ccs-dashboard
+./install.sh              # Check deps, add source line to ~/.bashrc, create skill symlink
 ```
 
-**After:** Just ask Claude. The included [custom skill](https://docs.anthropic.com/en/docs/claude-code/skills) gives you an interactive orchestrator — no commands to memorize.
+`./install.sh --check` reports status; `./install.sh --uninstall` removes it.
+
+Or wire it up manually:
+
+```bash
+# Add to .bashrc:
+source ~/tools/ccs-dashboard/ccs-dashboard.sh
+
+# Skill symlink (optional):
+ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
+```
+
+Then just ask Claude:
 
 ```
 You: What am I working on?
@@ -39,68 +47,22 @@ Claude: (runs /ccs-orchestrator)
 
 📁 backend-api (2)
 🟢 1. Fix auth middleware regression    a1c4f8e2  3m ago
-🔵 2. Add rate limiting endpoint       7b2e9d15  5h ago
-
-📁 frontend (1)
-🟡 3. Dashboard redesign v2            9f3b7a21  45m ago
+🔵 2. Add rate limiting endpoint        7b2e9d15  5h ago
 
 ### 📋 Pending Todos (3)
-☐ Add rate limit headers to response          (backend-api)
-☐ Write integration tests                     (backend-api)
-☐ Update sidebar component                    (frontend)
-
-### 🧟 Zombie Processes (2)
-PID 28341  Tl  490 MB  2d ago
-PID 31022  Tl  312 MB  1d ago
-
-<options>
-- d 1 — Expand session #1 recent conversations
-- f gh65 — View rate limiting feature progress
-- rc — Daily work recap
-- cl — Clean up zombie processes
-</options>
+☐ Add rate limit headers to response    (backend-api)
+☐ Write integration tests               (backend-api)
 ```
 
-The skill handles routing, context, and follow-up options automatically. You can also drill down:
+The bundled [skill](https://docs.anthropic.com/en/docs/claude-code/skills) gives you an interactive orchestrator with context-aware follow-up options — no commands to memorize. See [docs/commands.md](docs/commands.md) for a full walkthrough.
 
-```
-You: Show me what's left on the rate limiting feature
-
-Claude: (runs ccs-feature gh65)
-
-### 🟡 GH#65 Add rate limiting [backend-api]
-    Todos: 2/5 | Sessions: 3 | Last: 45m ago
-
-    Recent commits:
-    a3f1c82  feat: add token bucket rate limiter
-    9b2e7d1  feat: add Redis-backed rate limit store
-
-    Remaining todos:
-    ☐ Add rate limit headers to response
-    ☐ Write integration tests
-    ☐ Update API docs
-```
-
-Every feature is also available as a shell command for scripting or quick lookups:
-
-```
-$ ccs-status --md                     # Session dashboard
-$ ccs-resume-prompt --stdout          # Bootstrap prompt for new session
-$ ccs-feature gh65                    # Cross-session feature tracking
-$ ccs-recap                           # Daily work review
-```
-
-## How it works
+## Usage
 
 ccs-dashboard has two layers:
 
-**1. Claude Code Skill** (`/ccs-orchestrator`) — the primary interface. Ask in natural language, get an interactive orchestrator with context-aware options. No commands to remember.
+**1. Claude Code skill** (`/ccs-orchestrator`) — the primary interface. Ask in natural language ("work status", "what am I working on") and get an interactive orchestrator with context-aware options. Read-only: it observes and presents, it does not control other sessions.
 
-- Trigger: `/ccs-orchestrator`, or natural language like "work status", "what am I working on"
-- Read-only — observes and presents information, does not control other sessions
-- Features: Command Palette, natural language routing, context-aware follow-up options
-
-**2. CLI commands** — shell functions you can call directly from terminal. Useful for scripting, piping, or quick one-off lookups.
+**2. CLI commands** — shell functions you can call directly from the terminal, for scripting, piping, or quick one-off lookups.
 
 | Command | What it does |
 |---------|-------------|
@@ -108,78 +70,24 @@ ccs-dashboard has two layers:
 | `ccs-cleanup` | Find and kill suspended zombie processes |
 | `ccs-archive` | Manually mark a session as finished (archived) |
 | `ccs-crash` | Detect crash-interrupted sessions + `--clean`/`--clean-all` cleanup |
-| `ccs-resume-prompt` | Generate bootstrap prompt (< 2000 tokens) for new session |
+| `ccs-resume-prompt` | Generate bootstrap prompt (< 2000 tokens) for a new session |
 | `ccs-feature` | Track progress by feature/issue across sessions |
 | `ccs-recap` | Daily work review across all projects |
 | `ccs-details` | Interactive conversation browser (tig-like TUI) |
 | `ccs-overview` | Cross-session overview: sessions + todos + git status |
 | `ccs-checkpoint` | Lightweight progress snapshot: Done / In Progress / Blocked |
 | `ccs-handoff` | Generate handoff notes with conversation summary, git, file ops |
-| `ccs-health` | Session health detection — detect attention degradation signals |
+| `ccs-health` | Session health detection — surface attention-degradation signals |
 | `ccs-dispatch` | Dispatch a task to a new Claude Code session (async or sync) |
 | `ccs-jobs` | View dispatch job history and results |
 | `ccs-review` | Session review report — stats, conversation, LLM summary (md/html/pdf) |
 | `ccs-project` | Per-project insight report — cost, features, rhythm, code changes (md/html) |
 
-All commands support both **Terminal ANSI** and **Markdown** (`--md`) output modes.
-
-### ccs-health
-
-Session health detection — detect attention degradation signals.
-
-```bash
-ccs-health                    # Scan all active sessions
-ccs-health --md               # Markdown output
-ccs-health --json             # JSON output
-ccs-health <session-prefix>   # Specific session
-```
-
-Three indicators:
-- Duplicate tool calls (same file Read/Grep'd multiple times)
-- Session duration
-- Prompt-response round count
-
-Severity levels: 🟢 green / 🟡 yellow / 🔴 red
-
-Thresholds are configurable via environment variables (see `ccs-health.sh`).
-
-See **[docs/commands.md](docs/commands.md)** for detailed usage, flags, and examples.
-
-## Install
-
-```bash
-git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
-cd ~/tools/ccs-dashboard
-./install.sh            # Check deps + add source line to ~/.bashrc + create skill symlink
-./install.sh --check    # Check dependencies and installation status
-./install.sh --uninstall  # Remove
-```
-
-Or manually:
-
-```bash
-# Add to .bashrc:
-source ~/tools/ccs-dashboard/ccs-dashboard.sh
-
-# Skill symlink (optional):
-ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
-```
-
-## Status indicators
-
-```
-Terminal          Markdown    State       Meaning
-Green             🟢          active      < 10 min since last activity
-Yellow            🟡          recent      < 1 hour
-Blue              🔵          idle        < 1 day (open but idle)
-Gray              💤          stale       > 1 day (zombie candidate)
-Red 💀            💀          crashed     crash-interrupted (reboot/hung/dead process)
-Strikethrough     -           archived    has last-prompt marker
-```
+All commands support both **Terminal ANSI** and **Markdown** (`--md`) output. See [docs/commands.md](docs/commands.md) for detailed flags, examples, the typical workflow, and status indicators.
 
 ## Requirements
 
-**Platform:** Linux environment (remote server via SSH, local Linux, or WSL). Native Windows and macOS are not supported.
+**Platform:** Linux (remote server via SSH, local Linux, or WSL). Native Windows and macOS are not supported.
 
 | Required | Purpose |
 |----------|---------|
@@ -194,25 +102,11 @@ Strikethrough     -           archived    has last-prompt marker
 
 Data source: session logs under `~/.claude/projects/` (Claude) and `~/.gemini/` (Gemini).
 
-## File structure
+## Documentation
 
-```
-ccs-core.sh       # Shared helpers + basic commands (sessions/active/cleanup)
-ccs-dashboard.sh   # Entry point — sources all modules + ccs-status, ccs-pick
-ccs-viewer.sh      # ccs-html, ccs-details
-ccs-handoff.sh     # ccs-handoff, ccs-resume-prompt
-ccs-overview.sh    # ccs-overview + render helpers
-ccs-feature.sh     # Feature clustering + ccs-feature, ccs-tag
-ccs-ops.sh         # ccs-crash, ccs-recap, ccs-checkpoint
-ccs-health.sh      # Session health scoring
-ccs-dispatch.sh    # ccs-dispatch, ccs-jobs
-ccs-review.sh      # ccs-review — session review report
-ccs-project.sh     # ccs-project — per-project insight report
-install.sh         # Installer (deps check + bashrc + skill symlink)
-templates/         # Jinja2 HTML templates for ccs-review, ccs-project
-skills/            # Claude Code skill — primary interface
-docs/              # CLI command reference + archived design docs
-```
+- [docs/commands.md](docs/commands.md) — full CLI reference: flags, examples, typical workflow, status indicators
+- [docs/architecture.md](docs/architecture.md) — module and file layout
+- [docs/adr/](docs/adr/) — architecture decision records
 
 ## License
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 Code CLI Sessions (Claude, Gemini 等) 的任務指揮中心 — 跨 repo 追蹤、回顧、交接。
 
-Code CLI 工具 (如 Claude 或 Gemini) 將對話存放在特定目錄中，但缺乏統一的管理介面。ccs-dashboard 解析這些對話紀錄，讓你直接問 agent 或從 terminal 掌握所有 session 狀態。
+Code CLI 工具將對話存放在特定目錄中，但缺乏統一的管理介面。ccs-dashboard 解析這些對話紀錄，讓你直接問 agent 或從 terminal 掌握所有 session 狀態。
 
 ## 背景
 
@@ -12,23 +12,31 @@ Code CLI 工具 (如 Claude 或 Gemini) 將對話存放在特定目錄中，但�
 
 - **Session 是隱形的。** Claude Code 沒有內建方式列出、搜尋或比較 session。每個 terminal 都是獨立的孤島，關掉 tab 就失去 context。
 - **多 repo 混亂。** 同時修後端 bug、做前端功能、更新文件？你很難記得哪個 session 在哪個 repo 做什麼。
-- **殭屍 process 堆積。** 被 suspend 的 claude process（來自 terminal multiplexer、tab crash、`Ctrl+Z`）默默吃掉每個 190-500 MB RAM，沒有警告、沒有清理機制。
+- **殭屍 process 堆積。** 被 suspend 的 `claude` process（來自 terminal multiplexer、tab crash、`Ctrl+Z`）默默吃掉每個 190-500 MB RAM，沒有警告、沒有清理機制。
 - **Context 無法傳遞。** 開新 session 就要重新解釋一切。舊 session 的知識 — 碰了哪些檔案、做了什麼決定、還剩什麼待做 — 困在沒人看的 JSONL 裡。
 - **沒有跨 session 視角。** 一個 feature 可能橫跨 5 個 session、3 天時間，沒有辦法一次看到完整面貌 — commit、待辦、時間軸 — 只能手動翻 log。
 
-## 使用前 vs 使用後
+## 快速開始
 
-**使用前：** 只能翻 JSONL 原始檔。
-
-```
-$ ls ~/.claude/projects/
--home-alice-backend-api/    -home-alice-frontend/    -home-alice-docs/
-$ ls ~/.claude/projects/-home-alice-backend-api/
-3a8f1c42-...jsonl  7b2e9d15-...jsonl  a1c4f8e2-...jsonl
-# 然後呢？用 vim 開 50MB 的 JSONL？
+```bash
+git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
+cd ~/tools/ccs-dashboard
+./install.sh              # 檢查依賴、加 source 行到 ~/.bashrc、建立 skill symlink
 ```
 
-**使用後：** 直接問 Claude，內建的 [custom skill](https://docs.anthropic.com/en/docs/claude-code/skills) 會啟動互動式指揮台 — 不用記指令。
+`./install.sh --check` 檢查狀態；`./install.sh --uninstall` 移除。
+
+或手動設定：
+
+```bash
+# 在 .bashrc 加入：
+source ~/tools/ccs-dashboard/ccs-dashboard.sh
+
+# Skill symlink（選用）：
+ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
+```
+
+接著直接問 Claude：
 
 ```
 You: 我現在在做什麼？
@@ -39,66 +47,20 @@ Claude: (runs /ccs-orchestrator)
 
 📁 backend-api (2)
 🟢 1. Fix auth middleware regression    a1c4f8e2  3m ago
-🔵 2. Add rate limiting endpoint       7b2e9d15  5h ago
-
-📁 frontend (1)
-🟡 3. Dashboard redesign v2            9f3b7a21  45m ago
+🔵 2. Add rate limiting endpoint        7b2e9d15  5h ago
 
 ### 📋 Pending Todos (3)
-☐ Add rate limit headers to response          (backend-api)
-☐ Write integration tests                     (backend-api)
-☐ Update sidebar component                    (frontend)
-
-### 🧟 Zombie Processes (2)
-PID 28341  Tl  490 MB  2d ago
-PID 31022  Tl  312 MB  1d ago
-
-<options>
-- d 1 — 展開 session #1 最近對話
-- f gh65 — 查看 rate limiting feature 進度
-- rc — 今日工作回顧
-- cl — 清理殭屍 process
-</options>
+☐ Add rate limit headers to response    (backend-api)
+☐ Write integration tests               (backend-api)
 ```
 
-Skill 會自動處理路由、context、follow-up options。也可以進一步追問：
+內建的 [skill](https://docs.anthropic.com/en/docs/claude-code/skills) 會啟動互動式指揮台和 context-aware follow-up options，不用記指令。完整操作流程見 [commands.md](commands.md)。
 
-```
-You: rate limiting feature 還剩什麼？
-
-Claude: (runs ccs-feature gh65)
-
-### 🟡 GH#65 Add rate limiting [backend-api]
-    Todos: 2/5 | Sessions: 3 | Last: 45m ago
-
-    Recent commits:
-    a3f1c82  feat: add token bucket rate limiter
-    9b2e7d1  feat: add Redis-backed rate limit store
-
-    Remaining todos:
-    ☐ Add rate limit headers to response
-    ☐ Write integration tests
-    ☐ Update API docs
-```
-
-每個功能也可以直接用 shell 指令：
-
-```
-$ ccs-status --md                     # Session dashboard
-$ ccs-resume-prompt --stdout          # 產生接手 prompt
-$ ccs-feature gh65                    # 跨 session feature 追蹤
-$ ccs-recap                           # 每日工作回顧
-```
-
-## 運作方式
+## 使用方式
 
 ccs-dashboard 分兩層：
 
-**1. Claude Code Skill** (`/ccs-orchestrator`) — 主要介面。用自然語言問，得到互動式指揮台和 context-aware options，不用記指令。
-
-- 觸發方式：`/ccs-orchestrator`，或自然語言如「工作狀態」「我在做什麼」
-- 唯讀 — 只讀取和呈現資訊，不控制其他 session
-- 功能：Command Palette、自然語言路由、context-aware follow-up options
+**1. Claude Code Skill**（`/ccs-orchestrator`）— 主要介面。用自然語言問（「工作狀態」「我在做什麼」），得到互動式指揮台和 context-aware options。唯讀：只讀取和呈現資訊，不控制其他 session。
 
 **2. CLI 指令** — 可以從 terminal 直接呼叫的 shell function，適合腳本、pipe、快速查詢。
 
@@ -106,76 +68,22 @@ ccs-dashboard 分兩層：
 |------|------|
 | `ccs` / `ccs-status` | 統一 dashboard：活躍 session + 殭屍 process + 過期 session |
 | `ccs-cleanup` | 找出並清理被 suspend 的殭屍 process |
-| `ccs-archive` | 手動標記 Session 為已完成（存檔） |
+| `ccs-archive` | 手動標記 session 為已完成（存檔） |
+| `ccs-crash` | 偵測 crash 中斷的 session + `--clean`/`--clean-all` 清理 |
 | `ccs-resume-prompt` | 產生精簡 bootstrap prompt（< 2000 tokens），貼入新 session 即可接手 |
 | `ccs-feature` | 以 feature/issue 為單位的跨 session 進度追蹤 |
 | `ccs-recap` | 每日工作回顧 — 跨專案彙整 session/todo/git 活動 |
 | `ccs-details` | 互動式對話瀏覽器（類似 tig 的 TUI） |
 | `ccs-overview` | 跨 session 工作總覽：session + 待辦 + git 狀態 |
-| `ccs-crash` | 偵測 crash 中斷的 session + `--clean`/`--clean-all` 清理 |
-| `ccs-handoff` | 產生交接筆記：對話摘要、git 狀態、檔案操作 |
 | `ccs-checkpoint` | 輕量進度快照：Done / In Progress / Blocked |
+| `ccs-handoff` | 產生交接筆記：對話摘要、git 狀態、檔案操作 |
 | `ccs-health` | Session 健康偵測 — 偵測注意力退化信號 |
 | `ccs-dispatch` | 派發任務到新的 Claude Code session（async 或 sync） |
 | `ccs-jobs` | 查看 dispatch 任務歷史與結果 |
 | `ccs-review` | Session 回顧報告 — 統計、對話、LLM 摘要（md/html/pdf） |
 | `ccs-project` | 專案層級洞察報告 — 成本、進度、節奏、程式碼變動（md/html） |
 
-所有指令支援 **Terminal ANSI** 和 **Markdown** (`--md`) 兩種輸出模式。
-
-### ccs-health
-
-Session 健康偵測 — 偵測注意力退化信號。
-
-```bash
-ccs-health                    # 掃描所有 active session
-ccs-health --md               # Markdown 輸出
-ccs-health --json             # JSON 輸出
-ccs-health <session-prefix>   # 指定 session
-```
-
-三個偵測指標：
-- 重複 tool call（同一檔案被 Read/Grep 多次）
-- Session 持續時間
-- Prompt-response 輪數
-
-分級顯示：🟢 green / 🟡 yellow / 🔴 red
-
-閾值可透過環境變數覆蓋（見 `ccs-health.sh`）。
-
-詳細用法、參數、範例請見 **[commands.md](commands.md)**。
-
-## 安裝
-
-```bash
-git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
-cd ~/tools/ccs-dashboard
-./install.sh            # 檢查依賴 + 加 source 行到 ~/.bashrc + 建立 skill symlink
-./install.sh --check    # 只檢查依賴和安裝狀態
-./install.sh --uninstall  # 移除
-```
-
-或手動：
-
-```bash
-# 在 .bashrc 加入：
-source ~/tools/ccs-dashboard/ccs-dashboard.sh
-
-# Skill symlink（選用）：
-ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
-```
-
-## 狀態圖示
-
-```
-Terminal          Markdown    狀態        說明
-綠色              🟢          active      < 10 分鐘
-黃色              🟡          recent      < 1 小時
-藍色              🔵          idle        < 1 天（開著但閒置）
-灰色              💤          stale       > 1 天（殭屍候選）
-紅色 💀           💀          crashed     crash 中斷（重開機/hung/dead process）
-灰色刪除線         -          archived    有 last-prompt 標記
-```
+所有指令支援 **Terminal ANSI** 和 **Markdown**（`--md`）兩種輸出模式。詳細參數、範例、典型工作流程與狀態圖示見 [commands.md](commands.md)。
 
 ## 依賴
 
@@ -184,7 +92,7 @@ Terminal          Markdown    狀態        說明
 | 必要 | 用途 |
 |------|------|
 | bash 4+ | mapfile, associative arrays |
-| jq | JSONL 解析 |
+| jq | JSON/JSONL 解析 |
 | coreutils | stat, date, find |
 
 | 選用 | 用途 |
@@ -194,25 +102,11 @@ Terminal          Markdown    狀態        說明
 
 資料來源：`~/.claude/projects/` (Claude) 與 `~/.gemini/` (Gemini) 下的 session log。
 
-## 檔案結構
+## 文件
 
-```
-ccs-core.sh       # 共用 helper + 基礎指令 (sessions/active/cleanup)
-ccs-dashboard.sh   # 入口 — source 所有模組 + ccs-status, ccs-pick
-ccs-viewer.sh      # ccs-html, ccs-details
-ccs-handoff.sh     # ccs-handoff, ccs-resume-prompt
-ccs-overview.sh    # ccs-overview + render helpers
-ccs-feature.sh     # Feature clustering + ccs-feature, ccs-tag
-ccs-ops.sh         # ccs-crash, ccs-recap, ccs-checkpoint
-ccs-health.sh      # Session health 評分
-ccs-dispatch.sh    # ccs-dispatch, ccs-jobs
-ccs-review.sh      # ccs-review — session 回顧報告
-ccs-project.sh     # ccs-project — 專案層級洞察報告
-install.sh         # 安裝腳本（依賴檢查 + bashrc + skill symlink）
-templates/         # Jinja2 HTML 模板（ccs-review、ccs-project 用）
-skills/            # Claude Code skill — 主要介面
-docs/              # CLI 指令參考 + 歸檔設計文件
-```
+- [commands.md](commands.md) — 完整 CLI 參考：參數、範例、典型工作流程、狀態圖示
+- [architecture.md](architecture.md) — 模組與檔案結構
+- [adr/](adr/) — 架構決策紀錄
 
 ## 授權
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,30 @@
+# 架構與檔案結構
+
+回到 [README](../README.md)
+
+程式碼按功能拆為模組，`ccs-dashboard.sh` 是唯一入口（source 所有模組）。新增或修改指令前，先讀 [adr/001-modular-source-split.md](adr/001-modular-source-split.md) 確認歸屬模組與 checklist。
+
+## 檔案結構
+
+```
+ccs-core.sh        # 共用 helper + 基礎指令 (sessions/active/cleanup)
+ccs-dashboard.sh   # 入口 — source 所有模組 + ccs-status, ccs-pick
+ccs-viewer.sh      # ccs-html, ccs-details
+ccs-handoff.sh     # ccs-handoff, ccs-resume-prompt
+ccs-overview.sh    # ccs-overview + render helpers
+ccs-feature.sh     # Feature clustering + ccs-feature, ccs-tag
+ccs-ops.sh         # ccs-crash, ccs-recap, ccs-checkpoint
+ccs-health.sh      # Session health 評分
+ccs-dispatch.sh    # ccs-dispatch, ccs-jobs
+ccs-review.sh      # ccs-review — session 回顧報告
+ccs-project.sh     # ccs-project — 專案層級洞察報告
+install.sh         # 安裝腳本（依賴檢查 + bashrc + skill symlink）
+templates/         # Jinja2 HTML 模板（ccs-review、ccs-project 用）
+skills/            # Claude Code skill — 主要介面
+docs/              # CLI 指令參考 + 歸檔設計文件
+```
+
+## 架構決策
+
+- [adr/001-modular-source-split.md](adr/001-modular-source-split.md) — 模組化拆分（單一入口 source 多模組）
+- [adr/002-unified-multi-provider-architecture.md](adr/002-unified-multi-provider-architecture.md) — 統一多 Provider 架構

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,96 @@
 
 回到 [README](../README.md)
 
+## 典型工作流程
+
+最常見的用法是直接問 Claude，skill 會啟動互動式指揮台 — 不用記指令。
+
+**使用前：** 只能翻 JSONL 原始檔。
+
+```
+$ ls ~/.claude/projects/
+-home-alice-backend-api/    -home-alice-frontend/    -home-alice-docs/
+$ ls ~/.claude/projects/-home-alice-backend-api/
+3a8f1c42-...jsonl  7b2e9d15-...jsonl  a1c4f8e2-...jsonl
+# 然後呢？用 vim 開 50MB 的 JSONL？
+```
+
+**使用後：** 直接問 Claude，內建的 [custom skill](https://docs.anthropic.com/en/docs/claude-code/skills) 會啟動互動式指揮台。
+
+```
+You: 我現在在做什麼？
+
+Claude: (runs /ccs-orchestrator)
+
+### ⚡ Active Sessions (4)
+
+📁 backend-api (2)
+🟢 1. Fix auth middleware regression    a1c4f8e2  3m ago
+🔵 2. Add rate limiting endpoint       7b2e9d15  5h ago
+
+📁 frontend (1)
+🟡 3. Dashboard redesign v2            9f3b7a21  45m ago
+
+### 📋 Pending Todos (3)
+☐ Add rate limit headers to response          (backend-api)
+☐ Write integration tests                     (backend-api)
+☐ Update sidebar component                    (frontend)
+
+### 🧟 Zombie Processes (2)
+PID 28341  Tl  490 MB  2d ago
+PID 31022  Tl  312 MB  1d ago
+
+<options>
+- d 1 — 展開 session #1 最近對話
+- f gh65 — 查看 rate limiting feature 進度
+- rc — 今日工作回顧
+- cl — 清理殭屍 process
+</options>
+```
+
+Skill 會自動處理路由、context、follow-up options。也可以進一步追問：
+
+```
+You: rate limiting feature 還剩什麼？
+
+Claude: (runs ccs-feature gh65)
+
+### 🟡 GH#65 Add rate limiting [backend-api]
+    Todos: 2/5 | Sessions: 3 | Last: 45m ago
+
+    Recent commits:
+    a3f1c82  feat: add token bucket rate limiter
+    9b2e7d1  feat: add Redis-backed rate limit store
+
+    Remaining todos:
+    ☐ Add rate limit headers to response
+    ☐ Write integration tests
+    ☐ Update API docs
+```
+
+每個功能也可以直接用 shell 指令：
+
+```
+$ ccs-status --md                     # Session dashboard
+$ ccs-resume-prompt --stdout          # 產生接手 prompt
+$ ccs-feature gh65                    # 跨 session feature 追蹤
+$ ccs-recap                           # 每日工作回顧
+```
+
+## 狀態圖示
+
+`ccs-status` 等指令用以下色碼 / emoji 標示 session 狀態：
+
+```
+Terminal          Markdown    狀態        說明
+綠色              🟢          active      < 10 分鐘
+黃色              🟡          recent      < 1 小時
+藍色              🔵          idle        < 1 天（開著但閒置）
+灰色              💤          stale       > 1 天（殭屍候選）
+紅色 💀           💀          crashed     crash 中斷（重開機/hung/dead process）
+灰色刪除線         -          archived    有 last-prompt 標記
+```
+
 ## ccs-status (ccs)
 
 一眼掌握所有 Provider (Claude, Gemini 等) 的 session 狀態，分四個區塊：

--- a/docs/sync-checklist.md
+++ b/docs/sync-checklist.md
@@ -16,15 +16,12 @@ Phase 3 收尾時，確認以下檔案的對應欄位已同步。
 
 修改 session 狀態分類時：
 
-- `README.md` — Status indicators section
-- `docs/README.zh-TW.md` — 狀態圖示 section
-- `docs/commands.md` — ccs-status 說明
+- `docs/commands.md` — 狀態圖示 section + ccs-status 說明
 
 ## 模組檔案
 
 新增或移除 `.sh` 模組時：
 
-- `README.md` — File structure section
-- `docs/README.zh-TW.md` — 檔案結構 section
+- `docs/architecture.md` — 檔案結構 section
 - `install.sh` — modules array (line ~101)
 - `ccs-dashboard.sh` — source 順序


### PR DESCRIPTION
## Summary

- README slimmed 219 → 113 lines (en + zh-TW) to follow OSS scan-first conventions
- Deep content moved to `docs/*`: workflow demo + status indicators → `docs/commands.md`; file structure + ADR pointers → new `docs/architecture.md`
- Background 5 pain-point bullets kept in README as hook for new readers
- `docs/sync-checklist.md` updated to reflect new cross-ref locations

## Test plan

- [x] README links resolve: `docs/commands.md`, `docs/architecture.md`, `docs/adr/`, `docs/README.zh-TW.md`, `LICENSE`
- [x] zh-TW README mirrors en README structure (both 113 lines, parallel sections)
- [x] No content lost: `ccs-health` subsection still reachable via `docs/commands.md` (line ~395)
- [x] `sync-checklist.md` cross-refs match new locations

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)