### PR TITLE
feat(dispatch): agent-pager local-channel dispatch backend (Stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 ### Added
 
 - `ccs-failure-triage`: triage a session for model confabulation-family failure signals (Sub-pattern A/B/C/D). Includes 5 automated forensic checks and writes a report to `<project>/tmp/`. See `docs/failure-triage.md`.
+- **ccs-dispatch agent-pager backend** — optional local-channel worker backend (`CCS_DISPATCH_BACKEND=agentpager`, auto-detected) that runs a monitorable interactive worker via agent-pager instead of headless `claude -p`. Same-uid hybrid detection needs no `claude-broker` group; projects map to agent-pager keys via `~/.config/ccs-dashboard/proj-map`. Handoff-driven completion (`handoff-ready` status), async-only, and falls back to headless when agent-pager is unavailable. See `docs/commands.md`.
 
 ## [0.3.3] — 2026-04-17
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -167,6 +167,22 @@ _ccs_dispatch_finish() {
   rm -f "$prompt_f"
 }
 
+# Consume a framed agent-pager local-channel stream and emit each frame's
+# BODY to stdout (one per frame, newline-joined). Label is ignored — ccs
+# surfaces body only. Reads $1 (file path) or stdin.
+# Frame layout (agent-pager notify-send.sh local sink):
+#   <RS>MSG<US><LABEL><RS>\n<BODY>\n<RS>END<RS>\n   (RS=0x1E, US=0x1F)
+_ccs_consume_framed_stream() {
+  local src="${1:-/dev/stdin}"
+  awk -v RS=$'\x1e' -v us=$'\x1f' '
+    BEGIN { in_msg=0; expect_body=0; n=0 }
+    $0 ~ "^MSG" us        { in_msg=1; expect_body=1; next }
+    in_msg && expect_body { body=$0; sub(/^\n/,"",body); sub(/\n$/,"",body); expect_body=0; next }
+    in_msg && $0 ~ "^END" { bodies[n++]=body; in_msg=0 }
+    END { for (i=0;i<n;i++) { if (i) printf "\n"; printf "%s", bodies[i] } printf "\n" }
+  ' "$src"
+}
+
 # agent-pager backend — STAGE 1 STUB.
 # Stage 2 will write a local-channel inbound launch and map the worker
 # lifecycle back into jobs.jsonl. Until then this always fails so the

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -14,16 +14,25 @@ CCS_DISPATCH_MAX_CONCURRENT_WARN="${CCS_DISPATCH_MAX_CONCURRENT_WARN:-3}"
 
 # ── Backend selection ──
 # Returns 0 if the agent-pager backend is usable, 1 otherwise.
-# Stage 1: daemon active + spool dir exists. Stage 2 will additionally
-# require the merged local channel.
+# Requires the daemon active and the local-channel spool present, then
+# applies Hybrid Detection (design Decision A):
+#   same-uid  — spool owned by the caller (personal workflow): the caller
+#               already has full access, so skip the claude-broker group
+#               and setgid checks; daemon + inbound/ is enough.
+#   cross-uid — spool owned by another user (shared seat): enforce the
+#               strict AVer checks — caller in the claude-broker group and
+#               the inbound spool carrying that group (setgid evidence).
 _ccs_dispatch_agentpager_available() {
   command -v systemctl >/dev/null 2>&1 || return 1
   systemctl --user is-active --quiet agent-pager.service 2>/dev/null || return 1
   local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
   [ -d "$pager_dir" ] || return 1
-  # local channel readiness: spool present, caller in the broker group,
-  # and the spool carries that group (setgid evidence from install.sh).
   [ -d "$pager_dir/inbound" ] || return 1
+
+  # same-uid personal workflow: caller owns the spool -> trust it.
+  [ "$(stat -c %u "$pager_dir" 2>/dev/null)" = "$(id -u)" ] && return 0
+
+  # cross-uid shared seat: strict group + setgid verification.
   id -nG "$(id -un)" 2>/dev/null | tr ' ' '\n' | grep -qx claude-broker || return 1
   [ "$(stat -c %G "$pager_dir/inbound" 2>/dev/null)" = "claude-broker" ] || return 1
   return 0

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -19,7 +19,13 @@ CCS_DISPATCH_MAX_CONCURRENT_WARN="${CCS_DISPATCH_MAX_CONCURRENT_WARN:-3}"
 _ccs_dispatch_agentpager_available() {
   command -v systemctl >/dev/null 2>&1 || return 1
   systemctl --user is-active --quiet agent-pager.service 2>/dev/null || return 1
-  [ -d "${AGENT_PAGER_DIR:-$HOME/.agent-pager}" ] || return 1
+  local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
+  [ -d "$pager_dir" ] || return 1
+  # local channel readiness: spool present, caller in the broker group,
+  # and the spool carries that group (setgid evidence from install.sh).
+  [ -d "$pager_dir/inbound" ] || return 1
+  id -nG "$(id -un)" 2>/dev/null | tr ' ' '\n' | grep -qx claude-broker || return 1
+  [ "$(stat -c %G "$pager_dir/inbound" 2>/dev/null)" = "claude-broker" ] || return 1
   return 0
 }
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -183,6 +183,24 @@ _ccs_consume_framed_stream() {
   ' "$src"
 }
 
+# Map an absolute project_dir to the lead-side proj key that ccs writes
+# into the inbound .md. ccs keeps its OWN map (key = abspath, same format
+# as the lead whitelist) via CCS_DISPATCH_PROJ_MAP so it never reads the
+# lead's projects file. Echoes the key; rc 1 if no map / no match.
+_ccs_dispatch_resolve_proj_from_dir() {
+  local dir="${1%/}" line key val
+  local map_file="${CCS_DISPATCH_PROJ_MAP:-$HOME/.config/ccs-dashboard/proj-map}"
+  [ -f "$map_file" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    key="${line%%=*}"; val="${line#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"; key="${key%"${key##*[![:space:]]}"}"
+    val="${val#"${val%%[![:space:]]*}"}"; val="${val%"${val##*[![:space:]]}"}"
+    [ "${val%/}" = "$dir" ] && { printf '%s\n' "$key"; return 0; }
+  done < "$map_file"
+  return 1
+}
+
 # agent-pager backend — STAGE 1 STUB.
 # Stage 2 will write a local-channel inbound launch and map the worker
 # lifecycle back into jobs.jsonl. Until then this always fails so the

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -216,14 +216,356 @@ _ccs_dispatch_resolve_proj_from_dir() {
   return 1
 }
 
-# agent-pager backend — STAGE 1 STUB.
-# Stage 2 will write a local-channel inbound launch and map the worker
-# lifecycle back into jobs.jsonl. Until then this always fails so the
-# dispatcher falls back to headless.
+# ── agent-pager backend (stage 2) ──────────────────────────────────────────
+# Dispatch a worker over the agent-pager local channel: write an inbound launch,
+# then watch the per-user out.stream + the worker's handoff file back into a job
+# result. Completion is signalled by the worker writing tmp/handoff-<job_id>.md
+# (design Decision B): ccs then stops the seat and finalizes. There is NO
+# wall-clock kill — a stuck worker stays up for the operator to /stop (design D2).
+
+# Build the worker's opening prompt: the dispatch prompt plus a handoff-gating
+# invariant that tells the worker to write tmp/handoff-<job_id>.md when done
+# (that file is ccs's completion signal). ccs-handoff's own default output path
+# differs, so the worker is told to save to this exact per-job path.
+_ccs_dispatch_agentpager_prompt() {
+  local job_id="$1" task="$2"
+  cat <<HGRULE
+${task}
+
+---
+DISPATCH HANDOFF RULE (job ${job_id}, non-negotiable):
+This is a dispatched worker session. When the task above is fully complete (or
+before your context fills), first report a one-line summary of what you did.
+Then, AS YOUR VERY LAST ACTION, write a concise handoff to the file
+tmp/handoff-${job_id}.md (path relative to the project root; use ccs-handoff for
+the content if helpful). Writing that file is your completion signal: the
+dispatcher watches for tmp/handoff-${job_id}.md and closes this session once it
+appears, so do not create it until everything else — including your summary — is
+already done. You do NOT need to exit yourself.
+HGRULE
+}
+
+# Write an agent-pager inbound launch file. Frontmatter matches inbound-handler.sh
+# (kind/slot/proj/cli + two --- delimiters, body after the second). ccs passes a
+# proj KEY only — agent-pager resolves it to a path from its own whitelist (the
+# RCE boundary). Echoes the file path; rc 1 on write failure.
+_ccs_dispatch_agentpager_launch_file() {
+  local job_id="$1" proj="$2" key="$3" prompt="$4" pager_dir="$5"
+  local inbound="$pager_dir/inbound"
+  mkdir -p "$inbound" || return 1
+  local f="$inbound/$(date +%s)-${job_id}.md"
+  {
+    printf -- '---\n'
+    printf 'kind: launch\n'
+    printf 'slot: %s\n' "$key"
+    printf 'proj: %s\n' "$proj"
+    printf 'cli: claude\n'
+    printf -- '---\n'
+    printf '%s\n' "$prompt"
+  } > "$f" || return 1
+  printf '%s\n' "$f"
+}
+
+# Write an agent-pager inbound stop file to reclaim the local seat. Echoes the
+# path; rc 1 on write failure.
+_ccs_dispatch_agentpager_stop_file() {
+  local key="$1" pager_dir="$2"
+  local inbound="$pager_dir/inbound"
+  mkdir -p "$inbound" || return 1
+  local f="$inbound/$(date +%s%N)-${key}-stop.md"
+  {
+    printf -- '---\n'
+    printf 'kind: stop\n'
+    printf 'slot: %s\n' "$key"
+    printf -- '---\n'
+  } > "$f" || return 1
+  printf '%s\n' "$f"
+}
+
+# Decode only this job's frames from the per-user out.stream. The stream is
+# append-only and persists across jobs, so we read from the byte offset captured
+# at launch, not the whole file.
+_ccs_dispatch_agentpager_collect() {
+  local stream="$1" offset="$2" dest="$3"
+  if [ -f "$stream" ]; then
+    tail -c +$((offset + 1)) "$stream" | _ccs_consume_framed_stream > "$dest"
+  else
+    : > "$dest"
+  fi
+}
+
+# True while the worker's tmux session is alive. Wrapped so tests can mock tmux.
+_ccs_dispatch_agentpager_session_alive() {
+  tmux has-session -t "$1" 2>/dev/null
+}
+
+# Echo the last-activity timestamp (ISO) of a local session = mtime of its
+# out.stream. Lets ccs-jobs surface a stalled worker so the operator can /stop
+# it (design D2: no auto-kill). Empty if the stream does not exist yet.
+_ccs_dispatch_agentpager_last_activity() {
+  local key="$1" pager_dir="$2"
+  local stream="$pager_dir/channels/$key/out.stream"
+  [ -f "$stream" ] || return 0
+  date -Iseconds -r "$stream" 2>/dev/null
+}
+
+# Finalize an agent-pager job (handoff gating). Handoff file present + copied ->
+# handoff-ready (captured to results/<job_id>.handoff). Otherwise the status is
+# $3 (no_handoff_status, default "completed"; the monitor passes "failed" when
+# the worker session was never observed). ccs is not the worker's parent, so
+# there is no exit code. $4 is an optional operator note appended to md + jsonl.
+_ccs_dispatch_finish_agentpager() {
+  local job_id="$1" handoff_src="$2"
+  local no_handoff_status="${3:-completed}" note="${4:-}"
+  local dispatch_dir
+  dispatch_dir="$(_ccs_dispatch_dir)"
+  local raw="$dispatch_dir/results/${job_id}.raw"
+  local err="$dispatch_dir/results/${job_id}.err"
+  local md="$dispatch_dir/results/${job_id}.md"
+  local handoff_dst="$dispatch_dir/results/${job_id}.handoff"
+  local prompt_f="$dispatch_dir/results/${job_id}.prompt"
+
+  # handoff-ready only when the file is actually captured; a failed copy must not
+  # claim a handoff it did not save.
+  local status handoff_flag=false
+  if [ -f "$handoff_src" ] && cp "$handoff_src" "$handoff_dst" 2>/dev/null; then
+    handoff_flag=true
+    status="handoff-ready"
+  else
+    [ -f "$handoff_src" ] && note="${note:+$note; }handoff present but copy failed"
+    status="$no_handoff_status"
+  fi
+
+  local task=""
+  [ -f "$prompt_f" ] && task=$(head -c 200 "$prompt_f")
+  local initial project created_at backend
+  initial=$(_ccs_dispatch_jsonl_latest "$job_id")
+  project=$(echo "$initial" | jq -r '.project // "unknown"')
+  created_at=$(echo "$initial" | jq -r '.created_at // "unknown"')
+  backend=$(echo "$initial" | jq -r '.backend // "agentpager"')
+  local finished_at
+  finished_at=$(date -Iseconds)
+
+  local duration_s=""
+  if [ "$created_at" != "unknown" ]; then
+    local start_epoch
+    start_epoch=$(date -d "$created_at" +%s 2>/dev/null || echo "")
+    [ -n "$start_epoch" ] && duration_s="$(( $(date +%s) - start_epoch ))s"
+  fi
+
+  {
+    echo "# Dispatch Result: $job_id"
+    echo ""
+    echo "- **Project:** $project"
+    echo "- **Task:** $task"
+    echo "- **Status:** $status"
+    echo "- **Backend:** $backend"
+    echo "- **Created:** $created_at"
+    echo "- **Finished:** $finished_at"
+    [ -n "$duration_s" ] && echo "- **Duration:** $duration_s"
+    [ "$handoff_flag" = true ] && echo "- **Handoff:** $handoff_dst"
+    [ -n "$note" ] && echo "- **Note:** ⚠️ $note"
+    echo ""
+    echo "## Output"
+    echo ""
+    # A zero-frame stream collects to a lone newline, so test emptiness by
+    # non-whitespace content, not just file size.
+    if [ -f "$raw" ] && grep -q '[^[:space:]]' "$raw" 2>/dev/null; then
+      cat "$raw"
+    else
+      echo "(no output)"
+    fi
+    echo ""
+    echo "## Errors"
+    echo ""
+    if [ -f "$err" ] && [ -s "$err" ]; then
+      cat "$err"
+    else
+      echo "(none)"
+    fi
+  } > "$md"
+
+  local summary=""
+  if [ -f "$raw" ]; then
+    summary=$(tail -n "$CCS_DISPATCH_SUMMARY_LINES" "$raw" | head -c "$CCS_DISPATCH_SUMMARY_MAX_CHARS")
+  fi
+
+  _ccs_dispatch_jsonl_append "$(jq -nc \
+    --arg jid "$job_id" \
+    --arg st "$status" \
+    --arg fa "$finished_at" \
+    --arg sum "$summary" \
+    --arg note "$note" \
+    --argjson ho "$handoff_flag" \
+    '{job_id:$jid, status:$st, finished_at:$fa, summary:$sum, handoff:$ho}
+     + (if $note == "" then {} else {note:$note} end)'
+  )"
+
+  rm -f "$dispatch_dir/pids/${job_id}.pid"
+  [ -f "$md" ] && rm -f "$raw"
+  rm -f "$prompt_f"
+}
+
+# Background monitor for one agent-pager job. Runs under nohup from spawn. Polls
+# for the handoff file; when it appears, stops the seat and finalizes. Also exits
+# the loop if the worker's tmux session disappears on its own (self /exit or
+# crash). No wall-clock timeout (design D2: never auto-kill).
+_ccs_dispatch_agentpager_monitor() {
+  local job_id="$1" key="$2" project_dir="$3" start_offset="$4" pager_dir="$5"
+  local tmux_session="agent-pager-$key"
+  local stream="$pager_dir/channels/$key/out.stream"
+  local state_json="$pager_dir/state/sessions/$key.json"
+  local handoff_src="$project_dir/tmp/handoff-${job_id}.md"
+  local dispatch_dir
+  dispatch_dir="$(_ccs_dispatch_dir)"
+  local poll="${CCS_DISPATCH_AGENTPAGER_POLL:-3}"
+  local startup="${CCS_DISPATCH_AGENTPAGER_STARTUP:-60}"
+  local stop_wait="${CCS_DISPATCH_AGENTPAGER_STOP_WAIT:-30}"
+  local observed=0 note=""
+
+  # Phase A — startup grace. The runner spawns the worker's tmux session a few
+  # seconds after ccs writes the launch, so has-session is false right now.
+  # Wait for it to appear before the completion loop; otherwise the monitor would
+  # read "already gone" and finalize before the worker even runs.
+  local waited=0
+  while [ "$waited" -lt "$startup" ]; do
+    if _ccs_dispatch_agentpager_session_alive "$tmux_session"; then observed=1; break; fi
+    [ -f "$handoff_src" ] && break
+    sleep 1; waited=$((waited + 1))
+  done
+
+  # Watch the cwd agent-pager ACTUALLY resolved the proj key to (its state json),
+  # not ccs's project_dir. This is the single source of truth for where the worker
+  # runs, so the handoff path can never drift from a stale proj-map entry.
+  if [ -r "$state_json" ]; then
+    local real_cwd
+    real_cwd="$(jq -r '.cwd // empty' "$state_json" 2>/dev/null)"
+    [ -n "$real_cwd" ] && [ -d "$real_cwd" ] && \
+      handoff_src="$real_cwd/tmp/handoff-${job_id}.md"
+  fi
+
+  # Phase B — completion. Handoff file appears -> stop the seat; or the worker
+  # ends the session on its own. No wall-clock kill (design D2).
+  while _ccs_dispatch_agentpager_session_alive "$tmux_session"; do
+    observed=1
+    if [ -f "$handoff_src" ]; then
+      # The worker writes the handoff mid-turn, but its tool/prose frames only
+      # relay to out.stream at turn end. Wait for the stream to settle before
+      # stopping, or an eager stop truncates the captured output (E2E-observed).
+      _ccs_dispatch_agentpager_wait_settle "$stream"
+      # Reclaim the seat. If the first stop is not honored (worker mid-tool-call),
+      # retry once; if it still will not die, leave a note so the operator knows
+      # to reclaim manually rather than silently orphaning the single per-user seat.
+      _ccs_dispatch_agentpager_stop_file "$key" "$pager_dir" >/dev/null
+      _ccs_dispatch_agentpager_wait_gone "$tmux_session" "$stop_wait"
+      if _ccs_dispatch_agentpager_session_alive "$tmux_session"; then
+        _ccs_dispatch_agentpager_stop_file "$key" "$pager_dir" >/dev/null
+        _ccs_dispatch_agentpager_wait_gone "$tmux_session" "$stop_wait"
+        _ccs_dispatch_agentpager_session_alive "$tmux_session" && \
+          note="worker session did not stop; reclaim manually (tmux $tmux_session)"
+      fi
+      break
+    fi
+    sleep "$poll"
+  done
+  sleep 1  # let any trailing frames flush to the stream
+  _ccs_dispatch_agentpager_collect "$stream" "$start_offset" \
+    "$dispatch_dir/results/${job_id}.raw"
+  # A session that never appeared is a launch failure, not a clean completion.
+  local no_handoff_status="completed"
+  [ "$observed" = 0 ] && no_handoff_status="failed"
+  _ccs_dispatch_finish_agentpager "$job_id" "$handoff_src" "$no_handoff_status" "$note"
+}
+
+# Poll until the tmux session is gone or $2 seconds elapse. Extracted so the
+# stop-reclaim path stays readable and the wait bound is testable.
+_ccs_dispatch_agentpager_wait_gone() {
+  local session="$1" limit="$2" waited=0
+  while _ccs_dispatch_agentpager_session_alive "$session" && [ "$waited" -lt "$limit" ]; do
+    sleep 1; waited=$((waited + 1))
+  done
+}
+
+# Wait for the out.stream ($1) to stop growing (turn-end relay flushed), so a
+# fast worker's frames are captured before we stop it. Breaks after the size is
+# stable for QUIET consecutive checks, or after SETTLE seconds regardless.
+_ccs_dispatch_agentpager_wait_settle() {
+  local stream="$1"
+  local grace="${CCS_DISPATCH_AGENTPAGER_SETTLE:-8}"
+  local quiet="${CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET:-2}"
+  local last=-1 stable=0 waited=0 sz
+  while [ "$waited" -lt "$grace" ]; do
+    sz=0; [ -f "$stream" ] && sz="$(stat -c %s "$stream" 2>/dev/null || echo 0)"
+    if [ "$sz" = "$last" ]; then
+      stable=$((stable + 1)); [ "$stable" -ge "$quiet" ] && break
+    else
+      stable=0; last="$sz"
+    fi
+    sleep 1; waited=$((waited + 1))
+  done
+}
+
+# agent-pager backend spawn. Async-only: writes an inbound launch and starts a
+# background monitor, returning immediately. Returns 2 (dispatcher falls back to
+# headless) for --sync, an unresolvable proj key, or an inbound write failure.
 _ccs_dispatch_spawn_agentpager() {
-  echo "ccs-dispatch: agent-pager backend not yet implemented (stage 2)," \
-       "falling back to headless" >&2
-  return 2
+  local job_id="$1" project_dir="$2" prompt="$3" timeout_secs="$4" mode="$5"
+
+  if [ "$mode" = "sync" ]; then
+    echo "ccs-dispatch: agent-pager backend is async-only;" \
+         "falling back to headless for --sync" >&2
+    return 2
+  fi
+
+  local proj
+  if ! proj="$(_ccs_dispatch_resolve_proj_from_dir "$project_dir")"; then
+    echo "ccs-dispatch: no proj-map entry for $project_dir" \
+         "(set \$CCS_DISPATCH_PROJ_MAP or ~/.config/ccs-dashboard/proj-map);" \
+         "falling back to headless" >&2
+    return 2
+  fi
+
+  local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
+  local luser key stream start_offset=0
+  luser="$(id -un)"
+  key="local-$luser"
+
+  # Single-worker per user (key local-<user>): a second concurrent dispatch would
+  # share the same tmux session + out.stream and corrupt both jobs' output. Refuse
+  # and fall back to headless while one is already running (multi-worker is v2).
+  if _ccs_dispatch_agentpager_session_alive "agent-pager-$key"; then
+    echo "ccs-dispatch: a local agent-pager worker (agent-pager-$key) is already" \
+         "running; falling back to headless" >&2
+    return 2
+  fi
+
+  stream="$pager_dir/channels/$key/out.stream"
+  [ -f "$stream" ] && start_offset="$(stat -c %s "$stream" 2>/dev/null || echo 0)"
+
+  local worker_prompt launch_file
+  worker_prompt="$(_ccs_dispatch_agentpager_prompt "$job_id" "$prompt")"
+  if ! launch_file="$(_ccs_dispatch_agentpager_launch_file \
+        "$job_id" "$proj" "$key" "$worker_prompt" "$pager_dir")"; then
+    echo "ccs-dispatch: failed to write agent-pager launch;" \
+         "falling back to headless" >&2
+    return 2
+  fi
+
+  local dispatch_dir script_dir
+  dispatch_dir="$(_ccs_dispatch_dir)"
+  script_dir="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+  printf '%s' "$prompt" > "$dispatch_dir/results/${job_id}.prompt"
+
+  if [ "${CCS_DISPATCH_AGENTPAGER_MONITOR:-1}" = "1" ]; then
+    nohup bash -c '
+      source "$6/ccs-dashboard.sh"
+      _ccs_dispatch_agentpager_monitor "$1" "$2" "$3" "$4" "$5"
+    ' _ "$job_id" "$key" "$project_dir" "$start_offset" "$pager_dir" "$script_dir" \
+      > /dev/null 2>&1 &
+    echo $! > "$dispatch_dir/pids/${job_id}.pid"
+    disown
+  fi
+  return 0
 }
 
 _ccs_dispatch_spawn_headless() {
@@ -550,7 +892,7 @@ _ccs_jobs_show_list() {
   echo "========================"
 
   echo "$deduped" | jq -r --argjson tl "$tlen" '
-    .[] | "\(.job_id)  \((.backend // "?") | .[0:10] | . + " " * (10 - length))  \(.status | .[0:9] | . + " " * (9 - length))  \(.task | .[0:$tl])"
+    .[] | "\(.job_id)  \((.backend // "?") | .[0:10] | . + " " * (10 - length))  \(.status | .[0:13] | . + " " * (13 - length))  \(.task | .[0:$tl])"
   '
 }
 
@@ -567,6 +909,17 @@ _ccs_jobs_show_single() {
     record=$(_ccs_dispatch_jsonl_latest "$job_id")
     if [ -n "$record" ]; then
       echo "$record" | jq .
+      # For a still-running agent-pager worker, surface last-activity (out.stream
+      # mtime) so a stalled worker is visible for a manual /stop (design D2).
+      local be st
+      be=$(echo "$record" | jq -r '.backend // ""')
+      st=$(echo "$record" | jq -r '.status // ""')
+      if [ "$be" = "agentpager" ] && [ "$st" = "running" ]; then
+        local la
+        la=$(_ccs_dispatch_agentpager_last_activity \
+          "local-$(id -un)" "${AGENT_PAGER_DIR:-$HOME/.agent-pager}")
+        [ -n "$la" ] && echo "Last activity: $la"
+      fi
     else
       echo "Job not found: $job_id" >&2
       return 1

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -471,7 +471,42 @@ CCS_DISPATCH_SYNC_TIMEOUT=120     # sync 預設 timeout
 CCS_DISPATCH_TIMEOUT=600          # async 預設 timeout
 CCS_DISPATCH_RESULT_TTL_DAYS=7    # 結果檔保留天數
 CCS_DISPATCH_MAX_CONCURRENT_WARN=3  # 並行 job 警告閾值
+CCS_DISPATCH_BACKEND=auto         # auto | agentpager | headless
 ```
+
+### 後端 (Backends)
+
+ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 `auto`）：
+
+- **headless**（預設 / fallback）：用 `claude -p` 跑封閉的 one-shot worker，跑完寫
+  `results/<job-id>.md`。無需額外設定，永遠可用。
+- **agentpager**：透過 agent-pager（選用的外部工具）的 local channel 起一個**可監控的
+  互動 worker**（tmux session），輸出即時回流、可中途接管。需要 agent-pager daemon 在跑
+  且 local channel 就緒；不可用時自動 fallback 回 headless（漸進增強，不硬依賴）。
+
+`auto` 在 agent-pager 可用時選 agentpager，否則 headless。
+
+**啟用 agentpager（same-uid 個人工作流）：**
+
+1. agent-pager daemon 運行中且 `~/.agent-pager/inbound/` 存在（same-uid 免建
+   `claude-broker` 群組）。
+2. 建 `~/.config/ccs-dashboard/proj-map`（可用 `CCS_DISPATCH_PROJ_MAP` 覆寫），把專案
+   絕對路徑對應到 agent-pager 白名單裡的 key。ccs 只傳 key，實際路徑由 agent-pager 端
+   解析（key 即 RCE 邊界）：
+
+   ```
+   # <key>=<專案絕對路徑>（需與 agent-pager 白名單一致）
+   my-project=/abs/path/to/my-project
+   ```
+
+**agentpager 行為：**
+
+- **async only**：`--sync` 會 fallback 回 headless（互動 worker 可能長跑）。
+- **完成判定**：worker 完成時把交接寫到 `tmp/handoff-<job-id>.md`（開場 prompt 已注入
+  此規則）；ccs 偵測到即收席位、把交接存到 `results/<job-id>.handoff`，狀態記為
+  `handoff-ready`。無交接但 session 自行結束 → `completed`；session 從未起來 → `failed`。
+- **不自動中止**：卡住的 worker 不會被 wall-clock timeout 殺掉——在 `ccs-jobs <job-id>`
+  看 last-activity 後手動處理（MVP 單 worker per user，多 worker 為 v2）。
 
 結果存放：`${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/`
 

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -118,13 +118,13 @@ assert_eq "headless dispatch completed" "completed" "$st"
 assert_eq "spawn_headless defined" "function" "$(type -t _ccs_dispatch_spawn_headless)"
 rm -rf "$mock_dir2" "$proj"
 
-echo "=== agentpager backend stub falls back to headless ==="
+echo "=== agentpager backend falls back to headless (sync / no proj-map) ==="
 mock_dir3="$SCRIPT_DIR/tmp/test-dispatch-backend-bin3"
 proj3="$SCRIPT_DIR/tmp/test-dispatch-backend-proj3"
 mkdir -p "$mock_dir3" "$proj3"
 printf '#!/bin/bash\necho "mock result: $*"\n' > "$mock_dir3/claude"
 chmod +x "$mock_dir3/claude"
-# force agentpager; stub fails -> dispatcher falls back to headless
+# force agentpager; --sync (async-only backend) returns 2 -> dispatcher falls back
 # Capture stderr/stdout to temp file to avoid subshell (which loses variable assignments)
 tmplog="$SCRIPT_DIR/tmp/test-dispatch-backend-log3"
 CCS_DISPATCH_BACKEND=agentpager PATH="$mock_dir3:$PATH" \

--- a/tests/test-dispatch-backend.sh
+++ b/tests/test-dispatch-backend.sh
@@ -16,7 +16,7 @@ assert_eq "explicit agentpager" "agentpager" "$out"
 out=$(CCS_DISPATCH_BACKEND=bogus _ccs_dispatch_resolve_backend)
 assert_eq "invalid -> headless" "headless" "$out"
 
-echo "=== resolve_backend: auto detection ==="
+echo "=== resolve_backend: auto detection (daemon/spool gates) ==="
 mock_dir="$SCRIPT_DIR/tmp/test-dispatch-backend-bin"
 mkdir -p "$mock_dir"
 # daemon inactive (systemctl exit 3) -> headless
@@ -25,21 +25,80 @@ chmod +x "$mock_dir/systemctl"
 out=$(CCS_DISPATCH_BACKEND=auto PATH="$mock_dir:$PATH" _ccs_dispatch_resolve_backend)
 assert_eq "auto + daemon inactive -> headless" "headless" "$out"
 
-# daemon active + spool dir exists -> agentpager
+# daemon active from here on
 printf '#!/bin/bash\nexit 0\n' > "$mock_dir/systemctl"
 chmod +x "$mock_dir/systemctl"
-spool="$SCRIPT_DIR/tmp/test-dispatch-backend-spool"
-mkdir -p "$spool"
-out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$spool" PATH="$mock_dir:$PATH" \
-  _ccs_dispatch_resolve_backend)
-assert_eq "auto + active + spool -> agentpager" "agentpager" "$out"
 
-# daemon active but spool missing -> headless
+# daemon active but spool dir missing -> headless
 out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$SCRIPT_DIR/tmp/nonexistent-spool" \
   PATH="$mock_dir:$PATH" _ccs_dispatch_resolve_backend)
 assert_eq "auto + active + no spool -> headless" "headless" "$out"
 
-rm -rf "$mock_dir" "$spool"
+echo "=== resolve_backend: Hybrid Detection — same-uid (personal) ==="
+# same-uid: spool owned by the current user + inbound/ present -> agentpager,
+# skipping the claude-broker group + setgid checks (design Decision A).
+# stat/id are the REAL ones here; the test-created spool is owned by the caller.
+spool="$SCRIPT_DIR/tmp/test-dispatch-backend-spool"
+mkdir -p "$spool/inbound"
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$spool" PATH="$mock_dir:$PATH" \
+  _ccs_dispatch_resolve_backend)
+assert_eq "same-uid + active + inbound -> agentpager" "agentpager" "$out"
+
+# same-uid but inbound/ missing -> headless (local channel not initialized)
+spool_ni="$SCRIPT_DIR/tmp/test-dispatch-backend-spool-noinbound"
+mkdir -p "$spool_ni"
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$spool_ni" PATH="$mock_dir:$PATH" \
+  _ccs_dispatch_resolve_backend)
+assert_eq "same-uid + active + no inbound -> headless" "headless" "$out"
+
+rm -rf "$mock_dir" "$spool" "$spool_ni"
+
+echo "=== resolve_backend: Hybrid Detection — cross-uid (shared seat) ==="
+# Cross-uid path: spool owned by a DIFFERENT user. stat/id are mocked so the
+# ownership + broker-group + setgid strict checks run without needing root.
+xbin="$SCRIPT_DIR/tmp/test-dispatch-backend-xbin"
+mkdir -p "$xbin"
+printf '#!/bin/bash\nexit 0\n' > "$xbin/systemctl"
+cat > "$xbin/stat" <<'EOF'
+#!/bin/bash
+# mock: stat -c %u <path>  /  stat -c %G <path>
+case "$2" in
+  %u) echo "${MOCK_STAT_U:-0}" ;;
+  %G) echo "${MOCK_STAT_G:-nogroup}" ;;
+  *)  exit 1 ;;
+esac
+EOF
+cat > "$xbin/id" <<'EOF'
+#!/bin/bash
+case "$1" in
+  -u)  echo "${MOCK_ID_U:-1000}" ;;
+  -un) echo "${MOCK_ID_UN:-tester}" ;;
+  -nG) echo "${MOCK_ID_GROUPS:-tester}" ;;
+esac
+EOF
+chmod +x "$xbin"/*
+xspool="$SCRIPT_DIR/tmp/test-dispatch-backend-xspool"
+mkdir -p "$xspool/inbound"
+
+# cross-uid (owner 4242 != caller 1000) + caller NOT in claude-broker -> headless
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$xspool" \
+  MOCK_STAT_U=4242 MOCK_ID_U=1000 MOCK_ID_UN=tester MOCK_ID_GROUPS="tester users" \
+  MOCK_STAT_G=nogroup PATH="$xbin:$PATH" _ccs_dispatch_resolve_backend)
+assert_eq "cross-uid + not in broker -> headless" "headless" "$out"
+
+# cross-uid + in claude-broker + inbound setgid to claude-broker -> agentpager
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$xspool" \
+  MOCK_STAT_U=4242 MOCK_ID_U=1000 MOCK_ID_UN=tester MOCK_ID_GROUPS="tester claude-broker" \
+  MOCK_STAT_G=claude-broker PATH="$xbin:$PATH" _ccs_dispatch_resolve_backend)
+assert_eq "cross-uid + broker group + setgid -> agentpager" "agentpager" "$out"
+
+# cross-uid + in claude-broker but inbound NOT setgid claude-broker -> headless
+out=$(CCS_DISPATCH_BACKEND=auto AGENT_PAGER_DIR="$xspool" \
+  MOCK_STAT_U=4242 MOCK_ID_U=1000 MOCK_ID_UN=tester MOCK_ID_GROUPS="tester claude-broker" \
+  MOCK_STAT_G=othergroup PATH="$xbin:$PATH" _ccs_dispatch_resolve_backend)
+assert_eq "cross-uid + broker group + no setgid -> headless" "headless" "$out"
+
+rm -rf "$xbin" "$xspool"
 
 echo "=== dispatcher routes to headless (behavior unchanged) ==="
 mock_dir2="$SCRIPT_DIR/tmp/test-dispatch-backend-bin2"

--- a/tests/test-dispatch-framed.sh
+++ b/tests/test-dispatch-framed.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tests for _ccs_consume_framed_stream — agent-pager local-channel framed
+# protocol parser (Stage 2). Pure unit test: no daemon/tmux/claude.
+#
+# Frame layout (agent-pager notify-send.sh local sink):
+#   <RS>MSG<US><LABEL><RS>\n<BODY>\n<RS>END<RS>\n   (RS=0x1E, US=0x1F)
+# Parser emits each frame's BODY to stdout, one per frame, newline-joined.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$REPO_DIR/ccs-dispatch.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL: %s\n' "$1"; }
+
+RS=$'\x1e'; US=$'\x1f'
+# emit one frame: $1=label $2=body
+frame() { printf '%sMSG%s%s%s\n%s\n%sEND%s\n' "$RS" "$US" "$1" "$RS" "$2" "$RS" "$RS"; }
+
+test_single_frame() {
+  local out; out="$(frame 'host · proj' 'hello world' | _ccs_consume_framed_stream)"
+  [ "$out" = "hello world" ] && ok "single frame body extracted" \
+    || bad "single frame (got: '$out')"
+}
+
+test_multi_frame() {
+  local out; out="$( { frame 'h · p' 'first'; frame 'h · p' 'second'; } \
+    | _ccs_consume_framed_stream )"
+  [ "$out" = $'first\nsecond' ] && ok "multi frame bodies in order" \
+    || bad "multi frame (got: '$out')"
+}
+
+test_body_with_newlines() {
+  local out; out="$(frame 'h · p' $'line1\nline2' | _ccs_consume_framed_stream)"
+  [ "$out" = $'line1\nline2' ] && ok "multiline body preserved" \
+    || bad "multiline (got: '$out')"
+}
+
+test_empty_input() {
+  local out; out="$(printf '' | _ccs_consume_framed_stream)"
+  [ -z "$out" ] && ok "empty input -> empty output" || bad "empty (got: '$out')"
+}
+
+test_label_ignored() {
+  local out; out="$(frame 'arbitrary-label-123' 'payload' | _ccs_consume_framed_stream)"
+  [ "$out" = "payload" ] && ok "label ignored, body extracted" \
+    || bad "label (got: '$out')"
+}
+
+test_reads_file_arg() {
+  local tmp; tmp="$(mktemp "$SCRIPT_DIR/tmp.framed.XXXXXX")"
+  frame 'h · p' 'from-file' > "$tmp"
+  local out; out="$(_ccs_consume_framed_stream "$tmp")"
+  rm -f "$tmp"
+  [ "$out" = "from-file" ] && ok "reads file argument" || bad "file arg (got: '$out')"
+}
+
+run() {
+  test_single_frame
+  test_multi_frame
+  test_body_with_newlines
+  test_empty_input
+  test_label_ignored
+  test_reads_file_arg
+  printf '\n--- %d passed, %d failed ---\n' "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ]
+}
+run

--- a/tests/test-dispatch-proj.sh
+++ b/tests/test-dispatch-proj.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Tests for _ccs_dispatch_resolve_proj_from_dir — map an absolute
+# project_dir to the lead-side proj key for the inbound .md (Stage 2).
+# ccs keeps its OWN map (CCS_DISPATCH_PROJ_MAP, format "key = abspath",
+# mirroring the lead whitelist) and never reads the lead's file.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$REPO_DIR/ccs-dispatch.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok: %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL: %s\n' "$1"; }
+
+MAP="$(mktemp "$SCRIPT_DIR/tmp.projmap.XXXXXX")"
+cat > "$MAP" <<'EOF'
+# ccs proj map (key = abspath, mirrors lead whitelist keys)
+demo = /pool2/chenhsun/tools/ccs-dashboard
+other = /home/x/work/other
+EOF
+export CCS_DISPATCH_PROJ_MAP="$MAP"
+cleanup() { rm -f "$MAP"; }
+trap cleanup EXIT
+
+test_exact_match() {
+  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard)"
+  [ "$got" = "demo" ] && ok "exact path -> key" || bad "exact (got: '$got')"
+}
+test_trailing_slash() {
+  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard/)"
+  [ "$got" = "demo" ] && ok "trailing slash normalized" || bad "trailing slash (got: '$got')"
+}
+test_second_entry() {
+  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /home/x/work/other)"
+  [ "$got" = "other" ] && ok "second entry resolves" || bad "second (got: '$got')"
+}
+test_no_match() {
+  _ccs_dispatch_resolve_proj_from_dir /no/such/dir >/dev/null 2>&1 \
+    && bad "no match should fail" || ok "no match -> rc!=0"
+}
+test_missing_map() {
+  ( export CCS_DISPATCH_PROJ_MAP=/no/such/map
+    _ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard >/dev/null 2>&1 ) \
+    && bad "missing map should fail" || ok "missing map -> rc!=0"
+}
+
+run() {
+  test_exact_match
+  test_trailing_slash
+  test_second_entry
+  test_no_match
+  test_missing_map
+  printf '\n--- %d passed, %d failed ---\n' "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ]
+}
+run

--- a/tests/test-dispatch-spawn-agentpager.sh
+++ b/tests/test-dispatch-spawn-agentpager.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-spawn-agentpager.sh — agent-pager spawn backend (stage 2)
+# Unit coverage for the spawn helpers. The live monitor loop (tmux + real
+# worker) is covered by E2E, not here; spawn tests set
+# CCS_DISPATCH_AGENTPAGER_MONITOR=0 to skip starting the background monitor.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+RS=$'\x1e'; US=$'\x1f'
+
+echo "=== worker prompt carries handoff-gating invariant ==="
+p="$(_ccs_dispatch_agentpager_prompt "d-test-1234" $'VERIFICATION RULE ...\nTask: do X')"
+assert_contains "prompt keeps original task" "$p" "Task: do X"
+assert_contains "prompt names per-job handoff file" "$p" "tmp/handoff-d-test-1234.md"
+assert_contains "prompt references the job id" "$p" "d-test-1234"
+
+echo "=== launch file has valid frontmatter + body ==="
+tmproot="$SCRIPT_DIR/tmp/test-spawn-ap-pager"
+rm -rf "$tmproot"; mkdir -p "$tmproot"
+lf="$(_ccs_dispatch_agentpager_launch_file "d-test-1234" "ccs-dashboard" "local-tester" "hello worker body" "$tmproot")"
+assert_eq "launch file created" "yes" "$([ -f "$lf" ] && echo yes)"
+# parse the same way inbound-handler.sh does (parse_field + get_body)
+kind=$(sed -n 's/^kind: //p' "$lf" | head -1)
+slot=$(sed -n 's/^slot: //p' "$lf" | head -1)
+projk=$(sed -n 's/^proj: //p' "$lf" | head -1)
+body=$(awk 'f>=2{print; next} /^---$/{f++}' "$lf")
+assert_eq "kind is launch" "launch" "$kind"
+assert_eq "slot is the local key" "local-tester" "$slot"
+assert_eq "proj is the resolved key" "ccs-dashboard" "$projk"
+assert_contains "body carries the worker prompt" "$body" "hello worker body"
+
+echo "=== stop file targets the local key ==="
+sf="$(_ccs_dispatch_agentpager_stop_file "local-tester" "$tmproot")"
+assert_eq "stop kind" "stop" "$(sed -n 's/^kind: //p' "$sf" | head -1)"
+assert_eq "stop slot" "local-tester" "$(sed -n 's/^slot: //p' "$sf" | head -1)"
+rm -rf "$tmproot"
+
+echo "=== collect emits only this job's frames (byte offset) ==="
+strm="$SCRIPT_DIR/tmp/test-spawn-ap.stream"
+# a previous job's frame already in the per-user stream (append-only, persists)
+printf '%sMSG%sprev%s\nOLD BODY\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" > "$strm"
+off=$(stat -c %s "$strm")
+# this job's frames appended after the launch offset
+printf '%sMSG%stool%s\nran build\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" >> "$strm"
+printf '%sMSG%sprose%s\ndone task\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" >> "$strm"
+dest="$SCRIPT_DIR/tmp/test-spawn-ap.raw"
+_ccs_dispatch_agentpager_collect "$strm" "$off" "$dest"
+got="$(cat "$dest")"
+assert_contains "collect has this-job frame 1" "$got" "ran build"
+assert_contains "collect has this-job frame 2" "$got" "done task"
+assert_not_contains "collect excludes previous job's frame" "$got" "OLD BODY"
+rm -f "$strm" "$dest"
+
+echo "=== finish with handoff -> handoff-ready ==="
+dd="$(_ccs_dispatch_dir)"
+jid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$jid" --arg p "myproj" \
+  --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:$p,backend:"agentpager",created_at:$ca,status:"running"}')"
+printf 'raw output line\n' > "$dd/results/${jid}.raw"
+hf="$SCRIPT_DIR/tmp/handoff-${jid}.md"
+printf '# handoff\nstuff\n' > "$hf"
+_ccs_dispatch_finish_agentpager "$jid" "$hf"
+st=$(_ccs_dispatch_jsonl_latest "$jid" | jq -r '.status')
+assert_eq "status is handoff-ready" "handoff-ready" "$st"
+assert_eq "handoff captured to results" "yes" "$([ -f "$dd/results/${jid}.handoff" ] && echo yes)"
+assert_contains ".md carries the raw output" "$(cat "$dd/results/${jid}.md")" "raw output line"
+rm -f "$hf" "$dd/results/${jid}".*
+
+echo "=== finish without handoff -> completed ==="
+jid2="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$jid2" --arg p "myproj" \
+  --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:$p,backend:"agentpager",created_at:$ca,status:"running"}')"
+printf 'some output\n' > "$dd/results/${jid2}.raw"
+_ccs_dispatch_finish_agentpager "$jid2" "$SCRIPT_DIR/tmp/nonexistent-handoff.md"
+st2=$(_ccs_dispatch_jsonl_latest "$jid2" | jq -r '.status')
+assert_eq "status is completed (no handoff)" "completed" "$st2"
+assert_eq "no stray handoff file" "no" "$([ -f "$dd/results/${jid2}.handoff" ] && echo yes || echo no)"
+rm -f "$dd/results/${jid2}".*
+
+echo "=== spawn is async-only: --sync falls back (rc 2) ==="
+rc=0
+_ccs_dispatch_spawn_agentpager "d-sync" "$SCRIPT_DIR" "prompt" 60 sync >/dev/null 2>&1 || rc=$?
+assert_eq "sync -> rc 2 (fall back to headless)" "2" "$rc"
+
+echo "=== spawn falls back when proj-map cannot resolve (rc 2) ==="
+rc=0
+CCS_DISPATCH_PROJ_MAP="$SCRIPT_DIR/tmp/nonexistent-projmap" \
+  _ccs_dispatch_spawn_agentpager "d-noproj" "$SCRIPT_DIR" "prompt" 60 async \
+  >/dev/null 2>&1 || rc=$?
+assert_eq "no proj-map -> rc 2 (fall back to headless)" "2" "$rc"
+
+echo "=== spawn (async) writes launch inbound when proj resolves ==="
+_ccs_dispatch_agentpager_session_alive() { return 1; }  # no live seat -> guard passes
+projdir="$SCRIPT_DIR/tmp/test-spawn-ap-proj"; mkdir -p "$projdir"
+pmap="$SCRIPT_DIR/tmp/test-spawn-ap-projmap"
+printf 'ccs-dashboard = %s\n' "$projdir" > "$pmap"
+pager="$SCRIPT_DIR/tmp/test-spawn-ap-pager2"; mkdir -p "$pager/inbound"
+rc=0
+CCS_DISPATCH_PROJ_MAP="$pmap" AGENT_PAGER_DIR="$pager" \
+  CCS_DISPATCH_AGENTPAGER_MONITOR=0 \
+  _ccs_dispatch_spawn_agentpager "d-ok" "$projdir" "the prompt body" 60 async \
+  >/dev/null 2>&1 || rc=$?
+assert_eq "async spawn returns 0" "0" "$rc"
+found=$(ls "$pager/inbound/"*-d-ok.md 2>/dev/null | head -1)
+assert_eq "launch inbound written" "yes" "$([ -n "$found" ] && echo yes)"
+assert_contains "inbound is a launch" "$(cat "$found" 2>/dev/null)" "kind: launch"
+assert_contains "inbound carries the worker prompt" "$(cat "$found" 2>/dev/null)" "the prompt body"
+assert_contains "inbound carries handoff-gating invariant" "$(cat "$found" 2>/dev/null)" "tmp/handoff-d-ok.md"
+rm -rf "$projdir" "$pmap" "$pager"
+
+echo "=== last-activity reflects the out.stream mtime ==="
+la_root="$SCRIPT_DIR/tmp/test-spawn-ap-la"
+mkdir -p "$la_root/channels/local-tester"
+printf 'x' > "$la_root/channels/local-tester/out.stream"
+la="$(_ccs_dispatch_agentpager_last_activity "local-tester" "$la_root")"
+assert_contains "last-activity is an ISO timestamp" "$la" "$(date +%Y)"
+la2="$(_ccs_dispatch_agentpager_last_activity "local-nostream" "$la_root")"
+assert_eq "no stream -> empty last-activity" "" "$la2"
+rm -rf "$la_root"
+
+echo "=== ccs-jobs single view shows last-activity for a running agentpager job ==="
+dd="$(_ccs_dispatch_dir)"
+jid3="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$jid3" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+echo $$ > "$dd/pids/${jid3}.pid"   # live pid so sync_status keeps it running
+apdir="$SCRIPT_DIR/tmp/test-spawn-ap-jobs"
+mkdir -p "$apdir/channels/local-$(id -un)"
+printf 'frame' > "$apdir/channels/local-$(id -un)/out.stream"
+out="$(AGENT_PAGER_DIR="$apdir" ccs-jobs "$jid3" 2>/dev/null)"
+assert_contains "single view shows Last activity" "$out" "Last activity:"
+rm -rf "$apdir"; rm -f "$dd/pids/${jid3}.pid" "$dd/results/${jid3}".*
+
+echo "=== monitor tolerates worker-startup lag, then finalizes handoff-ready ==="
+# Regression: the runner spawns the tmux worker a few seconds AFTER ccs writes
+# the launch, so has-session is false when the monitor starts. The monitor must
+# WAIT for the session to appear, not conclude "already gone" and finalize early.
+dd="$(_ccs_dispatch_dir)"
+mjid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$mjid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+mroot="$SCRIPT_DIR/tmp/test-spawn-ap-monitor"
+rm -rf "$mroot"; mkdir -p "$mroot/channels/local-tester" "$mroot/proj/tmp"
+export _MON_CNT="$mroot/salive.count"; echo 0 > "$_MON_CNT"
+export _MON_STREAM="$mroot/channels/local-tester/out.stream"
+export _MON_HANDOFF="$mroot/proj/tmp/handoff-${mjid}.md"
+# mock: session is NOT up for the first 2 checks (startup lag); on the 3rd check
+# it comes up and the worker emits a frame + writes its handoff; then it ends.
+_ccs_dispatch_agentpager_session_alive() {
+  local n; n=$(( $(cat "$_MON_CNT") + 1 )); echo "$n" > "$_MON_CNT"
+  if [ "$n" -eq 3 ]; then
+    printf '%sMSG%stool%s\nworker did work\n%sEND%s\n' \
+      "$RS" "$US" "$RS" "$RS" "$RS" > "$_MON_STREAM"
+    printf '# handoff\n' > "$_MON_HANDOFF"
+  fi
+  [ "$n" -le 2 ] && return 1
+  [ "$n" -le 4 ] && return 0
+  return 1
+}
+# stub stop so the test never writes to a real inbound
+_ccs_dispatch_agentpager_stop_file() { :; }
+CCS_DISPATCH_AGENTPAGER_STARTUP=10 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+  CCS_DISPATCH_AGENTPAGER_SETTLE=1 CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET=1 \
+  _ccs_dispatch_agentpager_monitor "$mjid" "local-tester" "$mroot/proj" 0 "$mroot"
+mst=$(_ccs_dispatch_jsonl_latest "$mjid" | jq -r '.status')
+assert_eq "monitor finalized handoff-ready (not premature completed)" "handoff-ready" "$mst"
+assert_contains "monitor collected the worker's frame, not just the banner" \
+  "$(cat "$dd/results/${mjid}.md" 2>/dev/null)" "worker did work"
+unset _MON_CNT _MON_STREAM _MON_HANDOFF
+rm -rf "$mroot"; rm -f "$dd/results/${mjid}".*
+
+echo "=== spawn refuses when a local worker is already running (rc 2) ==="
+_ccs_dispatch_agentpager_session_alive() { return 0; }  # simulate a live seat
+gpd="$SCRIPT_DIR/tmp/test-spawn-ap-guard-proj"; mkdir -p "$gpd"
+gpm="$SCRIPT_DIR/tmp/test-spawn-ap-guard-map"; printf 'ccs-dashboard = %s\n' "$gpd" > "$gpm"
+gpg="$SCRIPT_DIR/tmp/test-spawn-ap-guard-pager"; mkdir -p "$gpg/inbound"
+rc=0
+CCS_DISPATCH_PROJ_MAP="$gpm" AGENT_PAGER_DIR="$gpg" CCS_DISPATCH_AGENTPAGER_MONITOR=0 \
+  _ccs_dispatch_spawn_agentpager "d-guard" "$gpd" "p" 60 async >/dev/null 2>&1 || rc=$?
+assert_eq "already-running local seat -> rc 2 (fall back)" "2" "$rc"
+assert_eq "no launch written when refused" "no" \
+  "$([ -n "$(ls "$gpg/inbound/"*-d-guard.md 2>/dev/null)" ] && echo yes || echo no)"
+rm -rf "$gpd" "$gpm" "$gpg"
+
+echo "=== finish: never-observed launch -> failed (not completed) ==="
+fjid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$fjid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+printf 'x\n' > "$dd/results/${fjid}.raw"
+_ccs_dispatch_finish_agentpager "$fjid" "$SCRIPT_DIR/tmp/nope-handoff.md" "failed"
+assert_eq "no handoff + failed floor -> failed" "failed" \
+  "$(_ccs_dispatch_jsonl_latest "$fjid" | jq -r '.status')"
+rm -f "$dd/results/${fjid}".*
+
+echo "=== finish: whitespace-only raw -> (no output) ==="
+zjid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$zjid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+printf '\n' > "$dd/results/${zjid}.raw"   # lone newline = zero-frame collect output
+zhf="$SCRIPT_DIR/tmp/handoff-${zjid}.md"; printf '# h\n' > "$zhf"
+_ccs_dispatch_finish_agentpager "$zjid" "$zhf"
+assert_contains "blank raw renders (no output)" \
+  "$(cat "$dd/results/${zjid}.md")" "(no output)"
+rm -f "$zhf" "$dd/results/${zjid}".*
+
+echo "=== ccs-jobs list shows full handoff-ready status (not truncated) ==="
+hjid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$hjid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$hjid" --arg fa "$(date -Iseconds)" \
+  '{job_id:$jid,status:"handoff-ready",finished_at:$fa,handoff:true}')"
+assert_contains "list shows full handoff-ready" "$(ccs-jobs 2>/dev/null)" "handoff-ready"
+
+echo "=== monitor resolves handoff path from agent-pager state cwd (no drift) ==="
+f3jid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$f3jid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+f3="$SCRIPT_DIR/tmp/test-spawn-ap-mon3"
+rm -rf "$f3"; mkdir -p "$f3/channels/local-tester" "$f3/state/sessions" \
+  "$f3/realcwd/tmp" "$f3/wrongcwd/tmp"
+printf '{"key":"local-tester","cwd":"%s","channel":"local"}\n' "$f3/realcwd" \
+  > "$f3/state/sessions/local-tester.json"
+printf '# h\n' > "$f3/realcwd/tmp/handoff-${f3jid}.md"   # handoff in the REAL cwd
+printf '%sMSG%st%s\ndid work\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" \
+  > "$f3/channels/local-tester/out.stream"
+export _M3="$f3/cnt"; echo 0 > "$_M3"
+_ccs_dispatch_agentpager_session_alive() {
+  local n; n=$(( $(cat "$_M3") + 1 )); echo "$n" > "$_M3"; [ "$n" -le 1 ]; }
+_ccs_dispatch_agentpager_stop_file() { :; }
+CCS_DISPATCH_AGENTPAGER_STARTUP=5 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+  CCS_DISPATCH_AGENTPAGER_STOP_WAIT=1 \
+  CCS_DISPATCH_AGENTPAGER_SETTLE=1 CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET=1 \
+  _ccs_dispatch_agentpager_monitor "$f3jid" "local-tester" "$f3/wrongcwd" 0 "$f3"
+assert_eq "handoff found via state cwd -> handoff-ready" "handoff-ready" \
+  "$(_ccs_dispatch_jsonl_latest "$f3jid" | jq -r '.status')"
+unset _M3; rm -rf "$f3"; rm -f "$dd/results/${f3jid}".*
+
+echo "=== monitor: session never appears -> failed ==="
+gjid="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$gjid" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+groot="$SCRIPT_DIR/tmp/test-spawn-ap-mon1"; rm -rf "$groot"; mkdir -p "$groot/channels/local-tester"
+_ccs_dispatch_agentpager_session_alive() { return 1; }  # never comes up
+CCS_DISPATCH_AGENTPAGER_STARTUP=2 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+  _ccs_dispatch_agentpager_monitor "$gjid" "local-tester" "$groot" 0 "$groot"
+assert_eq "never-observed session -> failed" "failed" \
+  "$(_ccs_dispatch_jsonl_latest "$gjid" | jq -r '.status')"
+rm -rf "$groot"; rm -f "$dd/results/${gjid}".*
+
+echo "=== monitor: stop unhonored -> retries + handoff-ready + note ==="
+hjid2="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$hjid2" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
+hroot="$SCRIPT_DIR/tmp/test-spawn-ap-mon2"; rm -rf "$hroot"
+mkdir -p "$hroot/channels/local-tester" "$hroot/proj/tmp"
+printf '# h\n' > "$hroot/proj/tmp/handoff-${hjid2}.md"
+printf '%sMSG%st%s\nwork\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" \
+  > "$hroot/channels/local-tester/out.stream"
+_ccs_dispatch_agentpager_session_alive() { return 0; }  # never stops
+export _HSTOP="$hroot/stopcnt"; echo 0 > "$_HSTOP"
+_ccs_dispatch_agentpager_stop_file() { echo $(( $(cat "$_HSTOP") + 1 )) > "$_HSTOP"; }
+CCS_DISPATCH_AGENTPAGER_STARTUP=2 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+  CCS_DISPATCH_AGENTPAGER_STOP_WAIT=1 \
+  CCS_DISPATCH_AGENTPAGER_SETTLE=1 CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET=1 \
+  _ccs_dispatch_agentpager_monitor "$hjid2" "local-tester" "$hroot/proj" 0 "$hroot"
+assert_eq "handoff captured despite failed stop -> handoff-ready" "handoff-ready" \
+  "$(_ccs_dispatch_jsonl_latest "$hjid2" | jq -r '.status')"
+assert_eq "stop re-sent (>=2 attempts)" "yes" \
+  "$([ "$(cat "$_HSTOP")" -ge 2 ] && echo yes || echo no)"
+assert_contains "note records the unstopped worker" \
+  "$(cat "$dd/results/${hjid2}.md")" "did not stop"
+unset _HSTOP; rm -rf "$hroot"; rm -f "$dd/results/${hjid2}".*
+
+test_summary


### PR DESCRIPTION
## Summary

Stage 2 整合：`ccs-dispatch` 新增 agent-pager local-channel 後端，把 worker 從封閉的 headless `claude -p` 換成**可監控的互動 tmux worker**（可看進度、可接管、可 escalate），agent-pager 不可用時自動 fallback 回 headless（漸進增強，不硬依賴內部工具）。含 same-uid Hybrid Detection，個人工作流免建 `claude-broker` 群組即可用。

## Changes

- **feat(dispatch): hybrid-detect agent-pager backend** — `_ccs_dispatch_agentpager_available` 雙軌：same-uid（spool 屬當前 user）跳過 broker 群組 + setgid 檢查；cross-uid 保留嚴格校驗。
- **feat(dispatch): add agent-pager local-channel spawn backend** — 寫 inbound launch（只傳 proj key，路徑由 agent-pager 解析＝RCE 邊界）→ 背景 monitor（handoff 檔觸發收席位）→ handoff gating（`handoff-ready`）。async-only、無 auto-kill、併發 guard、fallback 保底。
- **docs(dispatch): document agent-pager backend and proj-map setup** — `docs/commands.md` 後端章節 + `CHANGELOG` Unreleased。

## Test plan (reviewer checklist)

- [x] `bash tests/run-all.sh` 全綠
- [x] 真機 same-uid `_ccs_dispatch_resolve_backend`（auto）回 `agentpager`
- [x] 真機 happy-path E2E：dispatch → out.stream 回流 `results/<id>.raw` → `handoff-ready` + `.handoff` 捕獲 + 乾淨收席位
- [ ] cross-uid 嚴格路徑真機驗證（本機無 `claude-broker` 群組；目前單元 mock 覆蓋，多人共享環境待驗）

## Test results (author 已驗)

**Unit tests：** `bash tests/run-all.sh` → 21 suites passed, 0 failed, 1 skipped（`test-crash-detect`，需 live data）。其中 backend resolver 21、spawn backend 40 assertions 全綠。

**E2E tests：** 3 次真機 dispatch（agentpager 後端）皆達 `handoff-ready`——worker 執行任務、把交接寫到 `tmp/handoff-<id>.md`、monitor 偵測後送 `kind: stop` 收席位、out.stream 回流進 `.raw`、`.handoff` 捕獲、無孤兒進程。另以 `INBOUND_DRYRUN` 乾式驗證 launch 格式被 agent-pager 正確 parse（owner-uid、proj 解析、channel 路由）。

**Smoke tests：** N/A — 無 device smoke，涵蓋於上述 E2E。

## Reviewer summary

獨立 capable code reviewer（verdict: fix-first）：happy path 穩、fallback 接線正確、無 showstopper。6 findings + 併發 spawn guard 已全數修復並補測試：never-observed → `failed`（非 completed）、stop 逾時重試 + note、handoff watch 路徑改讀 agent-pager state json 的實際 cwd（根除 proj-map drift）、`ccs-jobs` status 欄寬、zero-frame `.raw` → `(no output)`、`cp` 失敗不謊稱 handoff-ready。二次真機 E2E 另抓到並修好兩個 timing bug：monitor 早於 worker session 出現的競態、stop 太早截斷輸出（settle-before-stop + invariant 改「總結先、handoff 最後寫」）。

## Carry-forward Minor items

- worker turn-end 最後一行總結 prose 偶爾被截於 `.raw`（Stop-hook relay 殘留競態）→ v1.1 pane idle 偵測根除；完整結果永遠在 `.handoff`（權威交付物）。
- multi-worker per user（key `local-<user>-<n>`）→ v2。
- Task 3：`ccs-jobs` 完整對齊 agentpager 進度 + `handoff-ready` 看板整合。

## Related

- Design / Plan：repo 內 `internal/`（依 AGENTS.md gitignore，不 commit）。
- 前置依賴：agent-pager（選用外部工具）的 local channel（漸進增強；不可用時 fallback headless）。