### PR TITLE
feat(dispatch): add ccs-dispatch-plan chain-spec generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ ccs-dashboard has two layers:
 | `ccs-health` | Session health detection — surface attention-degradation signals |
 | `ccs-dispatch` | Dispatch a task to a new Claude Code session (async or sync) |
 | `ccs-jobs` | View dispatch job history and results |
+| `ccs-dispatch-plan` | Expand a chain-spec into a next:-linked task.yaml chain (no dispatch) |
 | `ccs-dispatch-run` | Dispatch with a review gate + gated task-list chaining (task.yaml) |
 | `ccs-review` | Session review report — stats, conversation, LLM summary (md/html/pdf) |
 | `ccs-project` | Per-project insight report — cost, features, rhythm, code changes (md/html) |

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -104,6 +104,80 @@ _ccs_dispatch_gate_load_task() {
   echo "$js"
 }
 
+# Deterministically expand a chain-spec YAML into per-hop task.yaml files in
+# <dest_dir>. Merges spec.defaults into each hop (hop keys override), wires next:
+# in hops order (last hop has none), names files hop-NN-<id>.task.yaml. Echoes the
+# entry filename (basename of hop-01). rc 1 on unparseable spec / no hops / hop
+# missing id. Does NOT validate AC/executor -- that is delegated to load_task by the
+# caller. python3+pyyaml here so emitted YAML round-trips through load_task's parser.
+_ccs_dispatch_plan_expand() {
+  local spec="$1" dest="$2"
+  [ -f "$spec" ] || { echo "plan: spec not found: $spec" >&2; return 1; }
+  mkdir -p "$dest" || return 1
+  python3 - "$spec" "$dest" <<'PY'
+import sys, os, re, yaml
+spec_path, dest = sys.argv[1], sys.argv[2]
+try:
+    spec = yaml.safe_load(open(spec_path)) or {}
+except Exception as e:
+    sys.stderr.write("plan: spec YAML parse failed: %s\n" % e); sys.exit(1)
+defaults = spec.get("defaults") or {}
+hops = spec.get("hops")
+if not isinstance(hops, list) or not hops:
+    sys.stderr.write("plan: spec has no non-empty 'hops' list\n"); sys.exit(1)
+# precompute filenames (need next hop's name for next: wiring). hop id becomes a
+# filename, so require the same token set the gate enforces on AC ids.
+names = []
+for i, hop in enumerate(hops):
+    if not isinstance(hop, dict):
+        sys.stderr.write("plan: hop %d is not a mapping\n" % (i + 1)); sys.exit(1)
+    hid = hop.get("id")
+    if not isinstance(hid, str) or not re.match(r"^[A-Za-z0-9_.-]+$", hid):
+        sys.stderr.write("plan: hop %d has missing or invalid 'id' "
+                         "(need ^[A-Za-z0-9_.-]+$)\n" % (i + 1)); sys.exit(1)
+    names.append("hop-%02d-%s.task.yaml" % (i + 1, hid))
+for i, hop in enumerate(hops):
+    merged = dict(defaults)      # shallow: hop keys override defaults keys
+    merged.update(hop)
+    if i + 1 < len(hops):
+        merged["next"] = names[i + 1]
+    else:
+        merged.pop("next", None)
+    with open(os.path.join(dest, names[i]), "w") as f:
+        yaml.safe_dump(merged, f, sort_keys=True, default_flow_style=False)
+sys.stdout.write(names[0])
+PY
+}
+
+# Expand a chain-spec into <out_dir> ONLY if every emitted hop passes the gate's
+# own task loader (reusing _ccs_dispatch_gate_load_task = the single source of
+# validation truth: >=1 AC, >=1 cmd-track AC, executor whitelist, next: type,
+# unique AC ids). Atomic: expand to a staging dir, validate all, move into place
+# on full success; on any failure remove staging and leave <out_dir> untouched.
+# Echoes the absolute entry task path on success.
+_ccs_dispatch_plan_generate() {
+  local spec="$1" out="$2"
+  local stage="${out%/}.staging.$$"
+  rm -rf "$stage"
+  local entry
+  entry="$(_ccs_dispatch_plan_expand "$spec" "$stage")" || { rm -rf "$stage"; return 1; }
+  local f
+  for f in "$stage"/hop-*.task.yaml; do
+    if ! _ccs_dispatch_gate_load_task "$f" >/dev/null 2>&1; then
+      echo "plan: generated task failed gate validation: $(basename "$f")" >&2
+      rm -rf "$stage"; return 1
+    fi
+  done
+  mkdir -p "$out" || { rm -rf "$stage"; return 1; }
+  # Refresh: drop hop-*.task.yaml from a prior generation so a shorter/renamed
+  # chain does not leave orphan hops behind (only our own pattern; unrelated
+  # files in <out> are left alone). Validation already passed, so this is safe.
+  rm -f "$out"/hop-*.task.yaml
+  mv "$stage"/hop-*.task.yaml "$out"/ || { rm -rf "$stage"; return 1; }
+  rm -rf "$stage"
+  echo "$(_ccs_dispatch_abspath "$out/$entry")"
+}
+
 # Run one acceptance criterion against ground truth. cmd track: `bash -c <cmd>`
 # with cwd=<cwd>, bounded by <timeout_sec> (0 = unbounded), exit 0 = PASS /
 # non-zero = FAIL (a timeout returns 124 -> FAIL). guidance track: no execution,

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -500,6 +500,41 @@ HELP
   return "$rc"
 }
 
+# Public entry: expand a chain-spec YAML into a next:-linked set of task.yaml
+# files (deterministic; no execution). Print the entry task path to stdout so it
+# composes: ccs-dispatch-run "$(ccs-dispatch-plan spec.yaml)". Two-step by design:
+# the human inspects the generated chain before dispatching.
+ccs-dispatch-plan() {
+  local spec="${1:-}" out=""
+  if [ -z "$spec" ] || [ "$spec" = "-h" ] || [ "$spec" = "--help" ]; then
+    cat <<'HELP'
+Usage: ccs-dispatch-plan <chain-spec.yaml> [--out <dir>]
+  Expand a structured chain-spec into a next:-linked set of task.yaml files
+  (deterministic; does NOT dispatch). Prints the entry task path to stdout.
+  Then inspect the files and run:  ccs-dispatch-run <entry-path>
+  Default out dir: <dir-of-spec>/chain
+HELP
+    [ -z "$spec" ] && return 1 || return 0
+  fi
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --out)
+        [ $# -ge 2 ] || { echo "ccs-dispatch-plan: --out needs a value" >&2; return 1; }
+        out="$2"; shift 2 ;;
+      *) echo "ccs-dispatch-plan: unknown arg: $1" >&2; return 1 ;;
+    esac
+  done
+  [ -f "$spec" ] || { echo "ccs-dispatch-plan: spec not found: $spec" >&2; return 1; }
+  [ -z "$out" ] && out="$(dirname "$(_ccs_dispatch_abspath "$spec")")/chain"
+  local entry
+  entry="$(_ccs_dispatch_plan_generate "$spec" "$out")" || return 1
+  local -a _hops=("$out"/hop-*.task.yaml); local n="${#_hops[@]}"
+  echo "ccs-dispatch-plan: generated $n hop(s) -> $out" >&2
+  echo "ccs-dispatch-plan: dispatch with: ccs-dispatch-run $entry" >&2
+  echo "$entry"
+}
+
 # ── Job ID: d-YYYYMMDD-HHMMSS-XXXX ──
 _ccs_dispatch_job_id() {
   printf 'd-%s-%s' \

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -80,6 +80,7 @@ ccs-dashboard 分兩層：
 | `ccs-health` | Session 健康偵測 — 偵測注意力退化信號 |
 | `ccs-dispatch` | 派發任務到新的 Claude Code session（async 或 sync） |
 | `ccs-jobs` | 查看 dispatch 任務歷史與結果 |
+| `ccs-dispatch-plan` | 把 chain-spec 展開成 next:-linked task.yaml 鏈（只產檔、不派工） |
 | `ccs-dispatch-run` | 帶 review gate + 鏈結派工（gated task-list chaining，task.yaml） |
 | `ccs-review` | Session 回顧報告 — 統計、對話、LLM 摘要（md/html/pdf） |
 | `ccs-project` | 專案層級洞察報告 — 成本、進度、節奏、程式碼變動（md/html） |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -581,6 +581,50 @@ ccs-jobs <job-id> --full  # 單筆詳情並內嵌完整 .md 輸出
 - **handoff-ready 提示**：單筆 view 對 `handoff-ready` job 會提示 `.handoff` 路徑與接力
   `ccs-dispatch` 範本（auto-chain 為 v2）。
 
+## ccs-dispatch-plan
+
+把一份結構化的 **chain-spec** YAML 確定性展開為一組 `next:`-linked 的 `task.yaml`，
+讓「Claude 定案的計畫」不必逐檔手寫就能交給 `ccs-dispatch-run`。此指令**只產檔、不派工**
+（兩步設計：產檔後由人檢查展開結果，再另跑 `ccs-dispatch-run`）。
+
+```bash
+ccs-dispatch-plan <chain-spec.yaml> [--out <dir>]
+```
+
+**chain-spec 格式（單一檔案）：**
+
+```yaml
+defaults:                          # 所有 hop 共用，逐 hop 可覆寫
+  scope: { cwd: "/abs/project" }
+  executor: gemini                 # 選用；omitted => claude
+  execution_policy: { loop_budget: 1 }   # 選用
+hops:
+  - id: hop1
+    goal: "建立 hello.txt 內容 hello"
+    acceptance_criteria:
+      - { id: AC1, text: "檔案存在", verify: { cmd: "test -f hello.txt" } }
+  - id: hop2
+    goal: "附加第二行 world"
+    executor: claude               # 覆寫此 hop 的 executor
+    acceptance_criteria:
+      - { id: AC1, text: "第二行為 world", verify: { cmd: "test \"$(sed -n 2p hello.txt)\" = world" } }
+```
+
+**展開規則（確定性）：**
+
+- 每 hop → `<out>/hop-NN-<id>.task.yaml`（1-based、zero-padded）。
+- `defaults` 併入每個 hop；hop 層級同名 key 覆寫整個該 key。
+- 依 hops 順序自動串 `next:`（下一 hop 的檔名）；最後一 hop 無 `next:`。
+- out dir 預設 `<spec 所在目錄>/chain`，可 `--out` 覆寫。
+- 每份產出立即以 gate 自身的 task loader 驗證（≥1 AC、≥1 `verify.cmd`、
+  executor ∈ {claude,gemini}、AC id 唯一）。任一 hop 不合法 → 不產出任何檔、非零 exit。
+- 成功時 entry path（`hop-01-*`）印到 stdout，可直接組合：
+  `ccs-dispatch-run "$(ccs-dispatch-plan spec.yaml)"`。
+
+> **命名注意：** 產出的來源檔 `hop-NN-<id>.task.yaml` 與 `ccs-dispatch-run` 執行時
+> 凍結的證據目錄 `hop-NN-<id>/` 名稱相近但**不同東西**：前者是可供人檢查的鏈結來源，
+> 後者是每次執行凍結的副本＋gate 證據（在 `.../dispatch/runs/` 下）。
+
 ## ccs-dispatch-run
 
 Deterministic review-gate dispatch（review-gate：gate + 鏈結派工）。把「派工 → 以現實驗收 → 失敗重派一次」包成一個前景指令，且支援**同步 gated task-list 鏈結（gated task-list chain）**：當前任務驗收 PASS 後，會跟隨 `next:` 欄位自動執行並驗收下一個任務。這與非驗收的、非同步的 `--chain`（agentpager 快速通道）是完全獨立的兩層。

--- a/install.sh
+++ b/install.sh
@@ -190,6 +190,7 @@ do_install() {
   echo "  ccs-health          — session health detection"
   echo "  ccs-dispatch        — dispatch task to Code CLI (Claude Code)"
   echo "  ccs-jobs            — view dispatch job history"
+  echo "  ccs-dispatch-plan   — expand a chain-spec into a next:-linked task.yaml chain (no dispatch)"
   echo "  ccs-dispatch-run    — dispatch with review gate + gated task-list chaining (task.yaml)"
   echo "  ccs-review          — session review report (md/html/pdf)"
   echo "  ccs-project         — per-project insight report (md/html)"

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -55,6 +55,7 @@ description: "MANDATORY for any ccs-* command execution. Never run ccs-* command
 | dispatch [dir] "task" | dp | `ccs-dispatch --project <dir> "task"` — 派工到新 session |
 | jobs | j | `ccs-jobs` — dispatch 任務歷史 |
 | job <id> | | `ccs-jobs <id>` — 單筆結果（精簡：summary + artifact 路徑；`--full` 看完整輸出） |
+| dispatch-plan <spec.yaml> | dpp | `ccs-dispatch-plan <spec.yaml>` — 把 chain-spec 展開成 next:-linked task.yaml 鏈（只產檔、不派工） |
 | dispatch-run <task.yaml> | dpr | `ccs-dispatch-run <task.yaml>` — 帶 review gate + 鏈結派工 (gated task chain) |
 | review [sid] | rv | `ccs-review [sid]` — session review 報告 |
 | review html [sid] | | `ccs-review [sid] --format html -o <path>` — HTML 報告 |

--- a/tests/test-dispatch-plan-cli.sh
+++ b/tests/test-dispatch-plan-cli.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-plan-cli.sh — public command surface
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-plan-cli-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-plan-cli"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+SPEC="$WORK/spec.yaml"
+cat > "$SPEC" <<'YAML'
+defaults:
+  scope: { cwd: "/abs/proj" }
+  executor: gemini
+hops:
+  - id: alpha
+    goal: g
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { cmd: "true" } }
+YAML
+
+echo "=== default out dir = <spec-dir>/chain; stdout is exactly the entry path ==="
+out="$(ccs-dispatch-plan "$SPEC" 2>/dev/null)"; rc=$?
+assert_eq "cli rc 0" "0" "$rc"
+assert_eq "entry path default out" "$WORK/chain/hop-01-alpha.task.yaml" "$out"
+assert_eq "entry file exists" "yes" "$([ -f "$out" ] && echo yes)"
+assert_eq "stdout single line" "1" "$(printf '%s' "$out" | grep -c .)"
+
+echo "=== --out override ==="
+DEST="$WORK/custom"
+out2="$(ccs-dispatch-plan "$SPEC" --out "$DEST" 2>/dev/null)"
+assert_eq "entry path custom out" "$DEST/hop-01-alpha.task.yaml" "$out2"
+
+echo "=== summary goes to stderr, not stdout ==="
+se="$(ccs-dispatch-plan "$SPEC" --out "$WORK/o4" 2>&1 >/dev/null)"
+assert_contains "stderr has summary" "$se" "generated"
+
+echo "=== composes with dispatch-run consumer: entry is loadable ==="
+_ccs_dispatch_gate_load_task "$out" >/dev/null 2>&1
+assert_eq "entry loadable by gate" "0" "$?"
+
+echo "=== help + missing arg ==="
+ccs-dispatch-plan --help >/dev/null 2>&1; assert_eq "help rc 0" "0" "$?"
+ccs-dispatch-plan >/dev/null 2>&1; assert_eq "missing arg rc non-zero" "1" "$?"
+
+echo "=== --out with no value: clean error, must NOT hang ==="
+# run in a subshell under timeout so a regression (infinite loop) cannot hang the suite
+timeout 5 bash -c "source '$SCRIPT_DIR/ccs-dashboard.sh'; ccs-dispatch-plan '$SPEC' --out" >/dev/null 2>&1
+assert_eq "--out no value rc 1 (not 124 hang)" "1" "$?"
+
+echo "=== unknown arg: rc non-zero ==="
+ccs-dispatch-plan "$SPEC" --bogus >/dev/null 2>&1; assert_eq "unknown arg rc 1" "1" "$?"
+
+test_summary

--- a/tests/test-dispatch-plan-expand.sh
+++ b/tests/test-dispatch-plan-expand.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-plan-expand.sh — deterministic chain-spec expansion
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-plan-expand-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-plan-expand"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+SPEC="$WORK/spec.yaml"
+cat > "$SPEC" <<'YAML'
+defaults:
+  scope: { cwd: "/abs/proj" }
+  executor: gemini
+  execution_policy: { loop_budget: 1 }
+hops:
+  - id: hop1
+    goal: "make thing"
+    acceptance_criteria:
+      - id: AC1
+        text: "exists"
+        verify: { cmd: "test -f thing" }
+  - id: hop2
+    goal: "extend thing"
+    executor: claude
+    acceptance_criteria:
+      - id: AC1
+        text: "extended"
+        verify: { cmd: "grep -q more thing" }
+YAML
+
+DEST="$WORK/chain"
+entry="$(_ccs_dispatch_plan_expand "$SPEC" "$DEST")"; rc=$?
+
+echo "=== expansion succeeds, entry is hop-01 ==="
+assert_eq "expand rc 0" "0" "$rc"
+assert_eq "entry filename" "hop-01-hop1.task.yaml" "$entry"
+
+echo "=== both hop files written ==="
+assert_eq "hop1 exists" "yes" "$([ -f "$DEST/hop-01-hop1.task.yaml" ] && echo yes)"
+assert_eq "hop2 exists" "yes" "$([ -f "$DEST/hop-02-hop2.task.yaml" ] && echo yes)"
+
+# helper: read a JSON field from an emitted task.yaml via the same parser load_task uses
+jread() { python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(open(sys.argv[1]))))' "$1"; }
+
+echo "=== defaults merged; per-hop override wins ==="
+h1="$(jread "$DEST/hop-01-hop1.task.yaml")"
+h2="$(jread "$DEST/hop-02-hop2.task.yaml")"
+assert_eq "hop1 inherits gemini" "gemini" "$(echo "$h1" | jq -r '.executor')"
+assert_eq "hop1 inherits cwd" "/abs/proj" "$(echo "$h1" | jq -r '.scope.cwd')"
+assert_eq "hop1 inherits loop_budget" "1" "$(echo "$h1" | jq -r '.execution_policy.loop_budget')"
+assert_eq "hop2 override claude" "claude" "$(echo "$h2" | jq -r '.executor')"
+assert_eq "hop2 inherits cwd" "/abs/proj" "$(echo "$h2" | jq -r '.scope.cwd')"
+
+echo "=== next: wired in order; last hop has none ==="
+assert_eq "hop1 next -> hop2 file" "hop-02-hop2.task.yaml" "$(echo "$h1" | jq -r '.next')"
+assert_eq "hop2 has no next" "null" "$(echo "$h2" | jq -r '.next // "null"')"
+
+echo "=== hop preserves id/goal/acceptance_criteria ==="
+assert_eq "hop1 id" "hop1" "$(echo "$h1" | jq -r '.id')"
+assert_eq "hop1 goal" "make thing" "$(echo "$h1" | jq -r '.goal')"
+assert_eq "hop1 AC cmd" "test -f thing" "$(echo "$h1" | jq -r '.acceptance_criteria[0].verify.cmd')"
+
+echo "=== malformed spec: no hops -> non-zero, message ==="
+BAD="$WORK/nohops.yaml"; printf 'defaults: {executor: claude}\n' > "$BAD"
+err="$(_ccs_dispatch_plan_expand "$BAD" "$WORK/bad" 2>&1)"; brc=$?
+assert_eq "no-hops rc non-zero" "1" "$brc"
+assert_contains "no-hops message" "$err" "hops"
+
+echo "=== non-dict hop -> clean plan: error, no traceback, rc 1 ==="
+ND="$WORK/nondict.yaml"; printf 'hops:\n  - "just a string"\n' > "$ND"
+nderr="$(_ccs_dispatch_plan_expand "$ND" "$WORK/nd" 2>&1)"; ndrc=$?
+assert_eq "non-dict rc 1" "1" "$ndrc"
+assert_contains "non-dict clean msg" "$nderr" "plan:"
+assert_not_contains "non-dict no traceback" "$nderr" "Traceback"
+
+echo "=== hop id with slash -> clean plan: error, no traceback, rc 1 ==="
+SL="$WORK/slashid.yaml"
+{ echo "hops:"; echo "  - id: foo/bar"; echo "    goal: g";
+  echo "    acceptance_criteria: [{id: AC1, text: t, verify: {cmd: \"true\"}}]"; } > "$SL"
+slerr="$(_ccs_dispatch_plan_expand "$SL" "$WORK/sl" 2>&1)"; slrc=$?
+assert_eq "slash-id rc 1" "1" "$slrc"
+assert_contains "slash-id clean msg" "$slerr" "plan:"
+assert_not_contains "slash-id no traceback" "$slerr" "Traceback"
+
+test_summary

--- a/tests/test-dispatch-plan-generate.sh
+++ b/tests/test-dispatch-plan-generate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-plan-generate.sh — validation + atomic emit
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-plan-generate-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-plan-generate"
+rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
+
+mkspec() { # mkspec <file> <hops-yaml-body via stdin>
+  local f="$WORK/$1"; shift
+  { echo "defaults:"; echo "  scope: { cwd: \"/abs/proj\" }"; echo "  executor: gemini";
+    echo "hops:"; cat; } > "$f"
+  echo "$f"
+}
+
+echo "=== valid spec: files land in out dir, entry is abs path, rc 0 ==="
+spec="$(mkspec good.yaml <<'H'
+  - id: hop1
+    goal: g1
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { cmd: "true" } }
+  - id: hop2
+    goal: g2
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { cmd: "true" } }
+H
+)"
+OUT="$WORK/out-good"
+entry="$(_ccs_dispatch_plan_generate "$spec" "$OUT")"; rc=$?
+assert_eq "generate rc 0" "0" "$rc"
+assert_eq "entry is abs path" "$OUT/hop-01-hop1.task.yaml" "$entry"
+assert_eq "hop2 landed" "yes" "$([ -f "$OUT/hop-02-hop2.task.yaml" ] && echo yes)"
+
+echo "=== round-trip: every emitted file passes load_task ==="
+for f in "$OUT"/hop-*.task.yaml; do
+  _ccs_dispatch_gate_load_task "$f" >/dev/null 2>&1
+  assert_eq "load_task accepts $(basename "$f")" "0" "$?"
+done
+
+echo "=== bad executor: no files written, rc non-zero, names offending hop ==="
+bad="$(mkspec badexec.yaml <<'H'
+  - id: hopA
+    goal: g
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { cmd: "true" } }
+  - id: hopB
+    goal: g
+    executor: wingman
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { cmd: "true" } }
+H
+)"
+OUTBAD="$WORK/out-bad"
+err="$(_ccs_dispatch_plan_generate "$bad" "$OUTBAD" 2>&1)"; brc=$?
+assert_eq "bad-exec rc 1" "1" "$brc"
+assert_eq "out dir NOT created" "no" "$([ -d "$OUTBAD" ] && echo yes || echo no)"
+assert_contains "error names offending hop" "$err" "hop-02-hopB.task.yaml"
+
+echo "=== regenerate into populated out: no stale hops, count matches ==="
+spec3="$(mkspec three.yaml <<'H'
+  - { id: a, goal: g, acceptance_criteria: [{ id: AC1, text: t, verify: { cmd: "true" } }] }
+  - { id: b, goal: g, acceptance_criteria: [{ id: AC1, text: t, verify: { cmd: "true" } }] }
+  - { id: c, goal: g, acceptance_criteria: [{ id: AC1, text: t, verify: { cmd: "true" } }] }
+H
+)"
+OUTR="$WORK/out-regen"
+_ccs_dispatch_plan_generate "$spec3" "$OUTR" >/dev/null
+assert_eq "first gen has hop-03" "yes" "$([ -f "$OUTR/hop-03-c.task.yaml" ] && echo yes)"
+spec2b="$(mkspec two-b.yaml <<'H'
+  - { id: a, goal: g, acceptance_criteria: [{ id: AC1, text: t, verify: { cmd: "true" } }] }
+  - { id: b, goal: g, acceptance_criteria: [{ id: AC1, text: t, verify: { cmd: "true" } }] }
+H
+)"
+_ccs_dispatch_plan_generate "$spec2b" "$OUTR" >/dev/null
+cnt="$(ls "$OUTR"/hop-*.task.yaml 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq "regen leaves exactly 2 hops" "2" "$cnt"
+assert_eq "stale hop-03 removed" "no" "$([ -f "$OUTR/hop-03-c.task.yaml" ] && echo yes || echo no)"
+
+echo "=== all-guidance hop: rejected by load_task (line 98), no files ==="
+guid="$(mkspec guid.yaml <<'H'
+  - id: hopG
+    goal: g
+    acceptance_criteria:
+      - { id: AC1, text: t, verify: { guidance: "eyeball it" } }
+H
+)"
+OUTG="$WORK/out-guid"
+_ccs_dispatch_plan_generate "$guid" "$OUTG" >/dev/null 2>&1
+assert_eq "all-guidance rc 1" "1" "$?"
+assert_eq "guidance out dir NOT created" "no" "$([ -d "$OUTG" ] && echo yes || echo no)"
+
+test_summary


### PR DESCRIPTION
## 摘要

新增 `ccs-dispatch-plan` — 一個**確定性**指令，把單一結構化 chain-spec YAML 展開成
一組 `next:`-linked 的 `task.yaml`，讓「Claude 定案的計畫」不必逐檔手寫就能交給
`ccs-dispatch-run`。這是 mission-control PATH C，補上 leg ①（定案）到 leg ②（gemini
executor，PR #83 已 ship）之間先前手寫的橋接。

設計核心：LLM 判斷留在 leg ①（Claude 撰寫 spec），generator 只做確定性展開，維持
「gate = deterministic trust boundary」哲學。**只產檔、不派工**（兩步設計：產檔後由人
檢查展開結果，再另跑 `ccs-dispatch-run`）。

## 變更內容

- `_ccs_dispatch_plan_expand` — python/pyyaml 確定性展開：`defaults` 併入每個 hop
  （hop 層級覆寫）、依序串 `next:`、檔名 `hop-NN-<id>.task.yaml`。
- `_ccs_dispatch_plan_generate` — **複用既有 `_ccs_dispatch_gate_load_task`** 逐 hop
  驗證（單一驗證真相來源：≥1 AC、≥1 cmd-track AC、executor whitelist、AC id 唯一）；
  staging 原子產出，任一 hop 不合法則不留任何檔。
- `ccs-dispatch-plan` — 公開指令，`--out` 覆寫、stdout 印 entry path 可組合
  `ccs-dispatch-run "$(ccs-dispatch-plan spec.yaml)"`。
- 文件：`docs/commands.md` 新增段（含 source-vs-frozen 命名注意）、README / zh-TW /
  install.sh / ccs-orchestrator skill palette 指令清單同步。

## Code Review

獨立 fresh-context reviewer，發現 4 項、修正 3 項（1 項 deferred）：

- **HIGH** — `--out` 無值造成無限迴圈（`shift 2` 在 `$#<2` 不消耗參數）→ 修正：require value。
- **MEDIUM** — 重複產出進同一 populated out dir 殘留舊 hop + count 報錯 → 修正：清除
  舊 `hop-*.task.yaml` + count 改 glob array。
- **LOW** — 非 mapping hop / hop id 含 `/` 噴 Python traceback → 修正：hop 需 mapping、
  id 對齊 gate 的 token pattern，改印 clean `plan:` error。
- **LOW（deferred）** — process 被 kill 遺留 staging dir（不同 PID）。純 cosmetic，
  atomicity 不受影響（staging 為 `<out>` 之 sibling，非 nested）。

所有修正走 TDD（先補 failing test 再修）。

## Test Results

**Unit（新增，全 PASS）：**
- `test-dispatch-plan-expand.sh` — 22 passed, 0 failed
- `test-dispatch-plan-generate.sh` — 13 passed, 0 failed
- `test-dispatch-plan-cli.sh` — 11 passed, 0 failed

**Regression（0 failures）：**
- `test-gate-task` (11)、`test-gate-loop` (9)、`test-gate-chain-loop` (6)、
  `test-gate-executor`、`test-dispatch-executor-thread`、`test-dispatch-executor-cli`

**E2E（真實 gemini）：** 2-hop chain-spec → `ccs-dispatch-plan` 展開（`next:` 串接、
`defaults` 併入皆正確）→ 人工檢查 → `ccs-dispatch-run` → chain outcome=**accepted**，
兩 hop 皆 attempt-1 gate PASS，gemini 實際產出 `hello\nworld`。證實 PATH C→PATH A 銜接。

## 備註

- 版號未 bump；release 需另行明確授權。
- `_ccs_dispatch_gate_load_task` / gate 邏輯未更動；此功能為純新增（additive）。