### PR TITLE
feat(skills): add ccs-dispatch-run protocol skill + headless claude permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Or wire it up manually:
 # Add to .bashrc:
 source ~/tools/ccs-dashboard/ccs-dashboard.sh
 
-# Skill symlink (optional):
+# Skill symlinks (optional):
 ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
+ln -s ~/tools/ccs-dashboard/skills/ccs-dispatch-run ~/.claude/skills/ccs-dispatch-run
 ```
 
 Then just ask Claude:

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -345,14 +345,16 @@ _ccs_dispatch_run_worker() {
   local timeout_sec="${5:-$CCS_DISPATCH_TIMEOUT}" executor="${6:-claude}"
   local ad="$run_dir/attempt-$(printf '%02d' "$attempt")"
   mkdir -p "$ad"
-  # gemini needs --approval-mode yolo: headless has no tty, so without
-  # auto-approve it cannot run edit tools. The deterministic gate re-runs every
-  # verify.cmd against ground truth, so a yolo false-success is caught (see
+  # Both executors need auto-approve: headless has no tty, so a permission
+  # prompt hangs until the wall-clock timeout (claude -p without a permission
+  # mode stalls on the first edit tool and produces zero output/changes). The
+  # deterministic gate re-runs every verify.cmd against ground truth, so an
+  # auto-approved false-success is caught (see
   # docs/case-studies/gemini-yolo-overconfidence.md). claude is the default.
   local cmd
   case "$executor" in
     gemini) cmd=(gemini -p "$prompt" --approval-mode yolo) ;;
-    *)      cmd=(claude -p "$prompt") ;;
+    *)      cmd=(claude -p "$prompt" --permission-mode bypassPermissions) ;;
   esac
   (cd "$cwd" && timeout "$timeout_sec" "${cmd[@]}") \
     > "$ad/executor-output.md" 2>&1 || true

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -32,8 +32,9 @@ cd ~/tools/ccs-dashboard
 # 在 .bashrc 加入：
 source ~/tools/ccs-dashboard/ccs-dashboard.sh
 
-# Skill symlink（選用）：
+# Skill symlinks（選用）：
 ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
+ln -s ~/tools/ccs-dashboard/skills/ccs-dispatch-run ~/.claude/skills/ccs-dispatch-run
 ```
 
 接著直接問 Claude：

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -627,6 +627,10 @@ hops:
 
 ## ccs-dispatch-run
 
+> Agent 呼叫端協定（何時用、四步流程、Stage 2 紀律）見
+> `skills/ccs-dispatch-run/SKILL.md`；task.yaml 契約見其
+> `references/task-yaml.md`。
+
 Deterministic review-gate dispatch（review-gate：gate + 鏈結派工）。把「派工 → 以現實驗收 → 失敗重派一次」包成一個前景指令，且支援**同步 gated task-list 鏈結（gated task-list chain）**：當前任務驗收 PASS 後，會跟隨 `next:` 欄位自動執行並驗收下一個任務。這與非驗收的、非同步的 `--chain`（agentpager 快速通道）是完全獨立的兩層。
 
 ```bash
@@ -663,7 +667,7 @@ id: task-x                      # slug，也是 run-id 前綴
 goal: "新增 greeter 並被 CLI 呼叫"
 scope:
   cwd: "/abs/path/to/project"   # worker 執行與 gate 驗收的目錄
-executor: gemini                # 可選：claude(預設) | gemini。gemini 以 `gemini -p ... --approval-mode yolo` 跑（headless 無 tty，需 auto-approve；gate 為信任邊界，見 §8.4）
+executor: gemini                # 可選：claude(預設) | gemini。兩者皆 auto-approve 跑 headless（claude `--permission-mode bypassPermissions`、gemini `--approval-mode yolo`）— 無 tty 下權限 prompt 會卡到 timeout；gate 為信任邊界，見 §8.4
 next: "task-y.yaml"             # 可選：下一個要自動執行與驗收的任務路徑（相對於此 yaml）
 execution_policy:
   loop_budget: 1                # 重派上限（預設 1 = 共 2 attempts）

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ccs-dispatch-run
+description: Review-gate 派工協定 — 把任務派給獨立 worker CLI，以 machine-checkable acceptance criteria 做零 LLM 現實驗收（不信 worker 自述）。Use when delegating a well-specified coding task that needs reality-based acceptance, or when chaining gated tasks. Not for interactive/exploratory work (use ccs-dispatch) or in-context subagents. Keywords: dispatch-run, review gate, task.yaml, acceptance criteria, verify.cmd, gated chain, evidence.
+---
+
+# ccs-dispatch-run 呼叫協定
+
+把「派工 → 以現實驗收 → 失敗帶事實摘要重派一次」包成一個前景指令。
+你（主 session）只負責：寫 task.yaml、呼叫、讀結果、做 judgment
+review。迴圈邏輯在 CLI 內，不要自己重新實作。
+
+## 何時用 / 何時不用
+
+- **用**：任務目標明確、驗收條件可寫成 shell 指令（exit 0 = PASS）、
+  希望結果由現實（git diff / test / grep）裁決而非 worker 自述
+- **不用**：開放式探索或需要互動接管 → `ccs-dispatch`（agentpager
+  backend）；同 context 的小任務 → in-harness subagent
+- 與 `ccs-dispatch --chain`（agentpager 快速通道，無驗收）是兩層
+  獨立機制，不可混用
+
+## 前置
+
+`ccs-dashboard.sh` 已 source 進 shell（依安裝目錄，例：
+`source <install-dir>/ccs-dashboard.sh`）。驗收在 `scope.cwd` 指定
+的專案目錄執行，需為 git repo（evidence 會抓 `git diff`）。
+
+## 協定四步
+
+### 1. 寫 task.yaml
+
+Schema 與範例見 `references/task-yaml.md`。要點：
+
+- `goal` 是給 worker 的完整任務描述（worker 只看得到它 + 失敗摘要）
+- 每條 AC 恰有 `verify.cmd`（machine-checkable）或
+  `verify.guidance`（留給 judgment review）之一；至少一條 cmd-track
+- AC 品質紀律（integration criteria、security check）：若安裝了
+  `plan-quality` skill，依其要求寫 AC
+
+多任務鏈可先寫 chain-spec 再展開（不執行）：
+
+```bash
+ccs-dispatch-plan <chain-spec.yaml>   # 產出 next: 串好的 task.yaml 檔
+# 人工檢查產出檔後再 dispatch 印出的 entry path
+```
+
+### 2. 呼叫
+
+```bash
+ccs-dispatch-run <task.yaml>
+```
+
+- 前景阻塞直到終態；長任務用 background 執行 + 完成通知，避免乾等
+- Exit code：`0` accepted / `10` escalated / `11` hard_stop /
+  `2` task 載入失敗 / `1` usage error（無參數）
+- 鏈結時注意：exit `0` 只代表**已執行的 hops** 皆 PASS —
+  `stop_reason` 為 `failed` / `depth` 時也回 0，是否完整跑完
+  要查 `chain.json.stop_reason`
+- stdout 印 `run: <run-dir>` 與 outcome 摘要
+
+### 3. 讀結果
+
+結果樹（`<data-dir>/dispatch/runs/<first-id>-chain-NN/`）：
+
+```
+chain.json                     # 鏈終態：hops[]、stop_reason、outcome
+hop-NN-<task-id>/
+├── task.yaml                  # dispatch 當下凍結的驗收條件
+├── final.json                 # 本 hop 終態：outcome / attempts
+└── attempt-NN/
+    ├── prompt.md              # worker 收到的完整 prompt
+    ├── executor-output.md     # worker 原始輸出（僅供鑑識，勿當依據）
+    ├── git-status.txt / diff.patch   # ground truth
+    └── gate/
+        ├── <AC-id>.json       # per-AC verdict + exit code + output tail
+        └── verdict.json       # 本輪 gate 裁決
+```
+
+### 4. Judgment review（Stage 2）
+
+只讀 `diff.patch` + `git-status.txt`（worker 新增的檔案是
+untracked，**不會**出現在 diff.patch，要靠 `??` 行發現後另行讀檔）
++ `gate/verdict.json` + guidance-AC 清單，**不要重讀 worker trace**
+（fresh-context 紀律；executor-output.md 只在鑑識時看）。你裁決的是 script 抓不到的：是不是對的解、設計
+好不好、guidance-AC 過不過。
+
+## Verdict 語意
+
+- `PASS` — 全部 cmd-AC exit 0（guidance-AC 記 `SKIPPED_FOR_LLM`，
+  等你 Stage 2 裁決，不參與 gate 判定）
+- `RETRY` — 有 FAIL 且 loop_budget 未耗盡；CLI 自動帶「machine 事實
+  摘要」（AC id + cmd + exit code，無 worker prose）重派，你不介入
+- `ESCALATE` — budget 耗盡。交給人診斷（讀 evidence 樹），
+  **不是**由你直接重試 — 你帶著 planning 確認偏誤
+- `HARD_STOP` / `ERROR` — 判定函式已支援，目前無 producer
+  （現行 AC 執行只產生 PASS / FAIL / SKIPPED_FOR_LLM）
+
+## 鏈結（gated chain）
+
+PASS 後自動跟 `next:`（相對於當前 task.yaml 所在目錄解析）。
+停鏈原因記在 `chain.json.stop_reason`：`empty-next`（正常完成）/
+`depth` / `cycle` / `failed`（下一檔載入失敗）/ 非 PASS 終態。
+
+## 邊界（現行實作 = Scope C）
+
+- gate + 單次重派；無 tier ladder（重派同 executor）
+- executor 僅 `claude`（預設）/ `gemini`；兩者皆以 auto-approve 跑
+  headless（claude `--permission-mode bypassPermissions`、gemini
+  `--approval-mode yolo`）— **gate 為信任邊界**：worker 全權限執行
+  於 `scope.cwd`，假成功由 gate 重驗現實攔下；task 應只來自你自己
+  的規劃，勿餵不受信任的 goal
+- `scope.allowed_paths` / `forbidden_paths` 未實作（僅 `scope.cwd`
+  生效），worker 無路徑硬限制
+- worker 同步 headless 執行；agentpager async backend 未接入 gate 迴圈
+- Stage 2 無自動化（`final.json.stage2` 恆為 null，由你人工執行）

--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -1,0 +1,95 @@
+# task.yaml 契約（ccs-dispatch-run）
+
+> **SoT 宣告**：本檔為 task.yaml 的使用者面契約，以
+> `ccs-dispatch.sh` 現行實作為準；`docs/internal/` 的 spec drafts
+> 為設計史料。schema 變更走本檔 + CHANGELOG。
+
+## 欄位
+
+| 欄位 | 必填 | 型別 / 限制 |
+|------|------|-------------|
+| `id` | Yes | 非空字串；同時是 run 目錄名前綴 |
+| `goal` | Yes | 非空字串；worker 收到的任務描述全文 |
+| `scope.cwd` | No | worker 執行與 gate 驗收目錄；預設 `.`（呼叫時的 cwd）；建議寫絕對路徑 |
+| `executor` | No | `claude`（預設）\| `gemini`；頂層字串欄位。兩者皆以 auto-approve 跑 headless（gate 為信任邊界，見 SKILL.md § 邊界） |
+| `next` | No | 下一個 task.yaml 路徑；相對路徑以**本檔所在目錄**解析 |
+| `execution_policy.loop_budget` | No | 重派上限；預設 1（共 2 attempts）；0 = 不重派 |
+| `execution_policy.timeout_sec` | No | worker 與單條 AC 的 timeout；預設取 `CCS_DISPATCH_TIMEOUT`（600） |
+| `acceptance_criteria[]` | Yes | 非空陣列；規則見下 |
+
+## acceptance_criteria 規則（載入時強制驗證）
+
+- `id`：必填，`^[A-Za-z0-9_.-]+$`（直接用作 evidence 檔名），全 task 內唯一
+- `text`：外部可觀察行為描述（給人讀；載入器不驗證但必寫）
+- `verify`：**恰好一個**：
+  - `cmd`：bash predicate，於 `scope.cwd` 執行，exit 0 = PASS、
+    非零 = FAIL（timeout 回 124 = FAIL）
+  - `guidance`：prose 判準，gate 不執行，記 `SKIPPED_FOR_LLM`
+    交 Stage 2 裁決
+- **至少一條 cmd-track**（全 guidance 會 auto-PASS，破壞 gate 意義，
+  載入直接失敗）
+
+## AC 撰寫紀律
+
+- integration 類：驗「元件被呼叫」不只「檔案存在」
+  （例：`grep -q 'from .greeter import' src/cli.py`）
+- 涉及 credential 的 task：加一條
+  `! grep -rn "password\|api_key" <src>/` 類 AC
+- 若安裝了 `plan-quality` skill，依其完整要求
+- cmd 以 `bash -c` 於 `scope.cwd` 執行，不繼承 aliases 與非 export
+  的 shell 狀態（exported env vars 會繼承）— 別依賴你 session 的
+  互動環境；依賴工具（pytest 等）需在 `scope.cwd` 專案內可用
+
+## 完整範例
+
+```yaml
+id: greeter-module
+goal: |
+  在 src/greeter.py 新增 greet(name) 函式並讓 cli.py 實際呼叫它。
+  greet 回傳 "Hello, <name>!"。加 pytest 單元測試。
+scope:
+  cwd: "/abs/path/to/project"
+executor: claude
+next: "greeter-docs.task.yaml"        # 可省略
+execution_policy:
+  loop_budget: 1
+  timeout_sec: 900
+acceptance_criteria:
+  - id: AC1
+    text: "greet 函式存在"
+    verify:
+      cmd: "grep -q 'def greet(name' src/greeter.py"
+  - id: AC2
+    text: "單元測試通過"
+    verify:
+      cmd: "pytest tests/test_greeter.py -q"
+  - id: AC3
+    text: "greeter 被 cli.py 實際呼叫（非 dead code）"
+    verify:
+      cmd: "grep -q 'from .greeter import\\|import greeter' src/cli.py"
+  - id: AC4
+    text: "錯誤處理與專案既有 pattern 一致"
+    verify:
+      guidance: "對照 src/loader.py 的 exception handling 慣例"
+```
+
+## chain-spec（多任務展開）
+
+`ccs-dispatch-plan <chain-spec.yaml>` 把一份 spec 展開成 next: 串好
+的 task.yaml 檔（不執行；產出後人工檢查再 dispatch）：
+
+```yaml
+defaults:                      # 淺層 merge 進每個 hop（hop 覆蓋 defaults）
+  scope: { cwd: "/abs/path/to/project" }
+  execution_policy: { loop_budget: 1 }
+hops:
+  - id: step-one
+    goal: "..."
+    acceptance_criteria: [ ... ]
+  - id: step-two
+    goal: "..."
+    acceptance_criteria: [ ... ]
+```
+
+產出 `hop-01-step-one.task.yaml`、`hop-02-step-two.task.yaml`
+（自動 wire `next:`，末 hop 無），每檔皆過載入驗證才落地。

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -56,7 +56,7 @@ description: "MANDATORY for any ccs-* command execution. Never run ccs-* command
 | jobs | j | `ccs-jobs` — dispatch 任務歷史 |
 | job <id> | | `ccs-jobs <id>` — 單筆結果（精簡：summary + artifact 路徑；`--full` 看完整輸出） |
 | dispatch-plan <spec.yaml> | dpp | `ccs-dispatch-plan <spec.yaml>` — 把 chain-spec 展開成 next:-linked task.yaml 鏈（只產檔、不派工） |
-| dispatch-run <task.yaml> | dpr | `ccs-dispatch-run <task.yaml>` — 帶 review gate + 鏈結派工 (gated task chain) |
+| dispatch-run <task.yaml> | dpr | `ccs-dispatch-run <task.yaml>` — 帶 review gate + 鏈結派工 (gated task chain)；呼叫協定與 task.yaml schema 見 ccs-dispatch-run skill |
 | review [sid] | rv | `ccs-review [sid]` — session review 報告 |
 | review html [sid] | | `ccs-review [sid] --format html -o <path>` — HTML 報告 |
 | weekly [since] [until] | wk | `ccs-review --since <date> --until <date>` — 週報 |


### PR DESCRIPTION
## Summary

新增 `ccs-dispatch-run` 的 Agent Skills 標準 skill（薄呼叫協定），把 task.yaml schema 從 gitignored internal draft 升級為 repo 內使用者面契約，並修正一個 headless claude worker 的 permission bug。

- `skills/ccs-dispatch-run/SKILL.md` — 主 session 呼叫協定：何時用、四步流程（寫 task.yaml → 呼叫 → 讀 evidence → Stage 2 judgment）、verdict 語意、chain 行為、Scope C 邊界
- `skills/ccs-dispatch-run/references/task-yaml.md` — task.yaml 契約（SoT 宣告：以實作為準）
- cross-link：ccs-orchestrator palette、`docs/commands.md`、兩份 README 的 skill symlink 段
- **fix**：headless claude worker 加 `--permission-mode bypassPermissions` — 原本 claude executor（預設）凡需要 edit tool 的 task 都會卡權限 prompt 到 wall-clock timeout，零輸出零改動（unit tests stub 掉 spawn seam，只有 live E2E 才暴露）。與 gemini 既有的 `--approval-mode yolo` 對稱；gate 重驗現實，為信任邊界

實作背景：`docs/internal/dispatch-review-gate-draft.md` Q2 收斂案（迴圈本體 = stateless CLI，主 session 側一層薄協定 skill）的落地。

## Review

Fresh-context reviewer 全 diff 對照實作逐項核對：

- 結論：**可 merge**，無 BLOCKER/MAJOR
- 2 MINOR + 2 NIT（皆文件語意補強）已修正併入 commit：Stage 2 read set 補 `git-status.txt`（untracked 新檔不入 diff.patch）、chain exit 0 ≠ 完整跑完（`failed`/`depth` 也回 0）、AC shell 環境繼承措辭、補 usage exit 1
- 文件宣稱行為（欄位驗證、預設值、verdict 規則、evidence 樹、chain stop reasons）與 `ccs-dispatch.sh` 實作逐項一致

## Test plan

- [x] dispatch/gate/plan unit suites 全 pass（43 + 11 passed，executor-cli、chain、plan-cli 等 9 suites）
- [x] E2E smoke（真實 `claude -p` worker）：PASS 路徑 rc=0 / `outcome: accepted` / `stop_reason: empty-next`；FAIL 路徑 rc=10 / `attempts: 2` / attempt-02 prompt 含 machine-fact 失敗摘要
- [x] evidence 目錄樹與 SKILL.md 描述逐項一致
- [x] 脫敏 grep（個人路徑 / IP）零命中
- [x] frontmatter：name 與目錄一致、description 含 what + when
- [ ] `tests/e2e/test-status-e2e.sh` fail — pre-existing（master 同樣 fail），與本 diff 無關，未處理

🤖 Generated with [Claude Code](https://claude.com/claude-code)