### PR TITLE
feat(dispatch): notify pager on agentpager job completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 - `ccs-failure-triage`: triage a session for model confabulation-family failure signals (Sub-pattern A/B/C/D). Includes 5 automated forensic checks and writes a report to `<project>/tmp/`. See `docs/failure-triage.md`.
 - **ccs-dispatch agent-pager backend** — optional local-channel worker backend (`CCS_DISPATCH_BACKEND=agentpager`, auto-detected) that runs a monitorable interactive worker via agent-pager instead of headless `claude -p`. Same-uid hybrid detection needs no `claude-broker` group; projects map to agent-pager keys via `~/.config/ccs-dashboard/proj-map`. Handoff-driven completion (`handoff-ready` status), async-only, and falls back to headless when agent-pager is unavailable. See `docs/commands.md`.
 - **ccs-jobs agent-pager visibility** — the list shows a running agent-pager worker's last-activity in a footer line, and the single-job view hints the `.handoff` path plus a prefilled follow-up `ccs-dispatch` template on handoff-ready jobs. (PR #72)
+- **ccs-dispatch completion notification** — an agentpager job pushes one short pager message at finalize (job id, status, project, `.handoff` path) via agent-pager's notify channel. Best-effort (a missing or hung sender never affects finalize), opt-out with `CCS_DISPATCH_NOTIFY=0`, bot slot pinned via `CCS_DISPATCH_NOTIFY_SLOT`. (#74)
 
 ### Fixed
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -309,6 +309,50 @@ _ccs_dispatch_agentpager_last_activity() {
   date -Iseconds -r "$stream" 2>/dev/null
 }
 
+# Resolve the agent-pager outbound sender (notify-send.sh). Order: the
+# AGENT_PAGER_SENDER convention (agent-pager's own scripts honor it), then a
+# sibling of the runner unit's ExecStart script — the services run straight
+# from the checkout, so the unit is the one place that knows the bin dir.
+# Empty output = no sender available; callers skip the notification.
+_ccs_dispatch_notify_sender() {
+  if [ -n "${AGENT_PAGER_SENDER:-}" ] && [ -x "$AGENT_PAGER_SENDER" ]; then
+    echo "$AGENT_PAGER_SENDER"; return 0
+  fi
+  local exec_start script_path candidate
+  exec_start="$(systemctl --user show agent-pager-runner.service -p ExecStart 2>/dev/null)" || return 0
+  script_path="$(echo "$exec_start" | grep -o 'path=[^ ;]*' | head -1 | cut -d= -f2-)"
+  [ -n "$script_path" ] || return 0
+  candidate="$(dirname "$script_path")/notify-send.sh"
+  [ -x "$candidate" ] && echo "$candidate"
+  return 0
+}
+
+# Best-effort completion notification for an agentpager job (#74). Sends one
+# short pager message via notify-send.sh at finalize. Never fails the caller:
+# a missing sender or a send error is silently ignored (the sender itself
+# always exits 0). CCS_DISPATCH_NOTIFY=0 opts out entirely; the send is opted
+# in per call (AGENT_PAGER_NOTIFY=1, the launching-caller convention), while
+# the actual delivery still depends on agent-pager's own telegram config.
+_ccs_dispatch_notify_completion() {
+  [ "${CCS_DISPATCH_NOTIFY:-1}" != "0" ] || return 0
+  local job_id="$1" status="$2" project="$3" handoff_dst="$4" note="$5"
+  local sender
+  sender="$(_ccs_dispatch_notify_sender)"
+  [ -n "$sender" ] && [ -x "$sender" ] || return 0
+  {
+    # No prefix here: notify-send.sh already prepends the --label.
+    echo "$job_id $status"
+    echo "project: $project"
+    [ -n "$handoff_dst" ] && echo "handoff: $handoff_dst"
+    [ -n "$note" ] && echo "note: $note"
+  } | AGENT_PAGER_NOTIFY=1 \
+    AGENT_PAGER_BOT_SLOT="${CCS_DISPATCH_NOTIFY_SLOT:-1}" \
+    timeout "${CCS_DISPATCH_NOTIFY_TIMEOUT:-10}" \
+    "$sender" --cwd "$HOME" --label "ccs-dispatch" \
+    >/dev/null 2>&1 || true
+  return 0
+}
+
 # Finalize an agent-pager job (handoff gating). Handoff file present + copied ->
 # handoff-ready (captured to results/<job_id>.handoff). Otherwise the status is
 # $3 (no_handoff_status, default "completed"; the monitor passes "failed" when
@@ -404,6 +448,14 @@ _ccs_dispatch_finish_agentpager() {
   rm -f "$dispatch_dir/pids/${job_id}.pid"
   [ -f "$md" ] && rm -f "$raw"
   rm -f "$prompt_f"
+
+  # Notify after the job record is fully landed, so a pager reader who reacts
+  # immediately sees the final state. Sync's stale reconciliation does not come
+  # through here, so only a live finalize notifies.
+  local notify_handoff=""
+  [ "$handoff_flag" = true ] && notify_handoff="$handoff_dst"
+  _ccs_dispatch_notify_completion "$job_id" "$status" "$project" \
+    "$notify_handoff" "$note"
 }
 
 # Background monitor for one agent-pager job. Runs under nohup from spawn. Polls

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -508,6 +508,15 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
 - **不自動中止**：卡住的 worker 不會被 wall-clock timeout 殺掉——`ccs-jobs` 清單底部會
   顯示 running worker 的 last-activity（idle 時間），`ccs-jobs <job-id>` 亦有；據此手動
   `/stop` 處理（MVP 單 worker per user，多 worker 為 v2）。
+- **完成通知**：job 進入終態（`handoff-ready` / `completed` / `failed`）時，透過
+  agent-pager 的 notify 通道推一則短訊（job id、狀態、專案、`.handoff` 路徑）。
+  Best-effort：找不到 sender 或送出失敗不影響 finalize；實際送達仍依 agent-pager 的
+  telegram 設定。`CCS_DISPATCH_NOTIFY=0` 可關閉。sender 路徑取自 `AGENT_PAGER_SENDER`，
+  未設時從 agent-pager 的 systemd user unit 推導。`CCS_DISPATCH_NOTIFY_SLOT`（預設 `1`）
+  指定發送用的 pager bot slot——建議指到一個不掛互動 session 的保留 slot，避免通知
+  混進互動對話串（slot role 的原生支援由 agent-pager 端追蹤——internal GitLab
+  issue #76，落地後此預設會改為查詢保留 slot）。注意：只有 monitor 的
+  即時 finalize 會通知；`ccs-jobs` sync 的事後補帳（stale 對帳）不通知。
 
 結果存放：`${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/`
 

--- a/tests/fixture-helper.sh
+++ b/tests/fixture-helper.sh
@@ -5,6 +5,11 @@
 
 PASS=0 FAIL=0
 
+# Tests must never page the operator: any code path that reaches the dispatch
+# completion notification (#74) is muted by default. A test that exercises the
+# notification itself unsets this and stubs the sender.
+export CCS_DISPATCH_NOTIFY=0
+
 _TEST_DIRS=()
 
 assert_eq() {

--- a/tests/test-dispatch-notify.sh
+++ b/tests/test-dispatch-notify.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-notify.sh — agentpager job completion notification (#74)
+# Units: sender resolver (env / systemd-derived / none), CCS_DISPATCH_NOTIFY
+# gate, finish-hook integration (handoff-ready / failed), best-effort
+# degradation when no sender is available.
+# Isolation: XDG_DATA_HOME sandbox; sender stubbed by a capture script;
+# systemctl stubbed by a shell function.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-notify-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+DD="$(_ccs_dispatch_dir)"
+JOBS="$DD/jobs.jsonl"
+SANDBOX="$SCRIPT_DIR/tmp/test-dispatch-notify"
+rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"
+
+CAPTURE="$SANDBOX/notify-capture.txt"
+
+# Stub sender: records argv, the AGENT_PAGER_NOTIFY opt-in, and the stdin body.
+STUB_SENDER="$SANDBOX/notify-send.sh"
+cat > "$STUB_SENDER" <<STUB
+#!/usr/bin/env bash
+{
+  echo "ARGS:\$*"
+  echo "OPTIN:\${AGENT_PAGER_NOTIFY:-unset}"
+  echo "SLOT:\${AGENT_PAGER_BOT_SLOT:-unset}"
+  cat
+} >> "$CAPTURE"
+exit 0
+STUB
+chmod +x "$STUB_SENDER"
+
+reset_case() {
+  rm -f "$JOBS" "$CAPTURE"; rm -rf "$DD/results" "$DD/pids"
+  mkdir -p "$DD/results" "$DD/pids"
+  unset AGENT_PAGER_SENDER CCS_DISPATCH_NOTIFY CCS_DISPATCH_NOTIFY_TIMEOUT \
+    CCS_DISPATCH_NOTIFY_SLOT 2>/dev/null || true
+}
+
+# Seed one agentpager job record + optional handoff source file.
+seed_job() { # $1=job_id $2=with_handoff(0/1)
+  local jid="$1" with_handoff="$2"
+  printf '%s\n' "{\"job_id\":\"$jid\",\"project\":\"proj-x\",\"backend\":\"agentpager\",\"status\":\"running\",\"created_at\":\"2026-07-07T10:00:00+08:00\"}" >> "$JOBS"
+  HANDOFF_SRC="$SANDBOX/handoff-$jid.md"
+  rm -f "$HANDOFF_SRC"
+  [ "$with_handoff" = 1 ] && printf '# handoff\n' > "$HANDOFF_SRC"
+}
+
+echo "=== resolver: AGENT_PAGER_SENDER wins when executable ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+assert_eq "resolver honors AGENT_PAGER_SENDER" "$STUB_SENDER" \
+  "$(_ccs_dispatch_notify_sender)"
+
+echo "=== resolver: non-executable AGENT_PAGER_SENDER is ignored ==="
+reset_case
+export AGENT_PAGER_SENDER="$SANDBOX/not-executable.sh"
+touch "$SANDBOX/not-executable.sh"
+systemctl() { return 1; }
+assert_eq "non-executable sender -> empty" "" "$(_ccs_dispatch_notify_sender)"
+unset -f systemctl
+
+echo "=== resolver: derives from the runner unit's ExecStart path ==="
+reset_case
+systemctl() {
+  echo "ExecStart={ path=$SANDBOX/inbound-handler.sh ; argv[]=$SANDBOX/inbound-handler.sh ; ignore_errors=no }"
+}
+assert_eq "systemd-derived sibling notify-send.sh" "$STUB_SENDER" \
+  "$(_ccs_dispatch_notify_sender)"
+unset -f systemctl
+
+echo "=== resolver: nothing available -> empty ==="
+reset_case
+systemctl() { return 1; }
+assert_eq "no env, no unit -> empty" "" "$(_ccs_dispatch_notify_sender)"
+unset -f systemctl
+
+echo "=== finish: handoff-ready notifies with id/status/project/handoff ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+seed_job "n-hr" 1
+_ccs_dispatch_finish_agentpager "n-hr" "$HANDOFF_SRC"
+body="$(cat "$CAPTURE" 2>/dev/null)"
+assert_contains "notify names the job and status" "$body" "n-hr handoff-ready"
+assert_not_contains "body carries no label prefix (the sender prepends it)" \
+  "$body" "[ccs-dispatch] n-hr"
+assert_contains "notify names the project" "$body" "project: proj-x"
+assert_contains "notify carries the captured handoff path" "$body" "results/n-hr.handoff"
+assert_contains "notify overrides the label" "$body" "--label ccs-dispatch"
+assert_contains "sender is opted in for this call" "$body" "OPTIN:1"
+assert_contains "default notify slot is 1" "$body" "SLOT:1"
+
+echo "=== slot: CCS_DISPATCH_NOTIFY_SLOT pins the pager bot ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+export CCS_DISPATCH_NOTIFY_SLOT=2
+seed_job "n-slot" 1
+_ccs_dispatch_finish_agentpager "n-slot" "$HANDOFF_SRC"
+assert_contains "notify goes out on the configured slot" \
+  "$(cat "$CAPTURE" 2>/dev/null)" "SLOT:2"
+
+echo "=== finish: failed job notifies the failure ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+seed_job "n-fail" 0
+_ccs_dispatch_finish_agentpager "n-fail" "$HANDOFF_SRC" "failed"
+body="$(cat "$CAPTURE" 2>/dev/null)"
+assert_contains "failed status reaches the pager" "$body" "n-fail failed"
+assert_not_contains "no handoff line without a handoff" "$body" "handoff:"
+
+echo "=== gate: CCS_DISPATCH_NOTIFY=0 suppresses the call ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+export CCS_DISPATCH_NOTIFY=0
+seed_job "n-off" 1
+_ccs_dispatch_finish_agentpager "n-off" "$HANDOFF_SRC"
+assert_eq "opt-out -> sender never called" "" "$(cat "$CAPTURE" 2>/dev/null)"
+assert_eq "finalize still lands handoff-ready" "handoff-ready" \
+  "$(_ccs_dispatch_jsonl_latest "n-off" | jq -r '.status')"
+
+echo "=== best-effort: missing sender leaves finalize intact ==="
+reset_case
+export AGENT_PAGER_SENDER="$SANDBOX/gone.sh"   # does not exist
+systemctl() { return 1; }
+seed_job "n-nosender" 1
+_ccs_dispatch_finish_agentpager "n-nosender" "$HANDOFF_SRC"
+unset -f systemctl
+rec="$(_ccs_dispatch_jsonl_latest "n-nosender")"
+assert_eq "status unaffected by missing sender" "handoff-ready" \
+  "$(echo "$rec" | jq -r '.status')"
+assert_eq "md still written" "1" \
+  "$([ -f "$DD/results/n-nosender.md" ] && echo 1 || echo 0)"
+
+echo "=== best-effort: hanging sender is cut by the timeout ==="
+reset_case
+HANG_SENDER="$SANDBOX/hang-sender.sh"
+printf '#!/usr/bin/env bash\nsleep 30\n' > "$HANG_SENDER"
+chmod +x "$HANG_SENDER"
+export AGENT_PAGER_SENDER="$HANG_SENDER"
+export CCS_DISPATCH_NOTIFY_TIMEOUT=1
+seed_job "n-hang" 1
+start_s=$(date +%s)
+_ccs_dispatch_finish_agentpager "n-hang" "$HANDOFF_SRC"
+elapsed=$(( $(date +%s) - start_s ))
+assert_eq "finalize lands despite the hanging sender" "handoff-ready" \
+  "$(_ccs_dispatch_jsonl_latest "n-hang" | jq -r '.status')"
+if [ "$elapsed" -le 5 ]; then
+  assert_eq "timeout cuts the hang (took ${elapsed}s)" "ok" "ok"
+else
+  assert_eq "timeout cuts the hang (took ${elapsed}s)" "ok" "hung"
+fi
+
+echo "=== body stays short (mobile-readable) ==="
+reset_case
+export AGENT_PAGER_SENDER="$STUB_SENDER"
+seed_job "n-short" 1
+_ccs_dispatch_finish_agentpager "n-short" "$HANDOFF_SRC" "completed" "some operator note"
+lines="$(grep -c '' "$CAPTURE" 2>/dev/null || echo 0)"; lines="${lines:-0}"
+# capture = ARGS + OPTIN + body; body itself must stay <= 6 lines
+if [ "$lines" -le 8 ]; then
+  assert_eq "notification body <= 6 lines" "ok" "ok"
+else
+  assert_eq "notification body <= 6 lines (got $((lines - 2)))" "ok" "too-long"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

agentpager job 完成時（`handoff-ready` / `completed` / `failed`），monitor finalize 現在會透過 agent-pager 的 notify 通道推一則短 pager 訊息（job id、狀態、專案、`.handoff` 路徑），指揮席不用再輪詢 `ccs-jobs`。Closes #74。

## Changes

- `feat(dispatch)`: `_ccs_dispatch_notify_sender` — sender 解析（`AGENT_PAGER_SENDER` env 優先，否則從 agent-pager runner 的 systemd user unit ExecStart 推導；服務直接跑 checkout，unit 是唯一知道 bin 目錄的地方）。
- `feat(dispatch)`: `_ccs_dispatch_notify_completion` — best-effort 發送：sender 缺失 / 送失敗 / hang（`timeout`，`CCS_DISPATCH_NOTIFY_TIMEOUT` 預設 10s）都不影響 finalize；`CCS_DISPATCH_NOTIFY=0` 完全關閉；`CCS_DISPATCH_NOTIFY_SLOT`（預設 1）釘選 pager bot slot；body 不帶 label 前綴（`--label` 已前綴，避免重複）。
- Hook 在 `_ccs_dispatch_finish_agentpager` 尾端（job 紀錄落地後才通知）；只有 monitor 即時 finalize 通知，`ccs-jobs` sync 補帳不通知；headless fallback 不通知（同步短命路徑）。
- `tests/fixture-helper.sh`: 全域 `CCS_DISPATCH_NOTIFY=0` 靜音——測試絕不 page operator（review blocker）。
- `docs(commands)`: 通知行為 + 三個 env；slot 分流建議（原生 slot role 由 agent-pager 端追蹤，internal GitLab issue #76）。

## Test plan (reviewer checklist)

- [x] `bash tests/run-all.sh` 全綠
- [x] resolver 三路徑（env / systemd 推導 / 皆無）
- [x] handoff-ready / failed 通知內容逐欄驗證；opt-out 時 sender 不被呼叫且 finalize 照常
- [x] sender 缺失 / hang 時 finalize 不受影響（含 timeout 回歸測試）
- [x] slot 透傳（預設 1、`CCS_DISPATCH_NOTIFY_SLOT=2`）
- [x] 真機 E2E：真實 Telegram 送達（bot 1 收到，內容格式正確）

## Test results (author 已驗)

**Unit tests：**
`bash tests/run-all.sh`: 24 檔全綠，0 failed，1 skipped（`test-crash-detect.sh`，需 live session data）。
新增 `tests/test-dispatch-notify.sh`: 21 passed, 0 failed。
回歸 `test-dispatch-spawn-agentpager.sh` 40/40。

**E2E tests：**
真機（2026-07-07）：review 驗證過程實際觸發一次真實發送，operator 於 Telegram bot 1 收到通知，job id / status / project / handoff 路徑齊全；發現的 label 前綴重複已修（body 不再帶 `[ccs-dispatch]`）。測試產生的真實 `jobs.jsonl` 紀錄已清理。

**Smoke tests：**
N/A — 無裝置/部署面。

## Reviewer summary

獨立 capable code-reviewer（final gate）：1 blocker + 3 nits。

- **Blocker 已修**：既有 spawn 測試經過新 hook 會發真實 pager 訊息 → fixture 全域靜音。
- Nit 已修：sender hang 無 timeout（加 `timeout` + 回歸測試）；gate 非 "1" 值皆靜默關閉（改為僅 `=0` opt-out，對齊文件）。
- Nit 保留：systemd ExecStart path 含空白時推導截斷（安靜降級為不通知，可接受）。
- Reviewer 確認：呼叫鏈可達（monitor → finish → notify，非 dead code）、headless finalize 與 sync reconcile 不受影響、finish return 語意不變、set -u / quoting 安全。

## Carry-forward Minor items

- systemd path 含空白的推導截斷（安靜漏通知，機率極低）。
- slot role 原生支援（notify-only slot + 查詢介面）→ agent-pager 端 internal GitLab issue #76；落地後 `CCS_DISPATCH_NOTIFY_SLOT` 預設改為查詢保留 slot。

## Related

- Issue: #74
- agent-pager slot role: internal GitLab issue #76
- Plan / Design: `internal/`（gitignored 本機 sprint 文件）