### PR TITLE
feat(jobs): surface agent-pager backend progress + handoff-ready in ccs-jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 
 - `ccs-failure-triage`: triage a session for model confabulation-family failure signals (Sub-pattern A/B/C/D). Includes 5 automated forensic checks and writes a report to `<project>/tmp/`. See `docs/failure-triage.md`.
 - **ccs-dispatch agent-pager backend** — optional local-channel worker backend (`CCS_DISPATCH_BACKEND=agentpager`, auto-detected) that runs a monitorable interactive worker via agent-pager instead of headless `claude -p`. Same-uid hybrid detection needs no `claude-broker` group; projects map to agent-pager keys via `~/.config/ccs-dashboard/proj-map`. Handoff-driven completion (`handoff-ready` status), async-only, and falls back to headless when agent-pager is unavailable. See `docs/commands.md`.
+- **ccs-jobs agent-pager visibility** — the list shows a running agent-pager worker's last-activity in a footer line, and the single-job view hints the `.handoff` path plus a prefilled follow-up `ccs-dispatch` template on handoff-ready jobs. (PR #72)
+
+### Fixed
+
+- `ccs-jobs` status sync is now agent-pager-aware: resolves effective status via the same reduce-merge as the board (fallback markers no longer skip liveness), uses the worker tmux session instead of the monitor pid as the liveness signal, and defers to a live monitor during worker startup to avoid falsely completing a just-dispatched job. (PR #72)
 
 ## [0.3.3] — 2026-04-17
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -869,8 +869,17 @@ _ccs_jobs_sync_status() {
     backend=$(echo "$merged" | jq -r '.backend // "headless"')
 
     if [ "$backend" = "agentpager" ]; then
-      # Agentpager: the worker's tmux session — not the background monitor's pid —
-      # is the liveness signal (the monitor can die independently of the worker).
+      # Defer to a live monitor: it owns startup grace (the worker's tmux session
+      # appears a few seconds after dispatch), handoff detection, stop, and
+      # finalize. sync must not race ahead of it — during that startup window the
+      # session is legitimately absent, and finalizing here would falsely complete
+      # a job that is merely starting. sync only reconciles a monitor that is gone.
+      local pidfile="$dispatch_dir/pids/${jid}.pid"
+      if [ -f "$pidfile" ] && kill -0 "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null; then
+        continue
+      fi
+      # Monitor is gone (died / never started). The worker's tmux session — not
+      # the monitor pid — is now the liveness signal.
       if _ccs_dispatch_agentpager_session_alive "agent-pager-$key"; then
         [ "$jid" = "$newest_ap_jid" ] && continue   # live worker, still running
         # An older running record is stale (a newer worker owns the session). If

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -846,20 +846,57 @@ _ccs_jobs_sync_status() {
 
   local jids
   jids=$(jq -r 'select(.status=="running") | .job_id' "$jobs_file" | sort -u)
+
+  # Which running agentpager job owns the (per-user, shared-name) tmux session:
+  # the newest by created_at. The spawn guard admits at most one live worker, so
+  # older running agentpager records are stale (monitor died before finalizing).
+  local newest_ap_jid
+  newest_ap_jid=$(jq -rs '
+    group_by(.job_id) | map(reduce .[] as $r ({}; . + $r))
+    | map(select(.status=="running" and .backend=="agentpager"))
+    | sort_by(.created_at) | reverse | .[0].job_id // empty' "$jobs_file")
+
+  local key="local-$(id -un)"
   local jid
   for jid in $jids; do
-    local latest_status
-    latest_status=$(grep "\"job_id\":\"$jid\"" "$jobs_file" | tail -1 | jq -r '.status')
-    [ "$latest_status" = "running" ] || continue
+    # Effective status = reduce-merge (consistent with the board's show_list),
+    # not tail -1 of the last raw record — a trailing fallback marker has no
+    # status field and would otherwise read as null and skip this job.
+    local merged status backend
+    merged=$(_ccs_dispatch_jsonl_latest "$jid")
+    status=$(echo "$merged" | jq -r '.status // ""')
+    [ "$status" = "running" ] || continue
+    backend=$(echo "$merged" | jq -r '.backend // "headless"')
 
+    if [ "$backend" = "agentpager" ]; then
+      # Agentpager: the worker's tmux session — not the background monitor's pid —
+      # is the liveness signal (the monitor can die independently of the worker).
+      if _ccs_dispatch_agentpager_session_alive "agent-pager-$key"; then
+        [ "$jid" = "$newest_ap_jid" ] && continue   # live worker, still running
+        _ccs_dispatch_jsonl_append "$(jq -nc \
+          --arg jid "$jid" --arg fa "$(date -Iseconds)" \
+          '{job_id:$jid, status:"completed", finished_at:$fa,
+            note:"superseded; monitor exited"}')"
+        continue
+      fi
+      # Session gone. The monitor normally finalizes; if it did (md present),
+      # leave it alone. If not, reconcile to completed without doing the monitor's
+      # heavy finalize (stream/handoff capture) — design Q1=C keeps sync light.
+      [ -f "$dispatch_dir/results/${jid}.md" ] && continue
+      _ccs_dispatch_jsonl_append "$(jq -nc \
+        --arg jid "$jid" --arg fa "$(date -Iseconds)" \
+        '{job_id:$jid, status:"completed", finished_at:$fa,
+          note:"monitor exited without finalizing; session gone"}')"
+      continue
+    fi
+
+    # Headless (unchanged): the pidfile IS the worker; dead pid + no md = crash.
     local pidfile="$dispatch_dir/pids/${jid}.pid"
     if [ -f "$pidfile" ]; then
       kill -0 "$(cat "$pidfile")" 2>/dev/null && continue
     fi
-
     local md="$dispatch_dir/results/${jid}.md"
     [ -f "$md" ] && continue
-
     _ccs_dispatch_jsonl_append "$(jq -nc \
       --arg jid "$jid" \
       --arg fa "$(date -Iseconds)" \

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -931,6 +931,17 @@ _ccs_jobs_show_list() {
   echo "$deduped" | jq -r --argjson tl "$tlen" '
     .[] | "\(.job_id)  \((.backend // "?") | .[0:10] | . + " " * (10 - length))  \(.status | .[0:13] | . + " " * (13 - length))  \(.task | .[0:$tl])"
   '
+
+  # Q2=A: last-activity footer for the newest running agentpager worker (the one
+  # that owns the live tmux session). deduped is sorted created_at desc, so the
+  # first running+agentpager entry is the newest.
+  local running_ap
+  running_ap=$(echo "$deduped" | jq -r \
+    'map(select(.status=="running" and .backend=="agentpager")) | .[0].job_id // empty')
+  if [ -n "$running_ap" ]; then
+    _ccs_jobs_agentpager_footer "local-$(id -un)" \
+      "${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
+  fi
 }
 
 _ccs_jobs_show_single() {
@@ -962,6 +973,24 @@ _ccs_jobs_show_single() {
       return 1
     fi
   fi
+}
+
+# Echo a one-line last-activity footer for the running agentpager worker so a
+# stalled worker is visible on the board for a manual /stop (design D2/Q2=A).
+# Single-worker MVP: at most one running agentpager worker, so one line suffices.
+_ccs_jobs_agentpager_footer() {
+  local key="$1" pager_dir="$2"
+  local stream="$pager_dir/channels/$key/out.stream"
+  if [ ! -f "$stream" ]; then
+    printf '⏱ local worker: no output yet\n'
+    return 0
+  fi
+  local mtime now idle_min iso
+  mtime=$(stat -c %Y "$stream" 2>/dev/null) || return 0
+  now=$(date +%s)
+  idle_min=$(( (now - mtime) / 60 ))
+  iso=$(date -Iseconds -d "@$mtime" 2>/dev/null)
+  printf '⏱ local worker: last activity %s (%s)\n' "$iso" "$(_ccs_ago_str "$idle_min")"
 }
 
 # Generate suggested_actions for a session

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -873,6 +873,10 @@ _ccs_jobs_sync_status() {
       # is the liveness signal (the monitor can die independently of the worker).
       if _ccs_dispatch_agentpager_session_alive "agent-pager-$key"; then
         [ "$jid" = "$newest_ap_jid" ] && continue   # live worker, still running
+        # An older running record is stale (a newer worker owns the session). If
+        # it actually finalized (md present) leave it — same deference to the
+        # monitor as the session-gone branch below; otherwise reconcile.
+        [ -f "$dispatch_dir/results/${jid}.md" ] && continue
         _ccs_dispatch_jsonl_append "$(jq -nc \
           --arg jid "$jid" --arg fa "$(date -Iseconds)" \
           '{job_id:$jid, status:"completed", finished_at:$fa,

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -949,29 +949,35 @@ _ccs_jobs_show_single() {
   local dispatch_dir
   dispatch_dir="$(_ccs_dispatch_dir)"
   local md="$dispatch_dir/results/${job_id}.md"
+  local record
+  record=$(_ccs_dispatch_jsonl_latest "$job_id")
 
   if [ -f "$md" ]; then
     cat "$md"
-  else
-    local record
-    record=$(_ccs_dispatch_jsonl_latest "$job_id")
-    if [ -n "$record" ]; then
-      echo "$record" | jq .
-      # For a still-running agent-pager worker, surface last-activity (out.stream
-      # mtime) so a stalled worker is visible for a manual /stop (design D2).
-      local be st
-      be=$(echo "$record" | jq -r '.backend // ""')
-      st=$(echo "$record" | jq -r '.status // ""')
-      if [ "$be" = "agentpager" ] && [ "$st" = "running" ]; then
-        local la
-        la=$(_ccs_dispatch_agentpager_last_activity \
-          "local-$(id -un)" "${AGENT_PAGER_DIR:-$HOME/.agent-pager}")
-        [ -n "$la" ] && echo "Last activity: $la"
-      fi
-    else
-      echo "Job not found: $job_id" >&2
-      return 1
+  elif [ -n "$record" ]; then
+    echo "$record" | jq .
+    # For a still-running agent-pager worker, surface last-activity (out.stream
+    # mtime) so a stalled worker is visible for a manual /stop (design D2).
+    local be st
+    be=$(echo "$record" | jq -r '.backend // ""')
+    st=$(echo "$record" | jq -r '.status // ""')
+    if [ "$be" = "agentpager" ] && [ "$st" = "running" ]; then
+      local la
+      la=$(_ccs_dispatch_agentpager_last_activity \
+        "local-$(id -un)" "${AGENT_PAGER_DIR:-$HOME/.agent-pager}")
+      [ -n "$la" ] && echo "Last activity: $la"
     fi
+  else
+    echo "Job not found: $job_id" >&2
+    return 1
+  fi
+
+  # Q3=A: handoff-ready action hint (applies to both the md and record paths).
+  if [ -n "$record" ]; then
+    local hint_st hint_proj
+    hint_st=$(echo "$record" | jq -r '.status // ""')
+    hint_proj=$(echo "$record" | jq -r '.project // "."')
+    _ccs_jobs_handoff_hint "$job_id" "$hint_st" "$hint_proj" "$dispatch_dir"
   fi
 }
 
@@ -991,6 +997,19 @@ _ccs_jobs_agentpager_footer() {
   idle_min=$(( (now - mtime) / 60 ))
   iso=$(date -Iseconds -d "@$mtime" 2>/dev/null)
   printf '⏱ local worker: last activity %s (%s)\n' "$iso" "$(_ccs_ago_str "$idle_min")"
+}
+
+# Echo a handoff-ready action hint: point at the captured .handoff and give a
+# project-prefilled chain command. The next task can't be prefilled (it lives in
+# the handoff the operator must read), and auto-chaining is v2 (design Q3=A).
+_ccs_jobs_handoff_hint() {
+  local job_id="$1" status="$2" project="$3" dispatch_dir="$4"
+  [ "$status" = "handoff-ready" ] || return 0
+  printf '\n'
+  printf '→ Handoff ready: %s/results/%s.handoff\n' "$dispatch_dir" "$job_id"
+  printf '  Review it, then chain the next worker:\n'
+  printf '    ccs-dispatch --project %s "<next task from handoff>"\n' "$project"
+  printf '  (auto-chaining is v2)\n'
 }
 
 # Generate suggested_actions for a session

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -505,8 +505,9 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
 - **完成判定**：worker 完成時把交接寫到 `tmp/handoff-<job-id>.md`（開場 prompt 已注入
   此規則）；ccs 偵測到即收席位、把交接存到 `results/<job-id>.handoff`，狀態記為
   `handoff-ready`。無交接但 session 自行結束 → `completed`；session 從未起來 → `failed`。
-- **不自動中止**：卡住的 worker 不會被 wall-clock timeout 殺掉——在 `ccs-jobs <job-id>`
-  看 last-activity 後手動處理（MVP 單 worker per user，多 worker 為 v2）。
+- **不自動中止**：卡住的 worker 不會被 wall-clock timeout 殺掉——`ccs-jobs` 清單底部會
+  顯示 running worker 的 last-activity（idle 時間），`ccs-jobs <job-id>` 亦有；據此手動
+  `/stop` 處理（MVP 單 worker per user，多 worker 為 v2）。
 
 結果存放：`${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/`
 
@@ -519,6 +520,11 @@ ccs-jobs              # 最近 20 筆
 ccs-jobs --all        # 全部
 ccs-jobs <job-id>     # 單筆詳細結果（顯示 .md）
 ```
+
+- **清單 footer**：有 running 的 agentpager worker 時，清單底部顯示其 last-activity
+  （out.stream idle 時間），方便發現卡住的 worker。
+- **handoff-ready 提示**：單筆 view 對 `handoff-ready` job 會提示 `.handoff` 路徑與接力
+  `ccs-dispatch` 範本（auto-chain 為 v2）。
 
 ## ccs-review
 

--- a/tests/test-dispatch-spawn-agentpager.sh
+++ b/tests/test-dispatch-spawn-agentpager.sh
@@ -127,7 +127,10 @@ dd="$(_ccs_dispatch_dir)"
 jid3="d-test-$(head -c2 /dev/urandom | od -An -tx1 | tr -d ' \n')"
 _ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$jid3" --arg ca "$(date -Iseconds)" \
   '{job_id:$jid,project:"p",backend:"agentpager",created_at:$ca,status:"running"}')"
-echo $$ > "$dd/pids/${jid3}.pid"   # live pid so sync_status keeps it running
+# agentpager liveness = the worker's tmux session (not the monitor pid), so keep
+# the session alive; sync_status then leaves the job running and the single view
+# renders last-activity.
+_ccs_dispatch_agentpager_session_alive() { return 0; }
 apdir="$SCRIPT_DIR/tmp/test-spawn-ap-jobs"
 mkdir -p "$apdir/channels/local-$(id -un)"
 printf 'frame' > "$apdir/channels/local-$(id -un)/out.stream"

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -117,4 +117,22 @@ nos="$(ccs-jobs 2>/dev/null)"
 assert_contains "no stream yet -> no output yet footer" "$nos" "local worker: no output yet"
 unset AGENT_PAGER_DIR
 
+echo "=== single view: handoff-ready job shows chain hint ==="
+reset_jobs
+jrec '{"job_id":"d-hr","project":"ccs-dashboard","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+jrec '{"job_id":"d-hr","status":"handoff-ready","handoff":true,"finished_at":"2026-07-03T10:05:00+08:00"}'
+printf '# Dispatch Result: d-hr\n- **Status:** handoff-ready\n' > "$DD/results/d-hr.md"
+hr_out="$(ccs-jobs d-hr 2>/dev/null)"
+assert_contains "hint points to the .handoff file" "$hr_out" "results/d-hr.handoff"
+assert_contains "hint gives a chain command with the project" "$hr_out" \
+  'ccs-dispatch --project ccs-dashboard'
+assert_contains "hint marks auto-chaining as v2" "$hr_out" "auto-chaining is v2"
+
+echo "=== single view: non-handoff-ready job shows no hint ==="
+reset_jobs
+jrec '{"job_id":"d-cp","project":"p","backend":"headless","status":"completed","created_at":"2026-07-03T10:00:00+08:00","finished_at":"2026-07-03T10:05:00+08:00"}'
+printf '# Dispatch Result: d-cp\n- **Status:** completed\n' > "$DD/results/d-cp.md"
+cp_out="$(ccs-jobs d-cp 2>/dev/null)"
+assert_not_contains "completed job -> no chain hint" "$cp_out" "auto-chaining is v2"
+
 test_summary

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -67,6 +67,15 @@ _ccs_jobs_sync_status
 after=$(wc -l < "$JOBS")
 assert_eq "md present -> sync appends nothing" "$before" "$after"
 
+echo "=== sync: agentpager with a LIVE monitor is deferred to (no startup race) ==="
+reset_jobs
+jrec '{"job_id":"d-mon","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+echo $$ > "$DD/pids/d-mon.pid"   # live monitor (this shell's pid)
+_ccs_dispatch_agentpager_session_alive() { return 1; }  # worker session not up yet (startup lag)
+_ccs_jobs_sync_status
+assert_eq "live monitor + session-not-yet-up -> still running (no premature complete)" "running" \
+  "$(_ccs_dispatch_jsonl_latest "d-mon" | jq -r '.status')"
+
 echo "=== sync tiebreak: only newest running agentpager owns the live session ==="
 reset_jobs
 jrec '{"job_id":"d-old","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T09:00:00+08:00"}'

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -80,6 +80,19 @@ assert_eq "older running agentpager -> completed (superseded)" "completed" \
 assert_contains "older carries a superseded note" \
   "$(_ccs_dispatch_jsonl_latest "d-old" | jq -r '.note // ""')" "superseded"
 
+echo "=== sync tiebreak: stale older agentpager with md present is left untouched ==="
+reset_jobs
+jrec '{"job_id":"d-oldmd","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T09:00:00+08:00"}'
+jrec '{"job_id":"d-newmd","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T11:00:00+08:00"}'
+printf '# md\n' > "$DD/results/d-oldmd.md"   # older already finalized md (partial finalize)
+_ccs_dispatch_agentpager_session_alive() { return 0; }
+_ccs_jobs_sync_status
+# md present -> defer to the monitor, do not append a misleading superseded record
+assert_eq "older-with-md is not overwritten to completed" "running" \
+  "$(_ccs_dispatch_jsonl_latest "d-oldmd" | jq -r '.status')"
+assert_eq "newest still running" "running" \
+  "$(_ccs_dispatch_jsonl_latest "d-newmd" | jq -r '.status')"
+
 echo "=== sync: headless branch unchanged (control) ==="
 reset_jobs
 jrec '{"job_id":"d-hl","project":"p","backend":"headless","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -88,4 +88,33 @@ _ccs_jobs_sync_status
 assert_eq "headless dead pid + no md -> failed" "failed" \
   "$(_ccs_dispatch_jsonl_latest "d-hl" | jq -r '.status')"
 
+echo "=== list footer: running agentpager worker shows last-activity ==="
+reset_jobs
+export AGENT_PAGER_DIR="$SCRIPT_DIR/tmp/test-jobs-ap-pager"
+rm -rf "$AGENT_PAGER_DIR"
+mkdir -p "$AGENT_PAGER_DIR/channels/local-$(id -un)"
+printf 'frame' > "$AGENT_PAGER_DIR/channels/local-$(id -un)/out.stream"
+touch_minutes_ago "$AGENT_PAGER_DIR/channels/local-$(id -un)/out.stream" 3
+jrec '{"job_id":"d-foot","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+echo $$ > "$DD/pids/d-foot.pid"    # live pid so sync keeps it running (agentpager uses session)
+_ccs_dispatch_agentpager_session_alive() { return 0; }
+foot_out="$(ccs-jobs 2>/dev/null)"
+assert_contains "footer names the local worker" "$foot_out" "local worker: last activity"
+assert_contains "footer shows a 3m-ago idle" "$foot_out" "3m ago"
+
+echo "=== list footer: no running agentpager worker -> no footer ==="
+reset_jobs
+jrec '{"job_id":"d-done","project":"p","backend":"agentpager","status":"handoff-ready","created_at":"2026-07-03T10:00:00+08:00","finished_at":"2026-07-03T10:05:00+08:00"}'
+nofoot="$(ccs-jobs 2>/dev/null)"
+assert_not_contains "no running worker -> no footer" "$nofoot" "local worker:"
+
+echo "=== list footer: running worker but stream absent -> no output yet ==="
+reset_jobs
+rm -rf "$AGENT_PAGER_DIR"; mkdir -p "$AGENT_PAGER_DIR/inbound"
+jrec '{"job_id":"d-nostrm","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+_ccs_dispatch_agentpager_session_alive() { return 0; }
+nos="$(ccs-jobs 2>/dev/null)"
+assert_contains "no stream yet -> no output yet footer" "$nos" "local worker: no output yet"
+unset AGENT_PAGER_DIR
+
 test_summary

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# tests/test-jobs-agentpager.sh — ccs-jobs agentpager board integration (Task 3)
+# Units: sync_status (bug1 reduce-merge, bug2 session-aware, tiebreak),
+# list last-activity footer, single-view handoff-ready hint.
+# Isolation: XDG_DATA_HOME sandbox + AGENT_PAGER_DIR sandbox; tmux mocked via
+# overriding _ccs_dispatch_agentpager_session_alive.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Sandbox the data dir BEFORE sourcing anything that resolves it.
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-jobs-ap-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+RS=$'\x1e'; US=$'\x1f'
+DD="$(_ccs_dispatch_dir)"           # sandboxed dispatch dir
+JOBS="$DD/jobs.jsonl"
+
+# reset_jobs — start each unit from a clean jobs.jsonl + results/pids
+reset_jobs() {
+  rm -f "$JOBS"; rm -rf "$DD/results" "$DD/pids"
+  mkdir -p "$DD/results" "$DD/pids"
+}
+
+# append a raw jsonl line (helper keeps tests terse)
+jrec() { printf '%s\n' "$1" >> "$JOBS"; }
+
+echo "=== sync bug1: fallback marker (no status) still resolves to running ==="
+reset_jobs
+# agentpager job that fell back to headless: running record + fallback marker
+# (fallback marker has NO status field, so tail -1 would misread it as null).
+jrec '{"job_id":"d-b1","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+jrec '{"job_id":"d-b1","backend":"headless","fallback":true}'
+# no pidfile, no md -> a dead headless process must be reconciled to failed.
+_ccs_jobs_sync_status
+b1=$(_ccs_dispatch_jsonl_latest "d-b1" | jq -r '.status')
+assert_eq "fallback job with dead process -> failed (not skipped)" "failed" "$b1"
+
+echo "=== sync bug2: agentpager running, monitor pid dead but session alive -> stays running ==="
+reset_jobs
+jrec '{"job_id":"d-b2","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+echo 999999 > "$DD/pids/d-b2.pid"   # a dead pid (monitor gone)
+_ccs_dispatch_agentpager_session_alive() { return 0; }   # worker session alive
+_ccs_jobs_sync_status
+b2=$(_ccs_dispatch_jsonl_latest "d-b2" | jq -r '.status')
+assert_eq "agentpager session alive -> still running (not failed)" "running" "$b2"
+
+echo "=== sync bug2: agentpager running, session gone, no md -> completed(note) ==="
+reset_jobs
+jrec '{"job_id":"d-b3","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+_ccs_dispatch_agentpager_session_alive() { return 1; }   # session gone
+_ccs_jobs_sync_status
+b3=$(_ccs_dispatch_jsonl_latest "d-b3")
+assert_eq "session gone + no md -> completed" "completed" "$(echo "$b3" | jq -r '.status')"
+assert_contains "completed carries a monitor-exit note" \
+  "$(echo "$b3" | jq -r '.note // ""')" "monitor exited"
+
+echo "=== sync bug2: agentpager running, session gone but md exists -> untouched ==="
+reset_jobs
+jrec '{"job_id":"d-b4","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+printf '# md\n' > "$DD/results/d-b4.md"   # monitor already finalized (md present)
+before=$(wc -l < "$JOBS")
+_ccs_dispatch_agentpager_session_alive() { return 1; }
+_ccs_jobs_sync_status
+after=$(wc -l < "$JOBS")
+assert_eq "md present -> sync appends nothing" "$before" "$after"
+
+echo "=== sync tiebreak: only newest running agentpager owns the live session ==="
+reset_jobs
+jrec '{"job_id":"d-old","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T09:00:00+08:00"}'
+jrec '{"job_id":"d-new","project":"p","backend":"agentpager","status":"running","created_at":"2026-07-03T11:00:00+08:00"}'
+_ccs_dispatch_agentpager_session_alive() { return 0; }   # a session is alive
+_ccs_jobs_sync_status
+assert_eq "newest running agentpager stays running" "running" \
+  "$(_ccs_dispatch_jsonl_latest "d-new" | jq -r '.status')"
+assert_eq "older running agentpager -> completed (superseded)" "completed" \
+  "$(_ccs_dispatch_jsonl_latest "d-old" | jq -r '.status')"
+assert_contains "older carries a superseded note" \
+  "$(_ccs_dispatch_jsonl_latest "d-old" | jq -r '.note // ""')" "superseded"
+
+echo "=== sync: headless branch unchanged (control) ==="
+reset_jobs
+jrec '{"job_id":"d-hl","project":"p","backend":"headless","status":"running","created_at":"2026-07-03T10:00:00+08:00"}'
+echo 999999 > "$DD/pids/d-hl.pid"   # dead pid, no md
+_ccs_jobs_sync_status
+assert_eq "headless dead pid + no md -> failed" "failed" \
+  "$(_ccs_dispatch_jsonl_latest "d-hl" | jq -r '.status')"
+
+test_summary


### PR DESCRIPTION
## Summary

Task 3 收斂 `ccs-jobs` 對 agent-pager 後端 job 的看板整合：清單/看板正確同步 agentpager 狀態、把 running worker 的 last-activity 帶進清單、並對 handoff-ready job 給出接力動作提示。順帶修掉 Stage 2 已知刻意延後的 `_ccs_jobs_sync_status` 兩個對帳缺口。

## Changes

- `fix(dispatch)`: `_ccs_jobs_sync_status` 改用 reduce-merge 有效狀態（與看板一致），修 fallback marker 無 status 欄位被 `tail -1` 誤讀成 null 而 skip liveness 的缺口；agentpager job 改以 tmux session 為存活信號（不再拿背景 monitor pid 當失敗信號），加 newest-owns-session tiebreak；headless 分支行為不變。
- `feat(jobs)`: 清單底部顯示 running agentpager worker 的 last-activity（複用 `_ccs_ago_str`），不加欄位、不撐寬（手機優先）。
- `feat(jobs)`: 單筆 view 對 handoff-ready job 提示 `.handoff` 路徑 + 帶專案名的接力 `ccs-dispatch` 範本（auto-chain 為 v2）。
- `docs(commands)`: 補 `ccs-jobs` footer/hint 說明。
- `fix(dispatch)`: superseded 分支補上與 session-gone 分支對稱的 md-present 檢查（code review nit）。
- `fix(dispatch)`: sync 對 agentpager job 先 defer 給存活的 monitor pidfile，只有 monitor 消失才 reconcile，避免剛派工的 job 在 worker 啟動延遲期被誤判 completed（startup race，真機 E2E 發現，附回歸測試）。

## Test plan (reviewer checklist)

- [x] `bash tests/run-all.sh` 全綠
- [x] `_ccs_jobs_sync_status` 對 fallback marker、agentpager session 存活/消失、tiebreak 皆正確
- [x] 清單 footer 只在有 running agentpager worker 時出現
- [x] handoff-ready 提示在 md 與 record 兩條 render 路徑都出現、非 handoff-ready 不出現
- [x] 真機 E2E：派一個 agentpager job → running 期間清單 footer 顯示 worker last-activity → 完成後單筆顯示 handoff hint

## Test results (author 已驗)

**Unit tests：**
`bash tests/run-all.sh`: 22 檔全綠，0 failed，1 skipped（`test-crash-detect.sh`，需 live session data）。
新增 `tests/test-jobs-agentpager.sh`: 19 passed, 0 failed。
回歸 `test-dispatch-spawn-agentpager.sh` 40/40、`test-dispatch-backend.sh` 21/21。

**E2E tests：**
真機 E2E（same-uid local channel，2026-07-06）— 派一個 agentpager job 並全程輪詢：
- Q1：狀態流 `running → handoff-ready` 正確。
- Q2：running 期間清單底部穩定顯示 footer `⏱ local worker: last activity <iso> (<idle> ago)`，反映 worker 實際 out.stream 活動。
- Q3：完成後單筆 view 顯示 `.handoff` 路徑 + 帶專案名的接力範本（標註 auto-chain 為 v2）。
三項皆通過。備註：footer 只在 gap-free（派工與輪詢同一 process、無中間延遲）時穩定觀察得到——輪詢晚啟動只會抓到 worker 收尾前最後一瞬，非 footer 邏輯缺陷。

**Smoke tests：**
N/A — 純 CLI 輸出變更，無裝置/部署面。

## Reviewer summary

獨立 capable code-reviewer（final gate）：**No blockers, clean to merge**。確認 Q1=C/Q2=A/Q3=A 全滿足、headless 分支行為與 master 位元一致（僅移除空行）、footer/hint 皆在呼叫鏈可達（非 dead code）、sync 與 show_list 狀態判定一致（同 reduce-merge）。一個 review nit（superseded 分支缺 md 檢查）已修 + 補測試。

## Carry-forward Minor items

- `_ccs_jobs_show_single` 的 "Job not found" 分支不可達（`_ccs_dispatch_jsonl_latest` 對未知 id 回 `{}`）——pre-existing，master 行為相同，未在本 PR 範圍內處理。
- `_ccs_jobs_agentpager_footer` 在 clock 倒退時 idle 顯示負值（cosmetic，本機剛寫入檔案倒退幾乎不可能）。
- worker turn-end 最後一行總結偶爾被 stop 截於 `.raw`（v1.1，pane idle 偵測）。
- multi-worker per user（key `local-<user>-<n>`）、handoff 自動鏈鎖派發（v2）。

## Related

- Issue: #71
- Plan / Design: `internal/`（gitignored 本機 sprint 文件）
