### PR TITLE
feat(dispatch): add --preview sign-off gate before dispatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 - **ccs-dispatch agent-pager backend** — optional local-channel worker backend (`CCS_DISPATCH_BACKEND=agentpager`, auto-detected) that runs a monitorable interactive worker via agent-pager instead of headless `claude -p`. Same-uid hybrid detection needs no `claude-broker` group; projects map to agent-pager keys via `~/.config/ccs-dashboard/proj-map`. Handoff-driven completion (`handoff-ready` status), async-only, and falls back to headless when agent-pager is unavailable. See `docs/commands.md`.
 - **ccs-jobs agent-pager visibility** — the list shows a running agent-pager worker's last-activity in a footer line, and the single-job view hints the `.handoff` path plus a prefilled follow-up `ccs-dispatch` template on handoff-ready jobs. (PR #72)
 - **ccs-dispatch completion notification** — an agentpager job pushes one short pager message at finalize (job id, status, project, `.handoff` path) via agent-pager's notify channel. Best-effort (a missing or hung sender never affects finalize), opt-out with `CCS_DISPATCH_NOTIFY=0`, bot slot pinned via `CCS_DISPATCH_NOTIFY_SLOT`. (#74)
+- **ccs-dispatch preview sign-off** — `--preview` shows the worker prompt, project, backend, and seat, then asks for confirmation before dispatching; rejection, EOF, or timeout aborts with no job record. `--yes` skips the question for automation. (#75)
 
 ### Fixed
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -744,6 +744,50 @@ A reported failure is always preferable to a fabricated success.
 VRULE
 }
 
+# Render the sign-off block an operator reads before approving a dispatch
+# (#75). Narrow layout for phone reading; a long prompt folds to its head plus
+# a size note (CCS_DISPATCH_PREVIEW_MAX_CHARS, default 1500).
+_ccs_dispatch_preview_render() {
+  local project="$1" backend="$2" mode="$3" timeout_secs="$4" prompt="$5"
+  local max="${CCS_DISPATCH_PREVIEW_MAX_CHARS:-1500}"
+  local seat=""
+  [ "$backend" = "agentpager" ] && seat=" (seat local-$(id -un))"
+  echo "── dispatch preview ──"
+  echo "project : $project"
+  echo "backend : ${backend}${seat}"
+  [ "$backend" = "agentpager" ] && \
+    echo "          (falls back to headless if the seat is unavailable)"
+  echo "mode    : $mode (timeout ${timeout_secs}s)"
+  echo "prompt  : ${#prompt} chars"
+  # Fold the middle, not the tail: the prompt ends with "Task: ...", which is
+  # exactly what the operator signs off on. Char-based slicing keeps multibyte
+  # prompts intact (head -c would cut mid-UTF-8).
+  if [ "${#prompt}" -gt "$max" ]; then
+    local half=$(( max / 2 ))
+    printf '%s\n' "${prompt:0:half}"
+    echo "··· (folded $(( ${#prompt} - half * 2 )) of ${#prompt} chars) ···"
+    printf '%s\n' "${prompt: -half}"
+  else
+    printf '%s\n' "$prompt"
+  fi
+  echo "── end preview ──"
+}
+
+# Read the operator's verdict from stdin: y/yes (any case) approves (0),
+# anything else — including EOF from a non-interactive caller and a silence
+# timeout (CCS_DISPATCH_PREVIEW_TIMEOUT, default 60s) — rejects (1). A
+# non-interactive agent flow is expected to hit EOF, show the printed preview
+# to its user, and re-run with --yes once approved.
+_ccs_dispatch_preview_confirm() {
+  local reply=""
+  printf 'Dispatch? [y/N] ' >&2
+  IFS= read -r -t "${CCS_DISPATCH_PREVIEW_TIMEOUT:-60}" reply || return 1
+  case "$reply" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ccs-dispatch() {
   if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     cat <<'HELP'
@@ -758,13 +802,16 @@ Options:
   --context        Inject git status + todos
   --timeout <secs> Override timeout
   --project <dir>  Target project (required)
+  --preview        Show a sign-off block and ask before dispatching;
+                   rejection / EOF / timeout aborts with no job record
+  --yes            Skip the confirmation (with --preview: print and go)
 HELP
     return 0
   fi
 
   _ccs_dispatch_lazy_cleanup
 
-  local mode="async" context=false
+  local mode="async" context=false preview=false assume_yes=false
   local timeout_secs="" project="" task=""
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -772,6 +819,8 @@ HELP
       --context) context=true; shift ;;
       --timeout) timeout_secs="$2"; shift 2 ;;
       --project) project="$2"; shift 2 ;;
+      --preview) preview=true; shift ;;
+      --yes) assume_yes=true; shift ;;
       *) task="$1"; shift ;;
     esac
   done
@@ -813,6 +862,18 @@ HELP
 
   local backend
   backend=$(_ccs_dispatch_resolve_backend)
+
+  # Sign-off gate (#75): before the first side effect, so a rejection leaves
+  # no job record and no worker. --yes keeps automation non-interactive.
+  if $preview; then
+    _ccs_dispatch_preview_render "$project" "$backend" "$mode" \
+      "$timeout_secs" "$prompt"
+    if ! $assume_yes && ! _ccs_dispatch_preview_confirm; then
+      echo "ccs-dispatch: aborted (preview not approved)" >&2
+      return 1
+    fi
+  fi
+
   local job_id
   job_id=$(_ccs_dispatch_job_id)
   _ccs_dispatch_jsonl_append "$(jq -nc \

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -462,7 +462,17 @@ ccs-dispatch --timeout 300 \
 --context      注入目標專案 git 狀態
 --timeout <s>  覆蓋預設 timeout
 --project <d>  目標專案目錄（必填）
+--preview      派發前顯示 sign-off 區塊（prompt / 專案 / backend / seat），
+               stdin 確認 y 才 launch；拒絕、EOF、timeout 都直接中止且
+               不留任何 job 紀錄
+--yes          跳過確認（配 --preview = 印出預覽直接派，供自動化留痕）
 ```
+
+**拍板流程（operator sign-off）**：人直接操作時 `--preview` 會互動確認；
+agent（如 Claude 經 Bash 呼叫）stdin 無資料會得到 EOF → 乾淨中止，agent
+把印出的預覽呈給使用者，核准後帶 `--yes` 重跑。確認等待上限
+`CCS_DISPATCH_PREVIEW_TIMEOUT`（預設 60s），prompt 折疊長度
+`CCS_DISPATCH_PREVIEW_MAX_CHARS`（預設 1500）。
 
 可配置環境變數：
 
@@ -472,6 +482,8 @@ CCS_DISPATCH_TIMEOUT=600          # async 預設 timeout
 CCS_DISPATCH_RESULT_TTL_DAYS=7    # 結果檔保留天數
 CCS_DISPATCH_MAX_CONCURRENT_WARN=3  # 並行 job 警告閾值
 CCS_DISPATCH_BACKEND=auto         # auto | agentpager | headless
+CCS_DISPATCH_PREVIEW_TIMEOUT=60   # --preview 確認等待秒數
+CCS_DISPATCH_PREVIEW_MAX_CHARS=1500  # preview prompt 折疊長度
 ```
 
 ### 後端 (Backends)

--- a/tests/test-dispatch-preview.sh
+++ b/tests/test-dispatch-preview.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-preview.sh — dispatch preview sign-off gate (#75)
+# Units: preview render (fields, long-prompt folding), stdin confirm
+# (yes / no / EOF / timeout), and the ccs-dispatch integration: a rejected
+# preview leaves no job record and never spawns; --yes keeps automation flows.
+# Isolation: XDG_DATA_HOME sandbox; spawn and backend resolution stubbed.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-preview-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+DD="$(_ccs_dispatch_dir)"
+JOBS="$DD/jobs.jsonl"
+SANDBOX="$SCRIPT_DIR/tmp/test-dispatch-preview"
+rm -rf "$SANDBOX"; mkdir -p "$SANDBOX/proj"
+
+SPAWN_LOG="$SANDBOX/spawn.log"
+
+# Stub the spawn layer: record the call, never run a real worker.
+_ccs_dispatch_spawn() {
+  printf '%s\n' "SPAWN job=$1 backend=$6" >> "$SPAWN_LOG"
+  return 0
+}
+# Pin backend resolution so the tests do not depend on host agent-pager state.
+_ccs_dispatch_resolve_backend() { echo "headless"; }
+
+reset_case() {
+  rm -f "$JOBS" "$SPAWN_LOG"; rm -rf "$DD/results" "$DD/pids"
+  mkdir -p "$DD/results" "$DD/pids"
+}
+
+echo "=== render: preview block carries the sign-off facts ==="
+out="$(_ccs_dispatch_preview_render "/some/proj" "agentpager" "async" 600 "do the thing")"
+assert_contains "shows the project" "$out" "project : /some/proj"
+assert_contains "shows the backend" "$out" "backend : agentpager"
+assert_contains "agentpager backend names its seat" "$out" "local-$(id -un)"
+assert_contains "shows mode and timeout" "$out" "async (timeout 600s)"
+assert_contains "shows the prompt text" "$out" "do the thing"
+
+echo "=== render: long prompt folds the middle, keeps the task tail ==="
+long_prompt="$(printf 'x%.0s' $(seq 1 3000))Task: find me"
+out="$(CCS_DISPATCH_PREVIEW_MAX_CHARS=100 _ccs_dispatch_preview_render \
+  "/p" "headless" "async" 600 "$long_prompt")"
+assert_contains "folded prompt notes the full size" "$out" "of 3013 chars"
+assert_not_contains "folded prompt does not dump everything" "$out" \
+  "$(printf 'x%.0s' $(seq 1 200))"
+assert_contains "the trailing task line survives the fold" "$out" "Task: find me"
+
+echo "=== render: multibyte prompt folds on characters, not bytes ==="
+zh_prompt="$(printf '中%.0s' $(seq 1 600))"
+out="$(CCS_DISPATCH_PREVIEW_MAX_CHARS=100 _ccs_dispatch_preview_render \
+  "/p" "headless" "async" 600 "$zh_prompt")"
+assert_contains "head keeps 50 intact characters" "$out" \
+  "$(printf '中%.0s' $(seq 1 50))"
+assert_contains "fold marker counts characters" "$out" "of 600 chars"
+
+echo "=== confirm: y / Y accept, n / EOF reject ==="
+rc=0; echo "y" | _ccs_dispatch_preview_confirm || rc=$?
+assert_eq "y accepts" "0" "$rc"
+rc=0; echo "YES" | _ccs_dispatch_preview_confirm || rc=$?
+assert_eq "YES accepts" "0" "$rc"
+rc=0; echo "n" | _ccs_dispatch_preview_confirm || rc=$?
+assert_eq "n rejects" "1" "$rc"
+rc=0; _ccs_dispatch_preview_confirm </dev/null || rc=$?
+assert_eq "EOF (non-interactive caller) rejects" "1" "$rc"
+
+echo "=== confirm: silence times out as a rejection ==="
+rc=0; sleep 3 | CCS_DISPATCH_PREVIEW_TIMEOUT=1 _ccs_dispatch_preview_confirm || rc=$?
+assert_eq "timeout rejects" "1" "$rc"
+
+echo "=== integration: rejected preview leaves nothing behind ==="
+reset_case
+rc=0
+ccs-dispatch --preview --project "$SANDBOX/proj" "task A" </dev/null >/dev/null 2>&1 || rc=$?
+assert_eq "rejected preview returns non-zero" "1" "$rc"
+assert_eq "no job record on rejection" "0" "$( [ -f "$JOBS" ] && grep -c '' "$JOBS" || echo 0 )"
+assert_eq "spawn never called on rejection" "0" "$( [ -f "$SPAWN_LOG" ] && grep -c '' "$SPAWN_LOG" || echo 0 )"
+
+echo "=== integration: approved preview dispatches ==="
+reset_case
+out="$(echo y | ccs-dispatch --preview --project "$SANDBOX/proj" "task B" 2>/dev/null)"
+assert_contains "preview shown before dispatch" "$out" "dispatch preview"
+assert_contains "job dispatched after approval" "$out" "Job dispatched:"
+assert_eq "spawn called once" "1" "$(grep -c '' "$SPAWN_LOG")"
+assert_eq "job record written" "1" "$(grep -c '"task":"task B"' "$JOBS")"
+
+echo "=== integration: --preview --yes shows but never waits ==="
+reset_case
+out="$(ccs-dispatch --preview --yes --project "$SANDBOX/proj" "task C" </dev/null 2>/dev/null)"
+assert_contains "preview still printed" "$out" "dispatch preview"
+assert_eq "spawn called without stdin" "1" "$(grep -c '' "$SPAWN_LOG")"
+
+echo "=== integration: no flags keeps the current behavior ==="
+reset_case
+out="$(ccs-dispatch --project "$SANDBOX/proj" "task D" </dev/null 2>/dev/null)"
+assert_not_contains "no preview block by default" "$out" "dispatch preview"
+assert_eq "spawn called directly" "1" "$(grep -c '' "$SPAWN_LOG")"
+
+test_summary


### PR DESCRIPTION
## Summary

`ccs-dispatch --preview` 派發前 sign-off gate：顯示 worker prompt、專案、backend（含 agentpager seat 與 fallback 註記）、mode，stdin 確認 `y` 才 launch。拒絕、EOF、timeout 一律乾淨中止——gate 位於第一個副作用之前，**不留 job 紀錄、不起 worker**。補上 mission control「Claude 代派 + user 拍板」流程缺少的拍板點。Closes #75。

## Changes

- `feat(dispatch)`: `_ccs_dispatch_preview_render` — 窄幅 sign-off 區塊；長 prompt 折疊「中段」（頭尾保留，結尾的 `Task:` 行必定存活），字元切片不切壞多位元組中文（`CCS_DISPATCH_PREVIEW_MAX_CHARS` 預設 1500）。
- `feat(dispatch)`: `_ccs_dispatch_preview_confirm` — stdin y/N，EOF 與 timeout（`CCS_DISPATCH_PREVIEW_TIMEOUT` 預設 60s）皆視為拒絕。
- `feat(dispatch)`: `--preview` / `--yes` 旗標；gate 插在 prompt/backend 解析之後、jsonl append 之前。無旗標行為與現行位元一致。
- **Agent 拍板流程**：非互動呼叫端（stdin EOF）拿到印出的 preview 後乾淨中止 → agent 呈給使用者 → 核准後帶 `--yes` 重跑。
- `docs(commands)`: 旗標、拍板流程、兩個 env（含設定 block）。

## Test plan (reviewer checklist)

- [x] `bash tests/run-all.sh` 全綠
- [x] render 欄位（project/backend/seat/mode/長度）；長 prompt 折疊保尾；中文字元折疊
- [x] confirm：y / YES 核准；n / EOF / timeout 拒絕
- [x] 整合：拒絕 → 無 job 紀錄、spawn 未呼叫、return 1；核准 → 正常派發；`--preview --yes` 不等 stdin；無旗標行為不變

## Test results (author 已驗)

**Unit tests：**
`bash tests/run-all.sh`: 25 檔全綠，0 failed，1 skipped（`test-crash-detect.sh`，需 live session data）。
新增 `tests/test-dispatch-preview.sh`: 26 passed, 0 failed。

**E2E tests：**
N/A — gate 為純本地互動邏輯，整合測試以 stub spawn 覆蓋派發路徑；真機派發行為由既有 spawn 測試（40/40）與 #74 E2E 覆蓋。

**Smoke tests：**
N/A — 無裝置/部署面。

## Reviewer summary

獨立 capable code-reviewer（final gate）：**no blockers**、5 findings。

- 已修：`head -c` 位元組截斷會把中文 prompt 切出 mojibake → 改 bash 字元切片 + 中文折疊測試；折疊改頭+尾（原折尾會把 prompt 結尾的 `Task:` 行折掉）；agentpager preview 加 fallback 註記；env 補進 docs 設定 block。
- Reviewer 確認：gate 前呼叫鏈零 job 副作用（lazy_cleanup 為 pre-existing 維護）、read -t 的 EOF/timeout 回傳碼正規化正確、stdout（preview）/stderr（問句）分流對互動與 agent 流程皆正確、`--preview --sync` 無互動問題、fold 測試非 vacuous。

## Carry-forward Minor items

- preview 顯示的 agentpager prompt 與實際 worker prompt 有 wrapper 落差（`_ccs_dispatch_agentpager_prompt` 外包裝；fallback 亦有 jsonl 稽核紀錄）——資訊準確度 nit，可於 auto-chain（v2）一併處理。
- task 字串本身長得像旗標（如字面 `--preview`）會被 parser 吃掉——pre-existing `*)` parser 行為，非本次迴歸。

## Related

- Issue: #75
- 消費情境：mission control 設計（`internal/`，gitignored）；#74 完成通知為同系列