### PR TITLE
feat(dispatch): decouple ccs-jobs detail from worker output

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -238,11 +238,44 @@ This is a dispatched worker session. When the task above is fully complete (or
 before your context fills), first report a one-line summary of what you did.
 Then, AS YOUR VERY LAST ACTION, write a concise handoff to the file
 tmp/handoff-${job_id}.md (path relative to the project root; use ccs-handoff for
-the content if helpful). Writing that file is your completion signal: the
-dispatcher watches for tmp/handoff-${job_id}.md and closes this session once it
-appears, so do not create it until everything else — including your summary — is
-already done. You do NOT need to exit yourself.
+the content if helpful). Begin that file with a YAML frontmatter block the
+dispatcher parses for the job board — the lead reads this line instead of your
+full transcript, so make it a clean standalone summary:
+---
+summary: <one line, <=120 chars, what you accomplished>
+outcome: done | partial | blocked
+next: <one line, the next step if any — omit if none>
+---
+Writing tmp/handoff-${job_id}.md is your completion signal: the dispatcher
+watches for it and closes this session once it appears, so do not create it
+until everything else — including your summary — is already done. You do NOT
+need to exit yourself.
 HGRULE
+}
+
+# Extract the `summary:` line from a handoff file's leading YAML frontmatter.
+# Only a properly CLOSED `---`-delimited block at the top of the file is
+# honoured: the value is emitted only once the closing `---` is seen, so a
+# `summary:` in the body (or an unterminated frontmatter block) is never
+# mistaken for the header field. CRLF line endings are tolerated. Echoes the
+# trimmed value (empty if no frontmatter / no closing / no summary); always rc 0.
+_ccs_dispatch_parse_handoff_summary() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  awk '
+    { sub(/\r$/, "") }                   # tolerate CRLF
+    NR==1 && $0 != "---" { exit }        # no frontmatter -> nothing to read
+    NR==1 { in_fm=1; next }
+    in_fm && $0 == "---" {               # closing delimiter: block is valid
+      print found; exit
+    }
+    in_fm && found == "" && /^summary:[[:space:]]*/ {
+      val = $0
+      sub(/^summary:[[:space:]]*/, "", val)
+      sub(/[[:space:]]+$/, "", val)
+      found = val
+    }
+  ' "$f"
 }
 
 # Write an agent-pager inbound launch file. Frontmatter matches inbound-handler.sh
@@ -429,8 +462,14 @@ _ccs_dispatch_finish_agentpager() {
     fi
   } > "$md"
 
+  # Prefer the worker's structured handoff frontmatter summary (a clean, intended
+  # one-liner) over the raw-transcript tail, which is noisy. Fall back to the tail
+  # only when no frontmatter summary is present.
   local summary=""
-  if [ -f "$raw" ]; then
+  if [ "$handoff_flag" = true ]; then
+    summary=$(_ccs_dispatch_parse_handoff_summary "$handoff_dst")
+  fi
+  if [ -z "$summary" ] && [ -f "$raw" ]; then
     summary=$(tail -n "$CCS_DISPATCH_SUMMARY_LINES" "$raw" | head -c "$CCS_DISPATCH_SUMMARY_MAX_CHARS")
   fi
 
@@ -919,9 +958,10 @@ ccs-jobs() {
 ccs-jobs — view dispatch job history
 
 Usage:
-  ccs-jobs            Recent jobs
-  ccs-jobs --all      All jobs
-  ccs-jobs <job-id>   Single job detail
+  ccs-jobs                 Recent jobs
+  ccs-jobs --all           All jobs
+  ccs-jobs <job-id>        Single job detail (summary + artifact paths)
+  ccs-jobs <job-id> --full Single job detail with full output inlined
 HELP
     return 0
   fi
@@ -937,15 +977,19 @@ HELP
 
   _ccs_jobs_sync_status
 
-  local show_all=false single_id=""
-  case "${1:-}" in
-    --all) show_all=true ;;
-    "") ;;
-    *)  single_id="$1" ;;
-  esac
+  local show_all=false single_id="" full=false
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --all)  show_all=true ;;
+      --full) full=true ;;
+      "") ;;
+      *)      [ -z "$single_id" ] && single_id="$arg" ;;
+    esac
+  done
 
   if [ -n "$single_id" ]; then
-    _ccs_jobs_show_single "$single_id"
+    _ccs_jobs_show_single "$single_id" "$full"
   else
     _ccs_jobs_show_list "$show_all"
   fi
@@ -1071,28 +1115,61 @@ _ccs_jobs_show_list() {
 }
 
 _ccs_jobs_show_single() {
-  local job_id="$1"
+  local job_id="$1" full="${2:-false}"
   local dispatch_dir
   dispatch_dir="$(_ccs_dispatch_dir)"
   local md="$dispatch_dir/results/${job_id}.md"
   local record
   record=$(_ccs_dispatch_jsonl_latest "$job_id")
 
-  if [ -f "$md" ]; then
+  # --full inlines the whole result md (the on-disk artifact). Default stays lean
+  # so the lead's context does not grow with worker output: header fields + the
+  # one-line summary + pointers to the artifacts, which the lead reads on demand.
+  if [ "$full" = true ] && [ -f "$md" ]; then
     cat "$md"
   elif [ -n "$record" ]; then
-    echo "$record" | jq .
-    # For a still-running agent-pager worker, surface last-activity (out.stream
-    # mtime) so a stalled worker is visible for a manual /stop (design D2).
-    local be st
+    local be st proj ec created finished sum handoff_dst
     be=$(echo "$record" | jq -r '.backend // ""')
     st=$(echo "$record" | jq -r '.status // ""')
+    proj=$(echo "$record" | jq -r '.project // "unknown"')
+    ec=$(echo "$record" | jq -r '.exit_code // empty')
+    created=$(echo "$record" | jq -r '.created_at // empty')
+    finished=$(echo "$record" | jq -r '.finished_at // empty')
+    sum=$(echo "$record" | jq -r '.summary // ""')
+
+    echo "# Dispatch Job: $job_id"
+    echo ""
+    echo "- **Project:** $proj"
+    echo "- **Status:** $st"
+    [ -n "$ec" ] && echo "- **Exit code:** $ec"
+    [ -n "$be" ] && echo "- **Backend:** $be"
+    [ -n "$created" ] && echo "- **Created:** $created"
+    [ -n "$finished" ] && echo "- **Finished:** $finished"
+    if [ -n "$sum" ]; then
+      echo ""
+      echo "**Summary:** $sum"
+    fi
+    # Pointers, not content: the lead Reads these only when the summary is not
+    # enough (design: evidence stays on disk).
+    handoff_dst="$dispatch_dir/results/${job_id}.handoff"
+    if [ -f "$md" ]; then
+      echo ""
+      echo "Full output: $md (ccs-jobs $job_id --full)"
+    fi
+    [ -f "$handoff_dst" ] && echo "Handoff: $handoff_dst"
+
+    # For a still-running agent-pager worker, surface last-activity (out.stream
+    # mtime) so a stalled worker is visible for a manual /stop (design D2).
     if [ "$be" = "agentpager" ] && [ "$st" = "running" ]; then
       local la
       la=$(_ccs_dispatch_agentpager_last_activity \
         "local-$(id -un)" "${AGENT_PAGER_DIR:-$HOME/.agent-pager}")
       [ -n "$la" ] && echo "Last activity: $la"
     fi
+  elif [ -f "$md" ]; then
+    # No jsonl record but the artifact exists: nothing structured to distill, so
+    # fall back to the full md regardless of --full.
+    cat "$md"
   else
     echo "Job not found: $job_id" >&2
     return 1

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -537,11 +537,18 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
 查看 dispatch 任務歷史與結果。
 
 ```bash
-ccs-jobs              # 最近 20 筆
-ccs-jobs --all        # 全部
-ccs-jobs <job-id>     # 單筆詳細結果（顯示 .md）
+ccs-jobs                  # 最近 20 筆
+ccs-jobs --all            # 全部
+ccs-jobs <job-id>         # 單筆詳情：狀態欄位 + 一行 summary + artifact 路徑
+ccs-jobs <job-id> --full  # 單筆詳情並內嵌完整 .md 輸出
 ```
 
+- **單筆詳情預設精簡**：只印 header 欄位、worker 回傳的一行 `Summary` 與 artifact
+  路徑指標（`.md` / `.handoff`）；完整輸出改由 `--full` 或直接 Read `.md` 取得。
+  設計目的是讓指揮席（lead）查 job 時 context 不隨 worker 產出膨脹——證據留在磁碟，
+  需要才載入。`--full` flag 位置無關（可放 id 前或後）。
+- **Summary 來源**：agentpager worker 的 handoff 檔開頭若有 YAML frontmatter
+  `summary:`，優先採用（乾淨的一行）；否則 fallback 用 transcript 尾端截斷。
 - **清單 footer**：有 running 的 agentpager worker 時，清單底部顯示其 last-activity
   （out.stream idle 時間），方便發現卡住的 worker。
 - **handoff-ready 提示**：單筆 view 對 `handoff-ready` job 會提示 `.handoff` 路徑與接力

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -54,7 +54,7 @@ description: "MANDATORY for any ccs-* command execution. Never run ccs-* command
 | failure-triage [sid] | ft | `ccs-failure-triage [sid]` — triage session for model confabulation-family failure signals |
 | dispatch [dir] "task" | dp | `ccs-dispatch --project <dir> "task"` — 派工到新 session |
 | jobs | j | `ccs-jobs` — dispatch 任務歷史 |
-| job <id> | | `ccs-jobs <id>` — 單筆結果 |
+| job <id> | | `ccs-jobs <id>` — 單筆結果（精簡：summary + artifact 路徑；`--full` 看完整輸出） |
 | review [sid] | rv | `ccs-review [sid]` — session review 報告 |
 | review html [sid] | | `ccs-review [sid] --format html -o <path>` — HTML 報告 |
 | weekly [since] [until] | wk | `ccs-review --since <date> --until <date>` — 週報 |

--- a/tests/test-jobs-agentpager.sh
+++ b/tests/test-jobs-agentpager.sh
@@ -157,4 +157,54 @@ printf '# Dispatch Result: d-cp\n- **Status:** completed\n' > "$DD/results/d-cp.
 cp_out="$(ccs-jobs d-cp 2>/dev/null)"
 assert_not_contains "completed job -> no chain hint" "$cp_out" "auto-chaining is v2"
 
+echo "=== single view: default is slim (summary + pointer, no full output) ==="
+reset_jobs
+jrec '{"job_id":"d-slim","project":"p","backend":"headless","status":"completed","exit_code":0,"summary":"did the thing in one line","created_at":"2026-07-03T10:00:00+08:00","finished_at":"2026-07-03T10:05:00+08:00"}'
+{ printf '# Dispatch Result: d-slim\n## Output\n'; head -c 40000 /dev/zero | tr '\0' 'x'; } > "$DD/results/d-slim.md"
+def_out="$(ccs-jobs d-slim 2>/dev/null)"
+assert_contains "default shows the one-line summary" "$def_out" "did the thing in one line"
+assert_contains "default points at the full artifact" "$def_out" "results/d-slim.md"
+assert_not_contains "default does NOT inline the 40KB output" "$def_out" "xxxxxxxxxx"
+# Payload must be decoupled from artifact size.
+def_bytes=$(printf '%s' "$def_out" | wc -c)
+if [ "$def_bytes" -lt 2000 ]; then
+  printf '  PASS: default payload stays small (%s bytes vs 40KB artifact)\n' "$def_bytes"
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: default payload too large (%s bytes)\n' "$def_bytes"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "=== single view: --full inlines the artifact ==="
+full_out="$(ccs-jobs d-slim --full 2>/dev/null)"
+assert_contains "--full inlines the full output" "$full_out" "xxxxxxxxxx"
+
+echo "=== handoff frontmatter summary parser ==="
+hf="$DD/results/hf-sample.handoff"
+printf -- '---\nsummary:   clean intended line   \noutcome: done\n---\n\nsummary: body decoy\n' > "$hf"
+assert_eq "parser extracts + trims frontmatter summary" \
+  "clean intended line" "$(_ccs_dispatch_parse_handoff_summary "$hf")"
+printf '# no frontmatter\nsummary: body\n' > "$hf"
+assert_eq "parser returns empty when no frontmatter" \
+  "" "$(_ccs_dispatch_parse_handoff_summary "$hf")"
+# Unterminated frontmatter must NOT leak a body summary (review finding #3).
+printf -- '---\noutcome: done\nsummary: leaked from unterminated block\n' > "$hf"
+assert_eq "parser ignores summary in unterminated frontmatter" \
+  "" "$(_ccs_dispatch_parse_handoff_summary "$hf")"
+# CRLF line endings tolerated (review finding #2).
+printf -- '---\r\nsummary: crlf line\r\n---\r\n' > "$hf"
+assert_eq "parser tolerates CRLF frontmatter" \
+  "crlf line" "$(_ccs_dispatch_parse_handoff_summary "$hf")"
+# Colon-in-value preserved.
+printf -- '---\nsummary: fix: the bar\n---\n' > "$hf"
+assert_eq "parser preserves colons in the value" \
+  "fix: the bar" "$(_ccs_dispatch_parse_handoff_summary "$hf")"
+
+echo "=== ccs-jobs: --full accepted before the id (review finding #4) ==="
+reset_jobs
+jrec '{"job_id":"d-pos","project":"p","backend":"headless","status":"completed","summary":"pos test","created_at":"2026-07-03T10:00:00+08:00"}'
+{ printf '## Output\n'; head -c 3000 /dev/zero | tr '\0' 'y'; } > "$DD/results/d-pos.md"
+assert_contains "--full before id still inlines output" \
+  "$(ccs-jobs --full d-pos 2>/dev/null)" "yyyyyyyyyy"
+
 test_summary


### PR DESCRIPTION
## 背景

指揮席（lead）session 若開在 home dir 做跨 repo 協調，長壽的前提是 context 不隨工作量膨脹。實測發現 `ccs-jobs` 看板本身已與工作量脫鉤，但**單筆 `ccs-jobs <id>` 詳情會 `cat` 完整結果 `.md`**，指揮席每查一個 job 就把 worker 的整份輸出吸進 context。

本 PR 讓詳情 view 的 payload 與 worker 產出大小脫鉤：證據留在磁碟，只有蒸餾後的狀態進 context。設計理念參考 Claude Code dynamic workflows 的 context 隔離機制。

## 變更

- **`ccs-jobs <id>` 預設精簡**：只印 header 欄位 + 一行 `Summary` + artifact 路徑指標（`.md` / `.handoff`）；完整輸出改由 `--full` 內嵌或直接 Read `.md`。`.md` artifact 本身保持全文不動（它就是磁碟上的證據）。
- **Summary 來源升級**：worker handoff 檔開頭的 YAML frontmatter（`summary:`）優先採用（乾淨的一行），無則 fallback 用 transcript 尾端截斷。dispatch 的 HANDOFF RULE prompt 現要求 worker 產出該 frontmatter。
- **健壯性**：frontmatter parser 只認「正確閉合」的檔首區塊（避免未閉合時誤抓 body 的 `summary:`）、容忍 CRLF；`--full` flag 位置無關。

## 效果驗證

單筆詳情預設 payload 與產出大小脫鉤：

```
raw output size:   5KB    50KB   200KB
default detail:    301    304    307   bytes
```

`--full` 輸出 == 改動前行為（無回歸）。

## Review

Final gate（capable-tier subagent）審完 diff + 測試，無 blocking findings。4 個 minor findings（dead local var、CRLF、未閉合 frontmatter 洩漏、`--full` 位置）已全數修正並補測試。

## Test Report

- `tests/test-jobs-agentpager.sh`：**31 passed, 0 failed**（原 20 + 11 新增，涵蓋精簡 view、`--full`、parser 邊界：未閉合 / CRLF / colon-in-value / flag 位置）
- `tests/test-dispatch.sh`：0 failures
- `tests/test-dispatch-backend.sh`：21 passed, 0 failed
- `tests/test-dispatch-spawn-agentpager.sh`：40 passed, 0 failed
- `bash -n` syntax check 通過

## 文件同步（sync-checklist）

- `docs/commands.md`：ccs-jobs 段更新（精簡預設 + `--full` + summary 來源）
- `skills/ccs-orchestrator/SKILL.md`：Command Palette `job <id>` 說明更新

無新增 / 移除指令或模組、未改狀態圖示。