### PR TITLE
feat(dispatch): auto-chain agentpager workers via handoff next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 - **ccs-jobs agent-pager visibility** — the list shows a running agent-pager worker's last-activity in a footer line, and the single-job view hints the `.handoff` path plus a prefilled follow-up `ccs-dispatch` template on handoff-ready jobs. (PR #72)
 - **ccs-dispatch completion notification** — an agentpager job pushes one short pager message at finalize (job id, status, project, `.handoff` path) via agent-pager's notify channel. Best-effort (a missing or hung sender never affects finalize), opt-out with `CCS_DISPATCH_NOTIFY=0`, bot slot pinned via `CCS_DISPATCH_NOTIFY_SLOT`. (#74)
 - **ccs-dispatch preview sign-off** — `--preview` shows the worker prompt, project, backend, and seat, then asks for confirmation before dispatching; rejection, EOF, or timeout aborts with no job record. `--yes` skips the question for automation. (#75)
+- **ccs-dispatch chained handoffs** — `--chain [--max-depth N]` (agentpager only) auto-launches the next worker when one reports `outcome: done` + a non-empty `next:` in its handoff, within the same project, without routing the intermediate decision back through the lead session. Approved once up front; stops on `partial`/`blocked`/`failed`/empty-next/max-depth with a chain-termination pager notify. Lineage (`chain_parent`/`chain_depth`) shows in `ccs-jobs <id>`. An autonomy invariant (do not ask clarifying questions; blocked → `outcome: blocked`) now applies to all agentpager workers. See `docs/commands.md`.
 
 ### Fixed
 

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -11,6 +11,8 @@ CCS_DISPATCH_RESULT_TTL_DAYS="${CCS_DISPATCH_RESULT_TTL_DAYS:-7}"
 CCS_DISPATCH_SUMMARY_LINES="${CCS_DISPATCH_SUMMARY_LINES:-30}"
 CCS_DISPATCH_SUMMARY_MAX_CHARS="${CCS_DISPATCH_SUMMARY_MAX_CHARS:-200}"
 CCS_DISPATCH_MAX_CONCURRENT_WARN="${CCS_DISPATCH_MAX_CONCURRENT_WARN:-3}"
+CCS_DISPATCH_CHAIN_MAX_DEPTH="${CCS_DISPATCH_CHAIN_MAX_DEPTH:-5}"
+CCS_DISPATCH_CHAIN_BRIDGE_MAX_CHARS="${CCS_DISPATCH_CHAIN_BRIDGE_MAX_CHARS:-4000}"
 
 # ── Backend selection ──
 # Returns 0 if the agent-pager backend is usable, 1 otherwise.
@@ -250,32 +252,96 @@ Writing tmp/handoff-${job_id}.md is your completion signal: the dispatcher
 watches for it and closes this session once it appears, so do not create it
 until everything else — including your summary — is already done. You do NOT
 need to exit yourself.
+
+AUTONOMY (this is an unattended dispatched session):
+Do not ask clarifying questions and do not wait on terminal input. If a detail
+is ambiguous, make a reasonable assumption, proceed, and record the assumption
+in your handoff. If you are genuinely blocked and cannot proceed, do NOT stall
+waiting for input — set outcome: blocked in the handoff frontmatter and explain
+what you need. A blocked handoff surfaces the question to the operator.
 HGRULE
 }
 
-# Extract the `summary:` line from a handoff file's leading YAML frontmatter.
+# Extract the `<field>:` value from a handoff file's leading YAML frontmatter.
 # Only a properly CLOSED `---`-delimited block at the top of the file is
 # honoured: the value is emitted only once the closing `---` is seen, so a
-# `summary:` in the body (or an unterminated frontmatter block) is never
-# mistaken for the header field. CRLF line endings are tolerated. Echoes the
-# trimmed value (empty if no frontmatter / no closing / no summary); always rc 0.
-_ccs_dispatch_parse_handoff_summary() {
-  local f="$1"
+# `<field>:` in the body (or an unterminated frontmatter block) is never
+# mistaken for the header field. First occurrence wins. CRLF tolerated.
+# Echoes the trimmed value (empty if no frontmatter / no closing / no field);
+# always rc 0.
+_ccs_dispatch_parse_handoff_field() {
+  local f="$1" field="$2"
   [ -f "$f" ] || return 0
-  awk '
+  awk -v key="$field" '
     { sub(/\r$/, "") }                   # tolerate CRLF
     NR==1 && $0 != "---" { exit }        # no frontmatter -> nothing to read
     NR==1 { in_fm=1; next }
     in_fm && $0 == "---" {               # closing delimiter: block is valid
       print found; exit
     }
-    in_fm && found == "" && /^summary:[[:space:]]*/ {
-      val = $0
-      sub(/^summary:[[:space:]]*/, "", val)
+    in_fm && found == "" && index($0, key ":") == 1 {
+      val = substr($0, length(key) + 2)  # drop "key:"
+      sub(/^[[:space:]]*/, "", val)
       sub(/[[:space:]]+$/, "", val)
       found = val
     }
   ' "$f"
+}
+
+# Extract the `summary:` frontmatter field (see _ccs_dispatch_parse_handoff_field
+# for the exact semantics). Kept as a named helper for its existing callers.
+_ccs_dispatch_parse_handoff_summary() {
+  _ccs_dispatch_parse_handoff_field "$1" summary
+}
+
+# Build the context preamble that prefixes a chained hop's task. The parent
+# handoff is the chain's context carrier (design §9.3): the next worker cold-
+# starts, so it must be told what the previous worker did. Emits the parent
+# summary line plus the handoff body (frontmatter stripped), capped to
+# ~CCS_DISPATCH_CHAIN_BRIDGE_MAX_CHARS bytes (head -c; a soft ceiling that may
+# slice a trailing multibyte char). Empty output when the file is absent.
+_ccs_dispatch_chain_context_bridge() {
+  local handoff="$1"
+  [ -f "$handoff" ] || return 0
+  local summary body
+  summary="$(_ccs_dispatch_parse_handoff_field "$handoff" summary)"
+  # Body = everything after a closed leading frontmatter block; if there is no
+  # frontmatter, the whole file is the body.
+  body="$(awk '
+    NR==1 && $0 != "---" { print; body=1; next }
+    NR==1 { in_fm=1; next }
+    in_fm && $0 == "---" { in_fm=0; body=1; next }
+    in_fm { next }
+    body { print }
+  ' "$handoff" | head -c "$CCS_DISPATCH_CHAIN_BRIDGE_MAX_CHARS")"
+  printf 'You are continuing a chained task. The previous worker reported:\n'
+  [ -n "$summary" ] && printf '  %s\n' "$summary"
+  printf '\nIts full handoff (your context) follows:\n'
+  printf -- '---\n%s\n---\n\n' "$body"
+}
+
+# Pure continuation predicate. Returns an empty string when the chain should
+# CONTINUE (outcome==done AND next non-empty AND depth<max), or a verbatim stop
+# reason otherwise (partial / blocked / failed / depth / empty-next). No side
+# effects. See spec §2 (predicate) and §6 (reason strings).
+_ccs_dispatch_chain_stop_reason() {
+  local status="$1" outcome="$2" next="$3" depth="$4" max="$5"
+  if [ "$status" != "handoff-ready" ]; then
+    printf 'failed\n'; return 0
+  fi
+  case "$outcome" in
+    done)    : ;;                       # candidate to continue; checks below
+    partial) printf 'partial\n'; return 0 ;;
+    blocked) printf 'blocked\n'; return 0 ;;
+    *)       printf 'failed\n'; return 0 ;;  # empty / unknown outcome
+  esac
+  if [ -z "$next" ]; then
+    printf 'empty-next\n'; return 0
+  fi
+  if [ "$depth" -ge "$max" ]; then
+    printf 'depth\n'; return 0
+  fi
+  printf '\n'                            # continue
 }
 
 # Write an agent-pager inbound launch file. Frontmatter matches inbound-handler.sh
@@ -497,12 +563,128 @@ _ccs_dispatch_finish_agentpager() {
     "$notify_handoff" "$note"
 }
 
+# Best-effort chain-termination pager notify (spec §7): one short message with
+# the stop reason when a chain ends. "complete" for a clean end (empty-next /
+# depth), "stopped" otherwise. Never fails the caller. CCS_DISPATCH_NOTIFY=0
+# opts out (shared with the per-job completion notify).
+_ccs_dispatch_chain_notify() {
+  [ "${CCS_DISPATCH_NOTIFY:-1}" != "0" ] || return 0
+  local job_id="$1" reason="$2" project="$3" depth="$4"
+  local sender
+  sender="$(_ccs_dispatch_notify_sender)"
+  [ -n "$sender" ] && [ -x "$sender" ] || return 0
+  local verb="stopped"
+  case "$reason" in empty-next|depth) verb="complete" ;; esac
+  {
+    echo "chain ${verb}: ${reason}"
+    echo "last job: ${job_id} (depth ${depth})"
+    echo "project: ${project}"
+  } | AGENT_PAGER_NOTIFY=1 \
+    AGENT_PAGER_BOT_SLOT="${CCS_DISPATCH_NOTIFY_SLOT:-1}" \
+    timeout "${CCS_DISPATCH_NOTIFY_TIMEOUT:-10}" \
+    "$sender" --cwd "$HOME" --label "ccs-dispatch" \
+    >/dev/null 2>&1 || true
+  return 0
+}
+
+# Chain continuation engine (spec §2-§7). Called by the monitor after a job is
+# finalized. Reads the just-captured handoff's outcome/next, evaluates the
+# continuation predicate, and either stops the chain (record chain_stopped +
+# terminal notify) or mints + launches the next hop and re-enters the monitor.
+# The chain is single-project by construction: the next hop inherits the parent
+# project_dir and re-resolves the SAME proj key (no cross-project branch).
+_ccs_dispatch_chain_next() {
+  local job_id="$1" key="$2" project_dir="$3" pager_dir="$4"
+  local chain_depth="$5" max_depth="$6"
+  local dispatch_dir
+  dispatch_dir="$(_ccs_dispatch_dir)"
+  local handoff_dst="$dispatch_dir/results/${job_id}.handoff"
+
+  local status outcome next_task project reason
+  status="$(_ccs_dispatch_jsonl_latest "$job_id" | jq -r '.status // ""')"
+  outcome="$(_ccs_dispatch_parse_handoff_field "$handoff_dst" outcome)"
+  next_task="$(_ccs_dispatch_parse_handoff_field "$handoff_dst" next)"
+  project="$(_ccs_dispatch_jsonl_latest "$job_id" | jq -r '.project // "unknown"')"
+  reason="$(_ccs_dispatch_chain_stop_reason \
+    "$status" "$outcome" "$next_task" "$chain_depth" "$max_depth")"
+
+  if [ -n "$reason" ]; then
+    _ccs_dispatch_jsonl_append "$(jq -nc \
+      --arg jid "$job_id" --arg r "$reason" \
+      '{job_id:$jid, chain_stopped:$r}')"
+    _ccs_dispatch_chain_notify "$job_id" "$reason" "$project" "$chain_depth"
+    return 0
+  fi
+
+  # Continue: resolve the inherited proj key. Same dir the parent used, so this
+  # succeeds unless the proj-map changed mid-chain; if it cannot resolve, stop.
+  local proj
+  if ! proj="$(_ccs_dispatch_resolve_proj_from_dir "$project_dir")"; then
+    _ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$job_id" \
+      '{job_id:$jid, chain_stopped:"failed",
+        note:"chain: parent proj key no longer resolvable"}')"
+    _ccs_dispatch_chain_notify "$job_id" "failed" "$project" "$chain_depth"
+    return 0
+  fi
+
+  local next_job_id next_depth
+  next_job_id="$(_ccs_dispatch_job_id)"
+  next_depth=$((chain_depth + 1))
+
+  # Lineage record for the new hop (running).
+  _ccs_dispatch_jsonl_append "$(jq -nc \
+    --arg jid "$next_job_id" \
+    --arg proj "$project" \
+    --arg t "$next_task" \
+    --arg be "agentpager" \
+    --arg ca "$(date -Iseconds)" \
+    --arg cp "$job_id" \
+    --argjson cd "$next_depth" \
+    --argjson cm "$max_depth" \
+    '{job_id:$jid, project:$proj, task:$t, backend:$be, status:"running",
+      created_at:$ca, chain:true, chain_parent:$cp, chain_depth:$cd,
+      chain_max:$cm}')"
+  printf '%s' "$next_task" > "$dispatch_dir/results/${next_job_id}.prompt"
+
+  # Build the next worker prompt: parent context bridge + verification rule +
+  # the next task, then wrapped by the handoff rule + autonomy invariant.
+  local bridge vrule inner worker_prompt
+  bridge="$(_ccs_dispatch_chain_context_bridge "$handoff_dst")"
+  vrule="$(_ccs_dispatch_verification_rule)"
+  inner="${bridge}${vrule}Task: ${next_task}"
+  worker_prompt="$(_ccs_dispatch_agentpager_prompt "$next_job_id" "$inner")"
+
+  # Launch offset: only capture the new hop's frames.
+  local stream start_offset=0
+  stream="$pager_dir/channels/$key/out.stream"
+  [ -f "$stream" ] && start_offset="$(stat -c %s "$stream" 2>/dev/null || echo 0)"
+
+  if ! _ccs_dispatch_agentpager_launch_file \
+        "$next_job_id" "$proj" "$key" "$worker_prompt" "$pager_dir" >/dev/null; then
+    _ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$next_job_id" \
+      '{job_id:$jid, status:"failed", chain_stopped:"failed",
+        note:"chain: launch write failed"}')"
+    _ccs_dispatch_chain_notify "$next_job_id" "failed" "$project" "$next_depth"
+    return 0
+  fi
+
+  # This same background process keeps owning the chain: register its pid under
+  # the new hop so ccs-jobs sync defers to the live monitor, then re-enter.
+  echo $$ > "$dispatch_dir/pids/${next_job_id}.pid"
+  _ccs_dispatch_agentpager_monitor "$next_job_id" "$key" "$project_dir" \
+    "$start_offset" "$pager_dir" 1 "$next_depth" "$max_depth" "$job_id"
+}
+
 # Background monitor for one agent-pager job. Runs under nohup from spawn. Polls
 # for the handoff file; when it appears, stops the seat and finalizes. Also exits
 # the loop if the worker's tmux session disappears on its own (self /exit or
 # crash). No wall-clock timeout (design D2: never auto-kill).
 _ccs_dispatch_agentpager_monitor() {
   local job_id="$1" key="$2" project_dir="$3" start_offset="$4" pager_dir="$5"
+  local chain_enabled="${6:-0}" chain_depth="${7:-0}" max_depth="${8:-5}"
+  # Slot 9 (chain_parent) is accepted for call-site symmetry but not read here:
+  # chain_next derives the parent from the finished job_id it is handed.
+  local _chain_parent="${9:-}"
   local tmux_session="agent-pager-$key"
   local stream="$pager_dir/channels/$key/out.stream"
   local state_json="$pager_dir/state/sessions/$key.json"
@@ -566,6 +748,13 @@ _ccs_dispatch_agentpager_monitor() {
   local no_handoff_status="completed"
   [ "$observed" = 0 ] && no_handoff_status="failed"
   _ccs_dispatch_finish_agentpager "$job_id" "$handoff_src" "$no_handoff_status" "$note"
+
+  # Chain continuation: only when this dispatch opted in. chain_next evaluates
+  # the predicate on the captured handoff and either stops or launches + re-
+  # enters the monitor for the next hop (bounded by max_depth). (spec §3)
+  [ "$chain_enabled" = 1 ] || return 0
+  _ccs_dispatch_chain_next "$job_id" "$key" "$project_dir" "$pager_dir" \
+    "$chain_depth" "$max_depth"
 }
 
 # Poll until the tmux session is gone or $2 seconds elapse. Extracted so the
@@ -601,6 +790,7 @@ _ccs_dispatch_agentpager_wait_settle() {
 # headless) for --sync, an unresolvable proj key, or an inbound write failure.
 _ccs_dispatch_spawn_agentpager() {
   local job_id="$1" project_dir="$2" prompt="$3" timeout_secs="$4" mode="$5"
+  local chain_enabled="${6:-0}" max_depth="${7:-5}"
 
   if [ "$mode" = "sync" ]; then
     echo "ccs-dispatch: agent-pager backend is async-only;" \
@@ -650,8 +840,9 @@ _ccs_dispatch_spawn_agentpager() {
   if [ "${CCS_DISPATCH_AGENTPAGER_MONITOR:-1}" = "1" ]; then
     nohup bash -c '
       source "$6/ccs-dashboard.sh"
-      _ccs_dispatch_agentpager_monitor "$1" "$2" "$3" "$4" "$5"
+      _ccs_dispatch_agentpager_monitor "$1" "$2" "$3" "$4" "$5" "$7" 0 "$8" ""
     ' _ "$job_id" "$key" "$project_dir" "$start_offset" "$pager_dir" "$script_dir" \
+      "$chain_enabled" "$max_depth" \
       > /dev/null 2>&1 &
     echo $! > "$dispatch_dir/pids/${job_id}.pid"
     disown
@@ -708,11 +899,13 @@ _ccs_dispatch_spawn() {
   local job_id="$1" project_dir="$2" prompt="$3"
   local timeout_secs="$4" mode="$5"
   local backend="${6:-$(_ccs_dispatch_resolve_backend)}"
+  local chain_enabled="${7:-0}" max_depth="${8:-5}"
 
   _CCS_DISPATCH_LAST_BACKEND="$backend"
   if [ "$backend" = "agentpager" ]; then
     if _ccs_dispatch_spawn_agentpager \
-         "$job_id" "$project_dir" "$prompt" "$timeout_secs" "$mode"; then
+         "$job_id" "$project_dir" "$prompt" "$timeout_secs" "$mode" \
+         "$chain_enabled" "$max_depth"; then
       return 0
     fi
     _CCS_DISPATCH_LAST_BACKEND="headless"  # agent-pager failed -> fell back
@@ -788,6 +981,7 @@ VRULE
 # a size note (CCS_DISPATCH_PREVIEW_MAX_CHARS, default 1500).
 _ccs_dispatch_preview_render() {
   local project="$1" backend="$2" mode="$3" timeout_secs="$4" prompt="$5"
+  local chain_enabled="${6:-0}" max_depth="${7:-5}"
   local max="${CCS_DISPATCH_PREVIEW_MAX_CHARS:-1500}"
   local seat=""
   [ "$backend" = "agentpager" ] && seat=" (seat local-$(id -un))"
@@ -797,6 +991,9 @@ _ccs_dispatch_preview_render() {
   [ "$backend" = "agentpager" ] && \
     echo "          (falls back to headless if the seat is unavailable)"
   echo "mode    : $mode (timeout ${timeout_secs}s)"
+  [ "$chain_enabled" = 1 ] && \
+    echo "chain   : auto-continue up to ${max_depth} hops in this project" \
+         "(worker reports done + next)"
   echo "prompt  : ${#prompt} chars"
   # Fold the middle, not the tail: the prompt ends with "Task: ...", which is
   # exactly what the operator signs off on. Char-based slicing keeps multibyte
@@ -844,6 +1041,10 @@ Options:
   --preview        Show a sign-off block and ask before dispatching;
                    rejection / EOF / timeout aborts with no job record
   --yes            Skip the confirmation (with --preview: print and go)
+  --chain          (agentpager only) auto-continue the chain: when a worker
+                   reports outcome:done + next, launch the next worker in the
+                   same project without asking again. Approved once up front.
+  --max-depth <n>  Max chained hops (default 5); a runaway ceiling.
 HELP
     return 0
   fi
@@ -852,6 +1053,7 @@ HELP
 
   local mode="async" context=false preview=false assume_yes=false
   local timeout_secs="" project="" task=""
+  local chain=false max_depth="$CCS_DISPATCH_CHAIN_MAX_DEPTH"
   while [ $# -gt 0 ]; do
     case "$1" in
       --sync) mode="sync"; shift ;;
@@ -860,6 +1062,14 @@ HELP
       --project) project="$2"; shift 2 ;;
       --preview) preview=true; shift ;;
       --yes) assume_yes=true; shift ;;
+      --chain) chain=true; shift ;;
+      --max-depth)
+        case "$2" in
+          ''|*[!0-9]*)
+            echo "ccs-dispatch: --max-depth needs a non-negative integer" >&2
+            return 1 ;;
+        esac
+        max_depth="$2"; shift 2 ;;
       *) task="$1"; shift ;;
     esac
   done
@@ -902,11 +1112,20 @@ HELP
   local backend
   backend=$(_ccs_dispatch_resolve_backend)
 
+  # --chain needs the agentpager monitor; headless is fire-and-forget with no
+  # monitor to run the chain loop. Warn and dispatch a single job. (spec §3/§8)
+  if $chain && [ "$backend" != "agentpager" ]; then
+    echo "ccs-dispatch: --chain requires the agentpager backend;" \
+         "dispatching a single (non-chained) job on $backend" >&2
+    chain=false
+  fi
+  local chain_enabled=0; $chain && chain_enabled=1
+
   # Sign-off gate (#75): before the first side effect, so a rejection leaves
   # no job record and no worker. --yes keeps automation non-interactive.
   if $preview; then
     _ccs_dispatch_preview_render "$project" "$backend" "$mode" \
-      "$timeout_secs" "$prompt"
+      "$timeout_secs" "$prompt" "$chain_enabled" "$max_depth"
     if ! $assume_yes && ! _ccs_dispatch_preview_confirm; then
       echo "ccs-dispatch: aborted (preview not approved)" >&2
       return 1
@@ -923,12 +1142,15 @@ HELP
     --arg m "$mode" \
     --arg be "$backend" \
     --arg ca "$(date -Iseconds)" \
-    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, status:"running", created_at:$ca}'
+    --argjson ce "$chain_enabled" \
+    --argjson md "$max_depth" \
+    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, status:"running", created_at:$ca}
+     + (if $ce == 1 then {chain:true, chain_depth:0, chain_max:$md} else {} end)'
   )"
 
   local spawn_rc=0
   _ccs_dispatch_spawn "$job_id" "$project" "$prompt" \
-    "$timeout_secs" "$mode" "$backend" || spawn_rc=$?
+    "$timeout_secs" "$mode" "$backend" "$chain_enabled" "$max_depth" || spawn_rc=$?
 
   if [ "${_CCS_DISPATCH_LAST_BACKEND:-$backend}" != "$backend" ]; then
     _ccs_dispatch_jsonl_append "$(jq -nc \
@@ -1145,6 +1367,18 @@ _ccs_jobs_show_single() {
     [ -n "$be" ] && echo "- **Backend:** $be"
     [ -n "$created" ] && echo "- **Created:** $created"
     [ -n "$finished" ] && echo "- **Finished:** $finished"
+    local cdepth cmax cparent cstopped
+    cdepth=$(echo "$record" | jq -r '.chain_depth // empty')
+    if [ -n "$cdepth" ]; then
+      cmax=$(echo "$record" | jq -r '.chain_max // empty')
+      cparent=$(echo "$record" | jq -r '.chain_parent // empty')
+      cstopped=$(echo "$record" | jq -r '.chain_stopped // empty')
+      local cline="- **Chain:** depth ${cdepth}"
+      [ -n "$cmax" ] && cline="${cline}/${cmax}"
+      [ -n "$cparent" ] && cline="${cline}, parent=${cparent}"
+      [ -n "$cstopped" ] && cline="${cline}, stopped: ${cstopped}"
+      echo "$cline"
+    fi
     if [ -n "$sum" ]; then
       echo ""
       echo "**Summary:** $sum"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -466,6 +466,9 @@ ccs-dispatch --timeout 300 \
                stdin 確認 y 才 launch；拒絕、EOF、timeout 都直接中止且
                不留任何 job 紀錄
 --yes          跳過確認（配 --preview = 印出預覽直接派，供自動化留痕）
+--chain        (agentpager only) 自動接力：worker 回報 outcome:done + next 時，
+               在同一專案內自動派出下一個 worker，不再逐跳詢問（鏈首一次核准）
+--max-depth <n> 最大接力跳數（預設 5），防跑飛硬上限
 ```
 
 **拍板流程（operator sign-off）**：人直接操作時 `--preview` 會互動確認；
@@ -484,6 +487,8 @@ CCS_DISPATCH_MAX_CONCURRENT_WARN=3  # 並行 job 警告閾值
 CCS_DISPATCH_BACKEND=auto         # auto | agentpager | headless
 CCS_DISPATCH_PREVIEW_TIMEOUT=60   # --preview 確認等待秒數
 CCS_DISPATCH_PREVIEW_MAX_CHARS=1500  # preview prompt 折疊長度
+CCS_DISPATCH_CHAIN_MAX_DEPTH=5    # --chain 預設最大接力跳數
+CCS_DISPATCH_CHAIN_BRIDGE_MAX_CHARS=4000  # 鏈鎖 context 橋接上限
 ```
 
 ### 後端 (Backends)
@@ -529,6 +534,20 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
   混進互動對話串（slot role 的原生支援由 agent-pager 端追蹤——internal GitLab
   issue #76，落地後此預設會改為查詢保留 slot）。注意：只有 monitor 的
   即時 finalize 會通知；`ccs-jobs` sync 的事後補帳（stale 對帳）不通知。
+
+**鏈鎖模式（`--chain`）：**
+
+- 僅 agentpager 後端支援（headless 無 monitor，會警告並退回單發）。
+- 鏈首 `--preview` 會多顯示一行鏈鎖模式與最大跳數；核准一次即涵蓋整條鏈，
+  中繼決策不進指揮席（lead）context。
+- 續鏈判定：worker 的 handoff frontmatter `outcome: done` 且 `next:` 非空且
+  未達 max-depth 時，monitor 讀 `next:` 自動組下一跳（含前一跳 handoff 的
+  context 橋接 + HANDOFF RULE + 自主性指令），繼承同一專案 proj key。
+- 停鏈原因：`partial` / `blocked` / `failed` / `empty-next` / `depth`，記入
+  `chain_stopped`，並發一則鏈終止 pager 通知。
+- `ccs-jobs <job-id>` 顯示 `Chain: depth N/max, parent=…, stopped: …` 血緣。
+- 自主性指令套用**所有** agentpager 派工（不限鏈鎖）：worker 不問澄清問題、
+  卡住時設 `outcome: blocked`（→ 停鏈浮回指揮席），不等終端輸入。
 
 結果存放：`${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/`
 

--- a/tests/test-dispatch-chain.sh
+++ b/tests/test-dispatch-chain.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-chain.sh — chained-handoffs auto-chain (Task 11).
+# Units: generic frontmatter field parser, autonomy invariant, context bridge,
+# continuation predicate, chain_next lineage + recursion (monitor mock).
+# Isolation: XDG_DATA_HOME sandbox + AGENT_PAGER_DIR sandbox; tmux mocked via
+# overriding _ccs_dispatch_agentpager_session_alive.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-chain-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+RS=$'\x1e'; US=$'\x1f'
+DD="$(_ccs_dispatch_dir)"
+JOBS="$DD/jobs.jsonl"
+
+reset_jobs() {
+  rm -f "$JOBS"; rm -rf "$DD/results" "$DD/pids"
+  mkdir -p "$DD/results" "$DD/pids"
+}
+
+echo "=== generic field parser: outcome + next from closed frontmatter ==="
+ff="$DD/parse-sample.handoff"
+mkdir -p "$DD"
+printf -- '---\nsummary: did the thing\noutcome:  done \nnext: wire up the API\n---\n\noutcome: body decoy\n' > "$ff"
+assert_eq "field parser reads outcome (trimmed)" \
+  "done" "$(_ccs_dispatch_parse_handoff_field "$ff" outcome)"
+assert_eq "field parser reads next" \
+  "wire up the API" "$(_ccs_dispatch_parse_handoff_field "$ff" next)"
+assert_eq "field parser reads summary" \
+  "did the thing" "$(_ccs_dispatch_parse_handoff_field "$ff" summary)"
+assert_eq "missing field -> empty" \
+  "" "$(_ccs_dispatch_parse_handoff_field "$ff" nonesuch)"
+# Unterminated frontmatter must not leak a body field.
+printf -- '---\noutcome: done\nnext: leaked\n' > "$ff"
+assert_eq "unterminated frontmatter -> empty next" \
+  "" "$(_ccs_dispatch_parse_handoff_field "$ff" next)"
+# Summary delegate keeps its public behavior (regression).
+printf -- '---\nsummary: fix: the bar\n---\n' > "$ff"
+assert_eq "summary delegate preserves colons" \
+  "fix: the bar" "$(_ccs_dispatch_parse_handoff_summary "$ff")"
+
+echo "=== autonomy invariant present in every agentpager worker prompt ==="
+ap="$(_ccs_dispatch_agentpager_prompt "d-auto-1" $'Task: do X')"
+assert_contains "prompt keeps the task" "$ap" "Task: do X"
+assert_contains "prompt still names the per-job handoff" "$ap" "tmp/handoff-d-auto-1.md"
+assert_contains "prompt forbids clarifying questions" "$ap" "Do not ask clarifying questions"
+assert_contains "prompt routes blocked to outcome: blocked" "$ap" "outcome: blocked"
+
+echo "=== context bridge carries parent summary + body, capped ==="
+bh="$DD/bridge.handoff"
+printf -- '---\nsummary: added the parser\noutcome: done\nnext: add the writer\n---\n\nI added parse_field() in ccs-dispatch.sh.\nKey decision: delegate summary to it.\n' > "$bh"
+br="$(_ccs_dispatch_chain_context_bridge "$bh")"
+assert_contains "bridge includes the parent summary" "$br" "added the parser"
+assert_contains "bridge includes the parent body highlight" "$br" "Key decision: delegate"
+assert_contains "bridge frames it as a continuation" "$br" "previous worker"
+# Absent file -> empty bridge.
+assert_eq "absent handoff -> empty bridge" "" "$(_ccs_dispatch_chain_context_bridge "$DD/nope.handoff")"
+# Cap enforced.
+{ printf -- '---\nsummary: big\n---\n'; head -c 9000 /dev/zero | tr '\0' 'Z'; } > "$bh"
+brb=$(_ccs_dispatch_chain_context_bridge "$bh" | wc -c)
+if [ "$brb" -le 5000 ]; then
+  printf '  PASS: bridge capped (%s bytes)\n' "$brb"; PASS=$((PASS + 1))
+else
+  printf '  FAIL: bridge not capped (%s bytes)\n' "$brb"; FAIL=$((FAIL + 1))
+fi
+
+echo "=== continuation predicate: all branches ==="
+csr() { _ccs_dispatch_chain_stop_reason "$@"; }
+assert_eq "done + next + depth<max -> continue (empty)" \
+  "" "$(csr handoff-ready done 'do next' 0 5)"
+assert_eq "outcome partial -> partial" \
+  "partial" "$(csr handoff-ready partial 'do next' 0 5)"
+assert_eq "outcome blocked -> blocked" \
+  "blocked" "$(csr handoff-ready blocked 'do next' 0 5)"
+assert_eq "status failed (no handoff) -> failed" \
+  "failed" "$(csr failed '' '' 0 5)"
+assert_eq "status completed w/o handoff outcome -> failed" \
+  "failed" "$(csr completed '' '' 0 5)"
+assert_eq "done + empty next -> empty-next" \
+  "empty-next" "$(csr handoff-ready done '' 0 5)"
+assert_eq "done + next but depth == max -> depth" \
+  "depth" "$(csr handoff-ready done 'do next' 5 5)"
+assert_eq "done + next + last allowed depth (max-1) -> continue" \
+  "" "$(csr handoff-ready done 'do next' 4 5)"
+
+echo "=== chain engine: hop1 done+next -> hop2 launched; hop2 partial -> stop ==="
+reset_jobs
+export AGENT_PAGER_DIR="$SCRIPT_DIR/tmp/test-chain-pager"
+rm -rf "$AGENT_PAGER_DIR"
+mkdir -p "$AGENT_PAGER_DIR/channels/local-tester" "$AGENT_PAGER_DIR/inbound"
+CROOT="$SCRIPT_DIR/tmp/test-chain-proj"; rm -rf "$CROOT"; mkdir -p "$CROOT/tmp"
+CPMAP="$SCRIPT_DIR/tmp/test-chain-projmap"
+printf 'ccs-dashboard = %s\n' "$CROOT" > "$CPMAP"
+export CCS_DISPATCH_PROJ_MAP="$CPMAP"
+# Disable notify sender resolution (no agent-pager unit in tests).
+export CCS_DISPATCH_NOTIFY=0
+
+HEAD="d-chain-head"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$HEAD" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"ccs-dashboard",backend:"agentpager",created_at:$ca,
+    status:"running",chain:true,chain_depth:0,chain_max:5}')"
+echo $$ > "$DD/pids/${HEAD}.pid"
+
+export _CHAIN_CROOT="$CROOT"
+# Report the worker session gone on every check: the hop's handoff already
+# exists, so the monitor's Phase B loop exits at once and finalizes.
+_ccs_dispatch_agentpager_session_alive() { return 1; }
+_ccs_dispatch_agentpager_stop_file() { :; }
+
+# HEAD handoff (done + next) pre-seeded in the project tmp.
+printf -- '---\nsummary: head done\noutcome: done\nnext: do the second step\n---\nhead body\n' \
+  > "$CROOT/tmp/handoff-${HEAD}.md"
+
+# Intercept launch-file writes to learn the next hop's job id, capture the
+# prompt, and seed ITS handoff as partial (so hop 2 stops the chain).
+_ccs_dispatch_agentpager_launch_file() {
+  local job_id="$1" proj="$2" key="$3" prompt="$4" pager_dir="$5"
+  printf '%s\n' "$prompt" > "$_CHAIN_CROOT/last-launch.txt"
+  printf '%s\n' "$job_id" >> "$_CHAIN_CROOT/launched-ids.txt"
+  printf -- '---\nsummary: second partial\noutcome: partial\nnext: more\n---\nbody2\n' \
+    > "$_CHAIN_CROOT/tmp/handoff-${job_id}.md"
+  printf '%s/inbound/stub-%s.md\n' "$pager_dir" "$job_id"
+}
+
+CCS_DISPATCH_AGENTPAGER_STARTUP=1 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+  CCS_DISPATCH_AGENTPAGER_SETTLE=1 CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET=1 \
+  _ccs_dispatch_agentpager_monitor "$HEAD" "local-tester" "$CROOT" 0 "$AGENT_PAGER_DIR" \
+    1 0 5 ""
+
+assert_eq "head finalized handoff-ready" "handoff-ready" \
+  "$(_ccs_dispatch_jsonl_latest "$HEAD" | jq -r '.status')"
+HOP2=$(head -1 "$CROOT/launched-ids.txt")
+assert_eq "exactly one hop launched" "1" "$(wc -l < "$CROOT/launched-ids.txt" | tr -d ' ')"
+assert_contains "hop2 launch carries the next task" \
+  "$(cat "$CROOT/last-launch.txt")" "do the second step"
+assert_contains "hop2 launch carries the parent context bridge" \
+  "$(cat "$CROOT/last-launch.txt")" "previous worker"
+assert_contains "hop2 launch carries the HANDOFF RULE" \
+  "$(cat "$CROOT/last-launch.txt")" "tmp/handoff-${HOP2}.md"
+assert_eq "hop2 chain_parent is the head" "$HEAD" \
+  "$(_ccs_dispatch_jsonl_latest "$HOP2" | jq -r '.chain_parent')"
+assert_eq "hop2 chain_depth is 1" "1" \
+  "$(_ccs_dispatch_jsonl_latest "$HOP2" | jq -r '.chain_depth')"
+assert_eq "hop2 chain_stopped is partial" "partial" \
+  "$(_ccs_dispatch_jsonl_latest "$HOP2" | jq -r '.chain_stopped')"
+
+unset _CHAIN_CROOT AGENT_PAGER_DIR CCS_DISPATCH_PROJ_MAP CCS_DISPATCH_NOTIFY
+rm -rf "$CROOT" "$CPMAP" "$SCRIPT_DIR/tmp/test-chain-pager"
+
+echo "=== --chain preview names chain mode + depth (agentpager) ==="
+pv="$(_ccs_dispatch_preview_render "/p" "agentpager" "async" "600" "Task: x" 1 5)"
+assert_contains "preview shows chain mode" "$pv" "chain"
+assert_contains "preview shows the max depth" "$pv" "5"
+echo "=== preview without chain has no chain line (regression) ==="
+pv0="$(_ccs_dispatch_preview_render "/p" "agentpager" "async" "600" "Task: x")"
+assert_not_contains "no chain line when not chained" "$pv0" "auto-continue"
+
+echo "=== --chain on headless warns and dispatches a single job (no chain flag) ==="
+reset_jobs
+export CCS_DISPATCH_BACKEND=headless
+# Mock claude on PATH so the headless spawn never launches the real binary.
+mock_bin="$SCRIPT_DIR/tmp/test-chain-bin"; mkdir -p "$mock_bin"
+printf '#!/bin/bash\necho "mock: $*"\n' > "$mock_bin/claude"; chmod +x "$mock_bin/claude"
+chp="$SCRIPT_DIR/tmp/test-chain-hl-proj"; mkdir -p "$chp"
+warn="$(PATH="$mock_bin:$PATH" ccs-dispatch --sync --chain --project "$chp" --yes "do a thing" 2>&1 >/dev/null)"
+assert_contains "headless --chain emits a warning" "$warn" "chain"
+# The dispatched head job must NOT carry chain:true (headless can't chain).
+hid=$(jq -rs 'map(.job_id)|last' "$JOBS")
+assert_eq "headless head job is not chained" "null" \
+  "$(_ccs_dispatch_jsonl_latest "$hid" | jq -r '.chain // "null"')"
+rm -rf "$chp" "$mock_bin"; unset CCS_DISPATCH_BACKEND
+
+echo "=== --max-depth rejects a non-integer (protects the runaway ceiling) ==="
+reset_jobs
+before_lines=$([ -f "$JOBS" ] && wc -l < "$JOBS" || echo 0)
+mdproj="$SCRIPT_DIR/tmp/test-chain-md-proj"; mkdir -p "$mdproj"
+rc=0
+mderr="$(ccs-dispatch --chain --max-depth abc --project "$mdproj" --yes "x" 2>&1 >/dev/null)" || rc=$?
+assert_eq "non-integer --max-depth aborts (rc 1)" "1" "$rc"
+assert_contains "error names the bad flag" "$mderr" "max-depth"
+after_lines=$([ -f "$JOBS" ] && wc -l < "$JOBS" || echo 0)
+assert_eq "rejected dispatch appends no job record" "$before_lines" "$after_lines"
+rm -rf "$mdproj"
+
+echo "=== ccs-jobs single view prints chain lineage ==="
+reset_jobs
+jrec() { printf '%s\n' "$1" >> "$JOBS"; }
+jrec '{"job_id":"d-hop","project":"p","backend":"agentpager","status":"handoff-ready","created_at":"2026-07-09T10:00:00+08:00","finished_at":"2026-07-09T10:05:00+08:00","chain":true,"chain_parent":"d-head","chain_depth":2,"chain_max":5}'
+printf '# md\n' > "$DD/results/d-hop.md"
+co="$(ccs-jobs d-hop 2>/dev/null)"
+assert_contains "shows depth N/max" "$co" "depth 2/5"
+assert_contains "shows the parent" "$co" "parent=d-head"
+
+echo "=== ccs-jobs shows chain_stopped when present ==="
+reset_jobs
+jrec '{"job_id":"d-stp","project":"p","backend":"agentpager","status":"handoff-ready","created_at":"2026-07-09T10:00:00+08:00","chain":true,"chain_depth":1,"chain_max":5}'
+jrec '{"job_id":"d-stp","chain_stopped":"blocked"}'
+printf '# md\n' > "$DD/results/d-stp.md"
+so="$(ccs-jobs d-stp 2>/dev/null)"
+assert_contains "shows stop reason" "$so" "stopped: blocked"
+
+echo "=== non-chain job has no Chain line (regression) ==="
+reset_jobs
+jrec '{"job_id":"d-plain","project":"p","backend":"headless","status":"completed","created_at":"2026-07-09T10:00:00+08:00"}'
+printf '# md\n' > "$DD/results/d-plain.md"
+po="$(ccs-jobs d-plain 2>/dev/null)"
+assert_not_contains "no Chain line for a plain job" "$po" "**Chain:**"
+
+test_summary

--- a/tests/test-dispatch-spawn-agentpager.sh
+++ b/tests/test-dispatch-spawn-agentpager.sh
@@ -5,6 +5,13 @@
 # CCS_DISPATCH_AGENTPAGER_MONITOR=0 to skip starting the background monitor.
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Sandbox the data dir BEFORE sourcing anything that resolves it, so the test's
+# d-test-* records never land in the user's real jobs.jsonl (mirrors the
+# sibling test-jobs-agentpager.sh isolation).
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-spawn-ap-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
 source "$SCRIPT_DIR/tests/fixture-helper.sh"
 source "$SCRIPT_DIR/ccs-dashboard.sh"
 
@@ -15,6 +22,8 @@ p="$(_ccs_dispatch_agentpager_prompt "d-test-1234" $'VERIFICATION RULE ...\nTask
 assert_contains "prompt keeps original task" "$p" "Task: do X"
 assert_contains "prompt names per-job handoff file" "$p" "tmp/handoff-d-test-1234.md"
 assert_contains "prompt references the job id" "$p" "d-test-1234"
+assert_contains "prompt carries the autonomy invariant" "$p" "Do not ask clarifying questions"
+assert_contains "prompt routes blocked to outcome: blocked" "$p" "outcome: blocked"
 
 echo "=== launch file has valid frontmatter + body ==="
 tmproot="$SCRIPT_DIR/tmp/test-spawn-ap-pager"


### PR DESCRIPTION
## 摘要

把「鏈鎖接力」控制流寫進 code(backlog Task 11):當一個 agentpager worker 完成、
並在 handoff frontmatter 回報 `outcome: done` + 非空 `next:` 時,dispatch 的 monitor
自動組出下一個 worker 並派出,**中繼決策完全不進指揮席(lead)context**,只在鏈終止
或需要人接手時才浮上來。

嚴格定位:個人單人工作流、**單專案序列鏈**。跨專案接力與多 worker 並行仍是 v2。

設計 spec 已於 brainstorming 收斂核准(放在 `internal/`,依專案慣例不進 repo)。

## 變更內容

- **frontmatter 通用 parser**:`summary` / `outcome` / `next` 三欄共用同一套
  「僅認已閉合 frontmatter、首次出現為準、容忍 CRLF」語意。
- **context 橋接**:下一跳的開場 prompt 帶入前一跳 handoff 的 summary + body,
  讓冷啟動 worker 有脈絡。
- **續鏈判定式(純函式)**:`outcome==done` 且 `next` 非空 且 `depth<max` 才續;
  否則停鏈,原因為 `partial` / `blocked` / `failed` / `empty-next` / `depth`。
- **鏈鎖引擎**:以 monitor 內的有界尾遞迴實作,整條鏈跑在同一背景 process,
  單一 seat 無並行競爭;停鏈記 `chain_stopped` 並發鏈終止 pager 通知。
- **CLI**:新增 `--chain [--max-depth N]`(鏈首一次核准);`--max-depth` 驗證為
  非負整數;headless 後端無 monitor → 警告並退回單發。零回歸於非鏈鎖派工。
- **可觀測性**:`jobs.jsonl` 記 `chain_parent` / `chain_depth`;`ccs-jobs <id>`
  多印一行 `Chain: depth N/max, parent=…, stopped: …`。
- **自主性 invariant**:套用**所有** agentpager 派工——worker 不問澄清問題、
  卡住時設 `outcome: blocked`(→ 停鏈浮回指揮席),不等終端輸入。
- 附帶修正:`test-dispatch-spawn-agentpager.sh` 過去未 sandbox `XDG_DATA_HOME`,
  會把 `d-test-*` 記錄寫進真實 `jobs.jsonl`;補上 sandbox 隔離。

## Code Review

以 fresh-context subagent 進行獨立 review,結論 **fix-then-ship**:鏈鎖控制流無
正確性 bug,所有設計 invariant(判定式、鏈首一次核准、單專案繼承、headless
fallback、自主性 invariant、lineage、非鏈鎖零回歸)皆被遵守且有測試覆蓋。

Review 抓到一個實質問題,已於本 PR 修正:

- `--max-depth` 未驗證為整數 → 打錯字(如 `abc`)會讓 `jq --argjson` 失敗、
  附一行 garbage 到 `jobs.jsonl`,且 depth 比較出錯使 runaway ceiling 失效。
  已改為 parse 階段拒絕非整數。

兩個 nit(unread slot 註解、bridge cap 單位為 bytes)一併以註解澄清。

## 測試

全部本地執行通過:

```
tests/test-dispatch-chain.sh          43 passed, 0 failed  (本 PR 新增)
tests/test-dispatch-spawn-agentpager  42 passed, 0 failed
tests/test-jobs-agentpager.sh         31 passed, 0 failed
tests/test-dispatch-preview.sh        26 passed, 0 failed
tests/test-dispatch-notify.sh         21 passed, 0 failed
tests/run-all.sh                      26 suites, 0 failed, 1 skipped (live-only)
```

測試涵蓋:續鏈判定式每分支、proj key 繼承、context 橋接、lineage 欄位、
`--chain` preview 文案、`--max-depth` 驗證、headless 警告退回、非鏈鎖零回歸,
monitor 以既有 tmux/session mock 手法驅動。
