### PR TITLE
docs(dispatch): require pre-change baseline check for count-type AC

### DIFF
--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -35,6 +35,10 @@
 - **反假陽性基線驗證**：count / pattern 類 AC 的門檻，先對
   pre-change 基線跑過同一 predicate、確認改動前為 FAIL 再凍結——
   否則 AC 可能改動前即 PASS，gate 對該面向失去裁決力
+- **負向 AC 碰撞檢查**（wingman plan-passthrough 尤其）：`! grep`
+  類 AC 凍結前，對 plan 內給定的代碼**含註解字面**跑同一
+  predicate——基線驗證擋不住 plan 自帶的字面碰撞，gate 會 FAIL
+  在正確的實作上
 - integration 類：驗「元件被呼叫」不只「檔案存在」
   （例：`grep -q 'from .greeter import' src/cli.py`）
 - 涉及 credential 的 task：加一條

--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -32,6 +32,9 @@
 
 ## AC 撰寫紀律
 
+- **反假陽性基線驗證**：count / pattern 類 AC 的門檻，先對
+  pre-change 基線跑過同一 predicate、確認改動前為 FAIL 再凍結——
+  否則 AC 可能改動前即 PASS，gate 對該面向失去裁決力
 - integration 類：驗「元件被呼叫」不只「檔案存在」
   （例：`grep -q 'from .greeter import' src/cli.py`）
 - 涉及 credential 的 task：加一條


### PR DESCRIPTION
## Summary

task-yaml.md 的「AC 撰寫紀律」新增一條：count / pattern 類 AC 的門檻必須先對 pre-change 基線跑過同一 predicate、確認改動前為 FAIL 再凍結。

## Why

第一次 wingman executor dogfood 派工（agent-pager #89）的轉寫過程實際踩到：某條 AC 初稿 pattern 會被既有代碼 pre-change 匹配（假陽性），gate 對該面向失去裁決力；改為對過基線的 count 門檻後才凍結。此紀律與 plan-quality skill 的「轉寫紀律」段同步落地（claude-config `bf3ff91`），設計紀錄在 averloop repo `docs/internal/specs/2026-07-17-g5-ac-pipeline-design.md`。

## Test plan

- [x] doc-only 變更，無行為面；`git diff` 僅 task-yaml.md +3 行
- [x] sync-checklist 對照：不涉指令清單 / 狀態圖示 / 模組檔案，無跨檔同步需求
- [x] CHANGELOG：非 notable behavior，不加條目

🤖 Generated with [Claude Code](https://claude.com/claude-code)