### PR TITLE
feat(dispatch): per-task executor selection (claude/gemini)

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -294,10 +294,11 @@ _ccs_dispatch_run_worker() {
 # the terminal verdict word; rc 0 accepted / 10 escalated / 11 hard_stop.
 _ccs_dispatch_run_one() {
   local task="$1" task_yaml="$2" hop_dir="$3"
-  local cwd budget goal timeout_sec
+  local cwd budget goal timeout_sec executor
   cwd="$(echo "$task" | jq -r '.scope.cwd // "."')"
   budget="$(echo "$task" | jq -r ".execution_policy.loop_budget // $CCS_DISPATCH_GATE_LOOP_BUDGET")"
   goal="$(echo "$task" | jq -r '.goal')"
+  executor="$(echo "$task" | jq -r '.executor // "claude"')"
   timeout_sec="$(echo "$task" | jq -r '.execution_policy.timeout_sec // empty')"
   [ -z "$timeout_sec" ] && timeout_sec="$CCS_DISPATCH_TIMEOUT"
 
@@ -317,7 +318,7 @@ _ccs_dispatch_run_one() {
     fi
     printf '%s' "$prompt" > "$ad/prompt.md"
 
-    _ccs_dispatch_run_worker "$cwd" "$prompt" "$hop_dir" "$attempt" "$timeout_sec"
+    _ccs_dispatch_run_worker "$cwd" "$prompt" "$hop_dir" "$attempt" "$timeout_sec" "$executor"
     verdict="$(_ccs_dispatch_gate_run "$cwd" "$task" "$ad" "$attempt" "$budget")"
 
     case "$verdict" in

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -268,10 +268,19 @@ _ccs_dispatch_chain_alloc_dir() {
 # async backend for the gate loop is deferred (see plan Deferred).
 _ccs_dispatch_run_worker() {
   local cwd="$1" prompt="$2" run_dir="$3" attempt="$4"
-  local timeout_sec="${5:-$CCS_DISPATCH_TIMEOUT}"
+  local timeout_sec="${5:-$CCS_DISPATCH_TIMEOUT}" executor="${6:-claude}"
   local ad="$run_dir/attempt-$(printf '%02d' "$attempt")"
   mkdir -p "$ad"
-  (cd "$cwd" && timeout "$timeout_sec" claude -p "$prompt") \
+  # gemini needs --approval-mode yolo: headless has no tty, so without
+  # auto-approve it cannot run edit tools. The deterministic gate re-runs every
+  # verify.cmd against ground truth, so a yolo false-success is caught (see
+  # docs/case-studies/gemini-yolo-overconfidence.md). claude is the default.
+  local cmd
+  case "$executor" in
+    gemini) cmd=(gemini -p "$prompt" --approval-mode yolo) ;;
+    *)      cmd=(claude -p "$prompt") ;;
+  esac
+  (cd "$cwd" && timeout "$timeout_sec" "${cmd[@]}") \
     > "$ad/executor-output.md" 2>&1 || true
   (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
   (cd "$cwd" && git diff) > "$ad/diff.patch" 2>/dev/null || true

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -97,6 +97,8 @@ _ccs_dispatch_gate_load_task() {
          ([.acceptance_criteria[].id] | unique | length))
     and (any(.acceptance_criteria[]; (.verify.cmd // "") != ""))
     and ((.next == null) or (.next | type == "string" and (length > 0)))
+    and ((.executor == null) or
+         (.executor | type == "string" and (. == "claude" or . == "gemini")))
   ' >/dev/null 2>&1 \
     || { echo "gate: task validation failed: $yaml" >&2; return 1; }
   echo "$js"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -619,6 +619,7 @@ id: task-x                      # slug，也是 run-id 前綴
 goal: "新增 greeter 並被 CLI 呼叫"
 scope:
   cwd: "/abs/path/to/project"   # worker 執行與 gate 驗收的目錄
+executor: gemini                # 可選：claude(預設) | gemini。gemini 以 `gemini -p ... --approval-mode yolo` 跑（headless 無 tty，需 auto-approve；gate 為信任邊界，見 §8.4）
 next: "task-y.yaml"             # 可選：下一個要自動執行與驗收的任務路徑（相對於此 yaml）
 execution_policy:
   loop_budget: 1                # 重派上限（預設 1 = 共 2 attempts）

--- a/tests/test-dispatch-executor-cli.sh
+++ b/tests/test-dispatch-executor-cli.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-executor-cli.sh — worker spawns the selected CLI
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-executor-cli-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-executor-cli"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+# argv-recording shims for both CLIs, earlier on PATH than the real ones
+BIN="$WORK/bin"; mkdir -p "$BIN"
+for c in claude gemini; do
+  cat > "$BIN/$c" <<EOF
+#!/usr/bin/env bash
+echo "$c \$*" >> "$WORK/argv.log"
+EOF
+  chmod +x "$BIN/$c"
+done
+export PATH="$BIN:$PATH"
+
+CWD="$WORK/repo"; mkdir -p "$CWD"; (cd "$CWD" && git init -q)
+RUN="$WORK/run"; mkdir -p "$RUN"
+
+echo "=== gemini executor spawns gemini -p ... --approval-mode yolo ==="
+: > "$WORK/argv.log"
+_ccs_dispatch_run_worker "$CWD" "do X" "$RUN" 1 60 gemini
+log="$(cat "$WORK/argv.log")"
+assert_contains "gemini binary invoked" "$log" "gemini -p do X"
+assert_contains "gemini approval-mode yolo" "$log" "--approval-mode yolo"
+assert_not_contains "gemini did not call claude" "$log" "claude -p"
+
+echo "=== omitted executor spawns claude -p ==="
+: > "$WORK/argv.log"
+_ccs_dispatch_run_worker "$CWD" "do Y" "$RUN" 2 60
+log2="$(cat "$WORK/argv.log")"
+assert_contains "claude binary invoked" "$log2" "claude -p do Y"
+assert_not_contains "claude default did not call gemini" "$log2" "gemini -p"

--- a/tests/test-dispatch-executor-thread.sh
+++ b/tests/test-dispatch-executor-thread.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-executor-thread.sh — executor threads task -> run_one -> worker
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-executor-thread-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-executor-thread"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+CWD="$WORK/repo"; mkdir -p "$CWD"; (cd "$CWD" && git init -q)
+
+# Mock worker: record the 6th arg (executor) and satisfy the AC below.
+_ccs_dispatch_run_worker() {
+  local run_dir="$3" attempt="$4" executor="${6:-claude}"
+  echo "$executor" >> "$WORK/seen-executor.log"
+  mkdir -p "$run_dir/attempt-$(printf '%02d' "$attempt")"
+  : > "$CWD/done.txt"
+  return 0
+}
+
+mk() {  # mk <file> <executor-line-or-empty>
+  local f="$WORK/$1" ex="$2"
+  { echo "id: t"; echo "goal: g";
+    [ -n "$ex" ] && echo "$ex";
+    echo "scope: {cwd: \"$CWD\"}";
+    echo "acceptance_criteria:";
+    echo "  - id: AC1";
+    echo "    text: t";
+    echo "    verify: {cmd: \"test -f $CWD/done.txt\"}"; } > "$f"
+  echo "$f"
+}
+
+echo "=== gemini task threads gemini to worker ==="
+: > "$WORK/seen-executor.log"; rm -f "$CWD/done.txt"
+d="$(_ccs_dispatch_run "$(mk g.yaml 'executor: gemini')")"
+assert_contains "worker saw gemini" "$(cat "$WORK/seen-executor.log")" "gemini"
+assert_eq "gate verdict written" "PASS" \
+  "$(jq -r '.verdict' "$d"/hop-*/attempt-01/gate/verdict.json)"
+
+echo "=== omitted executor threads claude to worker ==="
+: > "$WORK/seen-executor.log"; rm -f "$CWD/done.txt"
+_ccs_dispatch_run "$(mk n.yaml '')" >/dev/null
+assert_eq "worker saw claude" "claude" "$(head -1 "$WORK/seen-executor.log")"

--- a/tests/test-gate-executor.sh
+++ b/tests/test-gate-executor.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# tests/test-gate-executor.sh — executor field whitelist validation
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-gate-executor-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-gate-executor"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+mk() {  # mk <file> <executor-line-or-empty>
+  local f="$WORK/$1" ex="$2"
+  { echo "id: t"; echo "goal: g";
+    [ -n "$ex" ] && echo "$ex";
+    echo "acceptance_criteria:";
+    echo "  - id: AC1";
+    echo "    text: t";
+    echo "    verify: {cmd: \"true\"}"; } > "$f"
+  echo "$f"
+}
+
+echo "=== executor: gemini loads OK ==="
+js="$(_ccs_dispatch_gate_load_task "$(mk g.yaml 'executor: gemini')")"; rc=$?
+assert_eq "gemini rc 0" "0" "$rc"
+assert_eq "gemini parsed" "gemini" "$(echo "$js" | jq -r '.executor')"
+
+echo "=== executor: claude loads OK ==="
+_ccs_dispatch_gate_load_task "$(mk c.yaml 'executor: claude')" >/dev/null 2>&1
+assert_eq "claude rc 0" "0" "$?"
+
+echo "=== omitted executor loads OK ==="
+js2="$(_ccs_dispatch_gate_load_task "$(mk n.yaml '')")"; rc2=$?
+assert_eq "omitted rc 0" "0" "$rc2"
+assert_eq "omitted executor null" "null" "$(echo "$js2" | jq -r '.executor // "null"')"
+
+echo "=== unknown executor -> rc 1 ==="
+_ccs_dispatch_gate_load_task "$(mk bogus.yaml 'executor: wingman')" >/dev/null 2>&1
+assert_eq "unknown -> rc 1" "1" "$?"
+_ccs_dispatch_gate_load_task "$(mk typo.yaml 'executor: gemeni')" >/dev/null 2>&1
+assert_eq "typo -> rc 1" "1" "$?"
+
+echo "=== non-string executor -> rc 1 ==="
+_ccs_dispatch_gate_load_task "$(mk numeric.yaml 'executor: 123')" >/dev/null 2>&1
+assert_eq "numeric -> rc 1" "1" "$?"


### PR DESCRIPTION
## Summary

為 gated dispatch 路徑加入 per-task executor 選擇，實現 3-role mission-control
工作流的 leg ②（cheaper executor）。task.yaml 新增可選的 top-level `executor:`
欄位（`claude` | `gemini`，省略時預設 `claude`），worker seam 依此在
`gemini -p ... --approval-mode yolo` 與 `claude -p` 之間切換。

deterministic gate（重跑每條 AC `verify.cmd`）維持不變，作為唯一的 trust
boundary——這正是 gemini executor 需要的：gemini 在 yolo 模式會自報未達成的
成功，gate 以 ground truth 驗證而非採信 worker 的自述。

## Changes

- `feat(dispatch)`: task.yaml `executor` 欄位白名單 validation（`{claude, gemini}`，
  未知值 / 拼錯 / 非字串一律在 load 階段 fail-fast，不 silent fallback）
- `feat(dispatch)`: worker seam 依 executor 選擇 CLI；gemini 走
  `--approval-mode yolo`（headless 無 tty，需 auto-approve）
- `feat(dispatch)`: executor 從 task JSON 經 `run_one` threading 到 worker
  （`.executor // "claude"`，第 6 個參數帶預設，向後相容既有 5-arg caller / mock）
- `docs(dispatch)`: `docs/commands.md` task.yaml schema 補上 `executor:` 欄位說明

## Test plan

- [x] executor 白名單 validation：gemini / claude / 省略 load OK；未知值、拼錯、
      非字串 → rc 1
- [x] worker 依 executor spawn 正確 CLI（PATH stub 攔 argv 驗證，不真的 spawn）
- [x] executor threading：gemini task 端到端傳到 worker，gate verdict 正常寫出；
      省略時預設 claude
- [x] 既有 gate / chain 測試無 regression（default claude 保持相容）
- [x] 真實 gemini dogfood：2-hop `next:` chain 端到端跑通
- [x] 無 hardcoded credential（grep 掃描 clean）

## Test results

- 新增 3 測試檔共 16 assert 全 PASS：`test-gate-executor.sh`（8）、
  `test-dispatch-executor-cli.sh`（5）、`test-dispatch-executor-thread.sh`（3）
- dispatch / gate regression：13 個既有測試檔全數 0 failed
- Dogfood（真實 gemini，2-hop chain）：hop-1 建檔、hop-2 append，兩 hop gate 皆
  PASS（attempt 1），chain outcome=accepted、走 `next:` 至 empty-next 正常結束。
  首度以真實非 claude executor 端到端驅動 `ccs-dispatch-run`（先前測試全 mock
  worker）
- Credential scan：clean

## Reviewer summary

改動集中在 `ccs-dispatch.sh` 三個 function 加一份 doc，gate 邏輯零改動。
獨立 code review 結論為 APPROVE WITH NITS，3 個 nit（doc 同步、non-string 負向
測試、yolo 理由註解）已全數修正並 squash 進對應 commit。重點確認：executor 在
呼叫鏈 gate_load → run_one → run_worker 中確實被消費（非 dead code），且無任何
路徑會讓 gemini task 靜默改用 claude。

## Carry-forward（不在本 PR）

- PATH C：plan → `next:`-linked task.yaml chain generator
- PATH B：agent-pager local-channel env injection 修復（讓 gemini 走 local
  channel 可監控）
- tier ladder（`next_executor.cli` 重派升級，與本次 executor provider 選擇正交）

## Related

- 前一個 sprint：gated task-list chaining（PR #82）
- scope-C gate 基礎：PR #81
