### PR TITLE
feat(health): add context occupancy indicator to ccs-health

### DIFF
--- a/ccs-health.sh
+++ b/ccs-health.sh
@@ -10,6 +10,11 @@ CCS_HEALTH_DURATION_RED="${CCS_HEALTH_DURATION_RED:-4320}"
 CCS_HEALTH_ROUNDS_YELLOW="${CCS_HEALTH_ROUNDS_YELLOW:-30}"
 CCS_HEALTH_ROUNDS_RED="${CCS_HEALTH_ROUNDS_RED:-60}"
 CCS_HEALTH_STALE_DAYS="${CCS_HEALTH_STALE_DAYS:-7}"
+# context occupancy thresholds — 0 = disabled (informational only, not scored
+# into overall). Context window size varies by model (200K vs 1M), so no
+# default red line; set explicitly to enable coloring for a known model tier.
+CCS_HEALTH_CONTEXT_YELLOW="${CCS_HEALTH_CONTEXT_YELLOW:-0}"
+CCS_HEALTH_CONTEXT_RED="${CCS_HEALTH_CONTEXT_RED:-0}"
 
 # ── Helper: extract health events from a JSONL session file ──
 # Usage: _ccs_health_events /path/to/SESSION.jsonl
@@ -35,7 +40,7 @@ _ccs_health_events() {
     reduce .[] as $line (
       {
         first_ts: null, last_ts: null, prompt_count: 0,
-        tool_reads: {}, tool_greps: {},
+        tool_reads: {}, tool_greps: {}, context_tokens: null,
         _seq: 0, _last_read_seq: {}, _last_edit_seq: {},
         _compact_seqs: [], _last_grep_seq: {},
         _dup_reads_x2: {}, _dup_greps_x2: {}
@@ -54,6 +59,17 @@ _ccs_health_events() {
             and ($line.isMeta | not)
             and ($line.message.content | type) == "string"
          then .prompt_count += 1
+         else . end)
+
+      # Track context occupancy: last main-thread assistant message with usage
+      # wins. input + cache_read + cache_creation ≈ current context tokens.
+      # Skip sidechain (subagent) turns so the estimate reflects the main thread.
+      | (if $line.type == "assistant" and ($line.message.usage != null)
+            and ($line.isSidechain != true)
+         then .context_tokens = (
+                ($line.message.usage.input_tokens // 0)
+                + ($line.message.usage.cache_read_input_tokens // 0)
+                + ($line.message.usage.cache_creation_input_tokens // 0))
          else . end)
 
       # Detect compaction events
@@ -143,6 +159,8 @@ _ccs_health_score() {
     --argjson dur_r "${CCS_HEALTH_DURATION_RED}" \
     --argjson rnd_y "${CCS_HEALTH_ROUNDS_YELLOW}" \
     --argjson rnd_r "${CCS_HEALTH_ROUNDS_RED}" \
+    --argjson ctx_y "${CCS_HEALTH_CONTEXT_YELLOW:-0}" \
+    --argjson ctx_r "${CCS_HEALTH_CONTEXT_RED:-0}" \
     '
     # dup_tool: max count across tool_reads and tool_greps
     def max_val:
@@ -152,6 +170,16 @@ _ccs_health_score() {
     def classify($v; $y; $r):
       if $v >= $r then "red"
       elif $v >= $y then "yellow"
+      else "green" end;
+
+    # context indicator: informational. Each line applies only when its own
+    # threshold is > 0, so a red-only or yellow-only config still has a green
+    # tier. Disabled (info) when both thresholds are off or the value is absent.
+    def classify_ctx($v; $y; $r):
+      if $v == null then "info"
+      elif ($y <= 0) and ($r <= 0) then "info"
+      elif ($r > 0) and ($v >= $r) then "red"
+      elif ($y > 0) and ($v >= $y) then "yellow"
       else "green" end;
 
     def severity:
@@ -178,11 +206,15 @@ _ccs_health_score() {
      end) as $dur_val |
 
     .prompt_count as $rnd_val |
+    (.context_tokens // null) as $ctx_val |
 
     classify($dup_val; $dup_y; $dup_r) as $dup_lv |
     classify($dur_val; $dur_y; $dur_r) as $dur_lv |
     classify($rnd_val; $rnd_y; $rnd_r) as $rnd_lv |
+    classify_ctx($ctx_val; $ctx_y; $ctx_r) as $ctx_lv |
 
+    # context is informational: it never feeds overall (context window size is
+    # model-dependent, so it must not distort the health verdict/sort)
     worst($dup_lv; worst($dur_lv; $rnd_lv)) as $overall |
 
     {
@@ -204,6 +236,12 @@ _ccs_health_score() {
           level: $rnd_lv,
           value: $rnd_val,
           threshold: { yellow: $rnd_y, red: $rnd_r }
+        },
+        context: {
+          level: $ctx_lv,
+          value: $ctx_val,
+          unit: "tokens",
+          threshold: { yellow: $ctx_y, red: $ctx_r }
         }
       }
     }
@@ -270,6 +308,9 @@ Indicators:
   dup_tool   Max effective duplicate tool calls
   duration   Session duration (minutes)
   rounds     User prompt count
+  context    Est. context occupancy from last assistant message
+             usage (input+cache_read+cache_creation). Informational;
+             set CCS_HEALTH_CONTEXT_YELLOW/RED (tokens) to color it.
 HELP
         return 0
         ;;
@@ -432,6 +473,14 @@ HELP
           if $lv == "red" then $red
           elif $lv == "yellow" then $yel
           else $grn end;
+        def cbadge($lv):
+          if $lv == "red" then $red
+          elif $lv == "yellow" then $yel
+          elif $lv == "green" then $grn
+          else "⚪" end;
+        def fmt_ctx($v):
+          if $v == null then "-"
+          else "~" + (($v / 1000) | floor | tostring) + "k" end;
         .[] |
         "### " + badge + " "
           + .session_id
@@ -453,6 +502,10 @@ HELP
           + " "
           + (.indicators.rounds.value
              | tostring),
+        "- context: "
+          + cbadge(.indicators.context.level)
+          + " "
+          + fmt_ctx(.indicators.context.value),
         ""
       '
       # Stale summary
@@ -490,13 +543,17 @@ HELP
           | tostring),
          .indicators.rounds.level,
          (.indicators.rounds.value
+          | tostring),
+         .indicators.context.level,
+         (.indicators.context.value
           | tostring)
         ] | @tsv
       ' | while IFS=$'\t' read -r \
           overall sid proj topic \
           dup_lv dup_v \
           dur_lv dur_v \
-          rnd_lv rnd_v; do
+          rnd_lv rnd_v \
+          ctx_lv ctx_v; do
 
         # Overall badge with color
         local badge color reset
@@ -542,6 +599,23 @@ HELP
         printf "  rounds:   "
         _health_ibadge "$rnd_lv"
         printf " %s\n" "$rnd_v"
+
+        # context occupancy (informational; dim dot when disabled/absent)
+        local ctx_badge ctx_disp
+        case "$ctx_lv" in
+          green)  ctx_badge='\033[32m●\033[0m' ;;
+          yellow) ctx_badge='\033[33m◐\033[0m' ;;
+          red)    ctx_badge='\033[31m○\033[0m' ;;
+          *)      ctx_badge='\033[90m·\033[0m' ;;
+        esac
+        if [ "$ctx_v" = "null" ]; then
+          ctx_disp="-"
+        else
+          ctx_disp="~$((ctx_v / 1000))k"
+        fi
+        printf "  context:  "
+        printf '%b' "$ctx_badge"
+        printf " %s\n" "$ctx_disp"
         echo
       done
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -417,6 +417,12 @@ ccs-health <session-id-prefix>
 
 整體等級取三項指標中最差的一項。
 
+另有一項**資訊指標**（不計入整體等級）：
+- **context** — 估算當前 context 佔用（取最後一則 assistant message
+  的 `input + cache_read + cache_creation` token 數）。因 context window
+  大小依 model 而異（200K vs 1M），預設不上色（⚪）；設定
+  `CCS_HEALTH_CONTEXT_YELLOW/RED`（token 數）才會分級。
+
 閾值預設值（可用環境變數覆蓋）：
 
 ```
@@ -426,6 +432,8 @@ CCS_HEALTH_DURATION_YELLOW=2880  # 持續時間黃色閾值（分鐘）
 CCS_HEALTH_DURATION_RED=4320     # 持續時間紅色閾值（分鐘）
 CCS_HEALTH_ROUNDS_YELLOW=30     # 輪數黃色閾值
 CCS_HEALTH_ROUNDS_RED=60        # 輪數紅色閾值
+CCS_HEALTH_CONTEXT_YELLOW=0     # context 黃色閾值（token；0=停用）
+CCS_HEALTH_CONTEXT_RED=0        # context 紅色閾值（token；0=停用）
 ```
 
 詳見 `ccs-health.sh`。

--- a/tests/test-health.sh
+++ b/tests/test-health.sh
@@ -146,6 +146,21 @@ assert_json_field "notool prompt_count" "$notool_result" '.prompt_count' "1"
 assert_json_field "notool tool_reads" "$notool_result" '.tool_reads | length' "0"
 assert_json_field "notool tool_greps" "$notool_result" '.tool_greps | length' "0"
 
+echo ""
+echo "=== context_tokens: last assistant usage sum ==="
+CTX_FIXTURE="$FIXTURE_DIR/ctx00001-context-tokens.jsonl"
+cat > "$CTX_FIXTURE" <<'JSONL'
+{"type":"user","message":{"content":"hi"},"timestamp":"2026-03-21T09:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"a"}],"usage":{"input_tokens":10,"cache_read_input_tokens":1000,"cache_creation_input_tokens":100,"output_tokens":50}},"timestamp":"2026-03-21T09:01:00Z"}
+{"type":"user","message":{"content":"more"},"timestamp":"2026-03-21T09:02:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"b"}],"usage":{"input_tokens":5,"cache_read_input_tokens":2000,"cache_creation_input_tokens":300,"output_tokens":80}},"timestamp":"2026-03-21T09:03:00Z"}
+JSONL
+ctx_events=$(_ccs_health_events "$CTX_FIXTURE")
+# last assistant usage: 5 + 2000 + 300 = 2305 (last message wins, not summed across turns)
+assert_json_field "context_tokens = last-msg usage sum" "$ctx_events" '.context_tokens' "2305"
+# a session with no usage field → null (graceful for gemini / partial logs)
+assert_json_field "context_tokens null when no usage" "$notool_result" '.context_tokens' "null"
+
 # ══════════════════════════════════════
 # _ccs_health_score tests
 # ══════════════════════════════════════
@@ -248,6 +263,91 @@ assert_json_field "null duration level" "$score_null" '.indicators.duration.leve
 assert_json_field "null duration value" "$score_null" '.indicators.duration.value' "0"
 assert_json_field "null dup_tool value" "$score_null" '.indicators.dup_tool.value' "0"
 assert_json_field "null rounds value" "$score_null" '.indicators.rounds.value' "0"
+
+echo ""
+echo "=== _ccs_health_score: context indicator (info by default) ==="
+score_ctx=$(cat <<'JSON' | _ccs_health_score
+{
+  "session_id": "ctx00001",
+  "first_ts": "2026-03-21T09:00:00Z",
+  "last_ts": "2026-03-21T09:30:00Z",
+  "prompt_count": 5,
+  "tool_reads": {},
+  "tool_greps": {},
+  "context_tokens": 234951
+}
+JSON
+)
+assert_json_field "context value" "$score_ctx" '.indicators.context.value' "234951"
+assert_json_field "context level info (thresholds off)" "$score_ctx" '.indicators.context.level' "info"
+assert_json_field "context excluded from overall" "$score_ctx" '.overall' "green"
+
+# context_tokens absent → value null, level info
+score_ctx_absent=$(cat <<'JSON' | _ccs_health_score
+{
+  "session_id": "ctxnull1",
+  "first_ts": "2026-03-21T09:00:00Z",
+  "last_ts": "2026-03-21T09:05:00Z",
+  "prompt_count": 1,
+  "tool_reads": {},
+  "tool_greps": {}
+}
+JSON
+)
+assert_json_field "context value null when absent" "$score_ctx_absent" '.indicators.context.value' "null"
+assert_json_field "context level info when absent" "$score_ctx_absent" '.indicators.context.level' "info"
+
+# env thresholds enable classification without touching overall
+CCS_HEALTH_CONTEXT_YELLOW=100000 CCS_HEALTH_CONTEXT_RED=200000
+score_ctx_red=$(cat <<'JSON' | _ccs_health_score
+{
+  "session_id": "ctxred01",
+  "first_ts": "2026-03-21T09:00:00Z",
+  "last_ts": "2026-03-21T09:30:00Z",
+  "prompt_count": 5,
+  "tool_reads": {},
+  "tool_greps": {},
+  "context_tokens": 234951
+}
+JSON
+)
+assert_json_field "context level red when threshold set" "$score_ctx_red" '.indicators.context.level' "red"
+assert_json_field "context still excluded from overall" "$score_ctx_red" '.overall' "green"
+CCS_HEALTH_CONTEXT_YELLOW=0 CCS_HEALTH_CONTEXT_RED=0
+
+# red-only config (yellow off) still keeps a green tier below the red line
+CCS_HEALTH_CONTEXT_YELLOW=0 CCS_HEALTH_CONTEXT_RED=200000
+score_ctx_redonly=$(cat <<'JSON' | _ccs_health_score
+{
+  "session_id": "ctxron01",
+  "first_ts": "2026-03-21T09:00:00Z",
+  "last_ts": "2026-03-21T09:30:00Z",
+  "prompt_count": 5,
+  "tool_reads": {},
+  "tool_greps": {},
+  "context_tokens": 50000
+}
+JSON
+)
+assert_json_field "context green below red line (yellow off)" "$score_ctx_redonly" '.indicators.context.level' "green"
+CCS_HEALTH_CONTEXT_YELLOW=0 CCS_HEALTH_CONTEXT_RED=0
+
+# runtime-emptied threshold degrades to disabled instead of crashing argjson
+CCS_HEALTH_CONTEXT_RED=""
+score_ctx_empty=$(cat <<'JSON' | _ccs_health_score
+{
+  "session_id": "ctxemp01",
+  "first_ts": "2026-03-21T09:00:00Z",
+  "last_ts": "2026-03-21T09:30:00Z",
+  "prompt_count": 5,
+  "tool_reads": {},
+  "tool_greps": {},
+  "context_tokens": 234951
+}
+JSON
+)
+assert_json_field "context info when threshold empty (no crash)" "$score_ctx_empty" '.indicators.context.level' "info"
+CCS_HEALTH_CONTEXT_RED=0
 
 # ══════════════════════════════════════
 # _ccs_health_badge tests
@@ -352,7 +452,7 @@ mkdir -p "$MOCK_PROJECTS/-pool2-testuser-project-beta"
 ALPHA_GREEN="$MOCK_PROJECTS/-pool2-testuser-project-alpha/aaaa1111-0000-0000-0000-000000000001.jsonl"
 cat > "$ALPHA_GREEN" <<'JSONL'
 {"type":"user","message":{"content":"hello alpha"},"timestamp":"2026-03-21T09:00:00Z"}
-{"type":"assistant","message":{"content":[{"type":"text","text":"Hi!"}]},"timestamp":"2026-03-21T09:05:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Hi!"}],"usage":{"input_tokens":10,"cache_read_input_tokens":5000,"cache_creation_input_tokens":200,"output_tokens":30}},"timestamp":"2026-03-21T09:05:00Z"}
 JSONL
 
 # Red session in project-beta (post-compaction dups → dup_val=5)
@@ -444,6 +544,35 @@ if echo "$md_out" | grep -q "## Session Health Report"; then
   pass=$((pass + 1))
 else
   printf '  FAIL: --md missing "## Session Health Report"\n'
+  fail=$((fail + 1))
+fi
+
+# Test 3b: context indicator surfaced in --json and rendered in --md
+echo ""
+echo "--- Test: context indicator (--json value + --md render) ---"
+alpha_ctx=$(echo "$json_out" | jq -r '.[] | select(.session_id=="aaaa1111") | .indicators.context.value')
+if [ "$alpha_ctx" = "5210" ]; then
+  printf '  PASS: --json context value = 5210\n'
+  pass=$((pass + 1))
+else
+  printf '  FAIL: --json context value → got "%s", expected "5210"\n' "$alpha_ctx"
+  fail=$((fail + 1))
+fi
+alpha_ctx_lv=$(echo "$json_out" | jq -r '.[] | select(.session_id=="aaaa1111") | .indicators.context.level')
+if [ "$alpha_ctx_lv" = "info" ]; then
+  printf '  PASS: --json context level info (thresholds off)\n'
+  pass=$((pass + 1))
+else
+  printf '  FAIL: --json context level → got "%s", expected "info"\n' "$alpha_ctx_lv"
+  fail=$((fail + 1))
+fi
+# fixtures are stale-dated, so expand with --all to render per-session lines
+md_all_out=$(CCS_PROJECTS_DIR="$MOCK_PROJECTS" ccs-health --md --all 2>/dev/null)
+if echo "$md_all_out" | grep -q "context:.*~5k"; then
+  printf '  PASS: --md renders context ~5k line\n'
+  pass=$((pass + 1))
+else
+  printf '  FAIL: --md missing context ~5k line\n'
   fail=$((fail + 1))
 fi
 


### PR DESCRIPTION
## 摘要

長壽 orchestrator（指揮席）session 的可行性前提是 context 成長可觀測——換代 / worker 縱向接力的時機應由數據觸發，而非靠紅線猜測。session JSONL 本來就帶 per-message `usage`，最後一則 assistant message 的 `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` ≈ 當前 context 佔用。本 PR 把這個估算落成 `ccs-health` 的一個新指標。

（Backlog Part 3 Task 13；設計理念見內部 context-economy 文件 §4-5。）

## 變更內容

- `_ccs_health_events`：jq reduce 新增 `context_tokens`，取**最後一則** main-thread assistant message 的 usage 加總（跳過 sidechain / subagent turn）。
- `_ccs_health_score`：新增 `indicators.context`（value + level）。
- `ccs-health` json / md / terminal 三種輸出都新增 context 行；md 顯示 `~NNNk`，無 usage 顯示 `-`。
- **刻意設計**：context 是**資訊指標，不計入 `overall`**。因 context window 大小依 model 而異（200K vs 1M），固定紅線會對合法的大 session 誤報。預設 `CCS_HEALTH_CONTEXT_YELLOW/RED=0`（停用、不上色 ⚪）；env 設定才分級，且每條界線只在自己 threshold > 0 時生效。
- `docs/commands.md` 同步 context 指標與 env 閾值。

## Test report

**Unit（`tests/test-health.sh`）：87 passed, 0 failed**
- `_ccs_health_events`：last-msg usage 加總 = 2305（非跨 turn 累加）；無 usage → null。
- `_ccs_health_score`：預設 info、value 正確、排除 overall；env 設定後分級為 red 但 overall 不變；red-only config 仍保留 green 階；runtime-emptied threshold 降級為 info 不 crash。
- 命令路徑：`--json` context value/level、`--md --all` render `~5k` 行。

**Full suite（`tests/run-all.sh`）：26 suites, 26 passed, 0 failed, 1 skipped（live-only）**

**整合驗證（真實 session）：**
- `ccs-health --md` → `- context: ⚪ ~144k`（本 session）等，跨 session 144k–476k。
- env 開啟後正確上色；476k > 200K 印證固定紅線會誤報，佐證資訊指標設計。

## Code review

獨立 reviewer（capable tier）審查，**無 blocker**，5 項 low findings，採納 4 項並加測試鎖定：
- 採納：runtime-empty env var 防護（`--argjson ...:-0`）、red-only 保留 green 階、sidechain turn 過濾、terminal `printf '%b'`。
- 略過 1 項 nit（弱斷言）：既有 `score_ctx_red` 測試已證明 overall 排除。
