### PR TITLE
feat(dispatch): let agentpager backend launch a gemini worker

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -862,7 +862,7 @@ _ccs_dispatch_chain_stop_reason() {
 # proj KEY only — agent-pager resolves it to a path from its own whitelist (the
 # RCE boundary). Echoes the file path; rc 1 on write failure.
 _ccs_dispatch_agentpager_launch_file() {
-  local job_id="$1" proj="$2" key="$3" prompt="$4" pager_dir="$5"
+  local job_id="$1" proj="$2" key="$3" prompt="$4" pager_dir="$5" cli="${6:-claude}"
   local inbound="$pager_dir/inbound"
   mkdir -p "$inbound" || return 1
   local f="$inbound/$(date +%s)-${job_id}.md"
@@ -871,7 +871,7 @@ _ccs_dispatch_agentpager_launch_file() {
     printf 'kind: launch\n'
     printf 'slot: %s\n' "$key"
     printf 'proj: %s\n' "$proj"
-    printf 'cli: claude\n'
+    printf 'cli: %s\n' "$cli"
     printf -- '---\n'
     printf '%s\n' "$prompt"
   } > "$f" || return 1
@@ -1108,7 +1108,7 @@ _ccs_dispatch_chain_notify() {
 # project_dir and re-resolves the SAME proj key (no cross-project branch).
 _ccs_dispatch_chain_next() {
   local job_id="$1" key="$2" project_dir="$3" pager_dir="$4"
-  local chain_depth="$5" max_depth="$6"
+  local chain_depth="$5" max_depth="$6" cli="${7:-claude}"
   local dispatch_dir
   dispatch_dir="$(_ccs_dispatch_dir)"
   local handoff_dst="$dispatch_dir/results/${job_id}.handoff"
@@ -1152,9 +1152,10 @@ _ccs_dispatch_chain_next() {
     --arg be "agentpager" \
     --arg ca "$(date -Iseconds)" \
     --arg cp "$job_id" \
+    --arg cli "$cli" \
     --argjson cd "$next_depth" \
     --argjson cm "$max_depth" \
-    '{job_id:$jid, project:$proj, task:$t, backend:$be, status:"running",
+    '{job_id:$jid, project:$proj, task:$t, backend:$be, cli:$cli, status:"running",
       created_at:$ca, chain:true, chain_parent:$cp, chain_depth:$cd,
       chain_max:$cm}')"
   printf '%s' "$next_task" > "$dispatch_dir/results/${next_job_id}.prompt"
@@ -1173,7 +1174,7 @@ _ccs_dispatch_chain_next() {
   [ -f "$stream" ] && start_offset="$(stat -c %s "$stream" 2>/dev/null || echo 0)"
 
   if ! _ccs_dispatch_agentpager_launch_file \
-        "$next_job_id" "$proj" "$key" "$worker_prompt" "$pager_dir" >/dev/null; then
+        "$next_job_id" "$proj" "$key" "$worker_prompt" "$pager_dir" "$cli" >/dev/null; then
     _ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$next_job_id" \
       '{job_id:$jid, status:"failed", chain_stopped:"failed",
         note:"chain: launch write failed"}')"
@@ -1185,7 +1186,7 @@ _ccs_dispatch_chain_next() {
   # the new hop so ccs-jobs sync defers to the live monitor, then re-enter.
   echo $$ > "$dispatch_dir/pids/${next_job_id}.pid"
   _ccs_dispatch_agentpager_monitor "$next_job_id" "$key" "$project_dir" \
-    "$start_offset" "$pager_dir" 1 "$next_depth" "$max_depth" "$job_id"
+    "$start_offset" "$pager_dir" 1 "$next_depth" "$max_depth" "$job_id" "$cli"
 }
 
 # Background monitor for one agent-pager job. Runs under nohup from spawn. Polls
@@ -1198,6 +1199,7 @@ _ccs_dispatch_agentpager_monitor() {
   # Slot 9 (chain_parent) is accepted for call-site symmetry but not read here:
   # chain_next derives the parent from the finished job_id it is handed.
   local _chain_parent="${9:-}"
+  local cli="${10:-claude}"
   local tmux_session="agent-pager-$key"
   local stream="$pager_dir/channels/$key/out.stream"
   local state_json="$pager_dir/state/sessions/$key.json"
@@ -1267,7 +1269,7 @@ _ccs_dispatch_agentpager_monitor() {
   # enters the monitor for the next hop (bounded by max_depth). (spec §3)
   [ "$chain_enabled" = 1 ] || return 0
   _ccs_dispatch_chain_next "$job_id" "$key" "$project_dir" "$pager_dir" \
-    "$chain_depth" "$max_depth"
+    "$chain_depth" "$max_depth" "$cli"
 }
 
 # Poll until the tmux session is gone or $2 seconds elapse. Extracted so the
@@ -1303,7 +1305,7 @@ _ccs_dispatch_agentpager_wait_settle() {
 # headless) for --sync, an unresolvable proj key, or an inbound write failure.
 _ccs_dispatch_spawn_agentpager() {
   local job_id="$1" project_dir="$2" prompt="$3" timeout_secs="$4" mode="$5"
-  local chain_enabled="${6:-0}" max_depth="${7:-5}"
+  local chain_enabled="${6:-0}" max_depth="${7:-5}" cli="${8:-claude}"
 
   if [ "$mode" = "sync" ]; then
     echo "ccs-dispatch: agent-pager backend is async-only;" \
@@ -1339,7 +1341,7 @@ _ccs_dispatch_spawn_agentpager() {
   local worker_prompt launch_file
   worker_prompt="$(_ccs_dispatch_agentpager_prompt "$job_id" "$prompt")"
   if ! launch_file="$(_ccs_dispatch_agentpager_launch_file \
-        "$job_id" "$proj" "$key" "$worker_prompt" "$pager_dir")"; then
+        "$job_id" "$proj" "$key" "$worker_prompt" "$pager_dir" "$cli")"; then
     echo "ccs-dispatch: failed to write agent-pager launch;" \
          "falling back to headless" >&2
     return 2
@@ -1353,9 +1355,9 @@ _ccs_dispatch_spawn_agentpager() {
   if [ "${CCS_DISPATCH_AGENTPAGER_MONITOR:-1}" = "1" ]; then
     nohup bash -c '
       source "$6/ccs-dashboard.sh"
-      _ccs_dispatch_agentpager_monitor "$1" "$2" "$3" "$4" "$5" "$7" 0 "$8" ""
+      _ccs_dispatch_agentpager_monitor "$1" "$2" "$3" "$4" "$5" "$7" 0 "$8" "" "$9"
     ' _ "$job_id" "$key" "$project_dir" "$start_offset" "$pager_dir" "$script_dir" \
-      "$chain_enabled" "$max_depth" \
+      "$chain_enabled" "$max_depth" "$cli" \
       > /dev/null 2>&1 &
     echo $! > "$dispatch_dir/pids/${job_id}.pid"
     disown
@@ -1412,13 +1414,13 @@ _ccs_dispatch_spawn() {
   local job_id="$1" project_dir="$2" prompt="$3"
   local timeout_secs="$4" mode="$5"
   local backend="${6:-$(_ccs_dispatch_resolve_backend)}"
-  local chain_enabled="${7:-0}" max_depth="${8:-5}"
+  local chain_enabled="${7:-0}" max_depth="${8:-5}" cli="${9:-claude}"
 
   _CCS_DISPATCH_LAST_BACKEND="$backend"
   if [ "$backend" = "agentpager" ]; then
     if _ccs_dispatch_spawn_agentpager \
          "$job_id" "$project_dir" "$prompt" "$timeout_secs" "$mode" \
-         "$chain_enabled" "$max_depth"; then
+         "$chain_enabled" "$max_depth" "$cli"; then
       return 0
     fi
     _CCS_DISPATCH_LAST_BACKEND="headless"  # agent-pager failed -> fell back
@@ -1558,6 +1560,9 @@ Options:
                    reports outcome:done + next, launch the next worker in the
                    same project without asking again. Approved once up front.
   --max-depth <n>  Max chained hops (default 5); a runaway ceiling.
+  --cli <name>     Worker CLI for the agentpager backend: claude (default) or
+                   gemini. Env default: CCS_DISPATCH_CLI. Ignored (with a
+                   warning) by the headless backend, which always runs claude.
 HELP
     return 0
   fi
@@ -1567,6 +1572,7 @@ HELP
   local mode="async" context=false preview=false assume_yes=false
   local timeout_secs="" project="" task=""
   local chain=false max_depth="$CCS_DISPATCH_CHAIN_MAX_DEPTH"
+  local cli="${CCS_DISPATCH_CLI:-claude}"
   while [ $# -gt 0 ]; do
     case "$1" in
       --sync) mode="sync"; shift ;;
@@ -1583,6 +1589,7 @@ HELP
             return 1 ;;
         esac
         max_depth="$2"; shift 2 ;;
+      --cli) cli="$2"; shift 2 ;;
       *) task="$1"; shift ;;
     esac
   done
@@ -1596,6 +1603,11 @@ HELP
   if [ ! -d "$project" ]; then
     echo "Error: $project not found" >&2; return 1
   fi
+  case "$cli" in
+    claude|gemini) ;;
+    *) echo "ccs-dispatch: --cli must be 'claude' or 'gemini' (got: $cli)" >&2
+       return 1 ;;
+  esac
 
   project="$(cd "$project" && pwd)"
 
@@ -1634,6 +1646,15 @@ HELP
   fi
   local chain_enabled=0; $chain && chain_enabled=1
 
+  # --cli selects the worker CLI for the agentpager (interactive) backend only.
+  # The headless backend always runs claude; warn + downgrade so the job record
+  # is honest about what actually ran. (mirrors the --chain downgrade above)
+  if [ "$cli" != "claude" ] && [ "$backend" != "agentpager" ]; then
+    echo "ccs-dispatch: --cli $cli only affects the agentpager backend;" \
+         "dispatching with claude on $backend" >&2
+    cli="claude"
+  fi
+
   # Sign-off gate (#75): before the first side effect, so a rejection leaves
   # no job record and no worker. --yes keeps automation non-interactive.
   if $preview; then
@@ -1655,21 +1676,25 @@ HELP
     --arg m "$mode" \
     --arg be "$backend" \
     --arg ca "$(date -Iseconds)" \
+    --arg cli "$cli" \
     --argjson ce "$chain_enabled" \
     --argjson md "$max_depth" \
-    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, status:"running", created_at:$ca}
+    '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, cli:$cli, status:"running", created_at:$ca}
      + (if $ce == 1 then {chain:true, chain_depth:0, chain_max:$md} else {} end)'
   )"
 
   local spawn_rc=0
   _ccs_dispatch_spawn "$job_id" "$project" "$prompt" \
-    "$timeout_secs" "$mode" "$backend" "$chain_enabled" "$max_depth" || spawn_rc=$?
+    "$timeout_secs" "$mode" "$backend" "$chain_enabled" "$max_depth" "$cli" || spawn_rc=$?
 
   if [ "${_CCS_DISPATCH_LAST_BACKEND:-$backend}" != "$backend" ]; then
+    # A fallback always lands on headless, which runs claude. Correct the record's
+    # cli too, so a gemini request that silently fell back is not misrecorded as
+    # gemini (the pre-spawn record may carry cli:gemini when backend=agentpager).
     _ccs_dispatch_jsonl_append "$(jq -nc \
       --arg jid "$job_id" \
       --arg be "$_CCS_DISPATCH_LAST_BACKEND" \
-      '{job_id:$jid, backend:$be, fallback:true}')"
+      '{job_id:$jid, backend:$be, cli:"claude", fallback:true}')"
   fi
 
   if [ "$mode" = "sync" ]; then

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -477,6 +477,8 @@ ccs-dispatch --timeout 300 \
 --chain        (agentpager only) 自動接力：worker 回報 outcome:done + next 時，
                在同一專案內自動派出下一個 worker，不再逐跳詢問（鏈首一次核准）
 --max-depth <n> 最大接力跳數（預設 5），防跑飛硬上限
+--cli <name>   agentpager 後端的 worker CLI：claude（預設）或 gemini；env 預設
+               CCS_DISPATCH_CLI。headless 後端忽略（會警告並用 claude）
 ```
 
 **拍板流程（operator sign-off）**：人直接操作時 `--preview` 會互動確認；
@@ -493,6 +495,7 @@ CCS_DISPATCH_TIMEOUT=600          # async 預設 timeout
 CCS_DISPATCH_RESULT_TTL_DAYS=7    # 結果檔保留天數
 CCS_DISPATCH_MAX_CONCURRENT_WARN=3  # 並行 job 警告閾值
 CCS_DISPATCH_BACKEND=auto         # auto | agentpager | headless
+CCS_DISPATCH_CLI=claude           # agentpager worker CLI: claude | gemini
 CCS_DISPATCH_PREVIEW_TIMEOUT=60   # --preview 確認等待秒數
 CCS_DISPATCH_PREVIEW_MAX_CHARS=1500  # preview prompt 折疊長度
 CCS_DISPATCH_CHAIN_MAX_DEPTH=5    # --chain 預設最大接力跳數
@@ -527,6 +530,9 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
 **agentpager 行為：**
 
 - **async only**：`--sync` 會 fallback 回 headless（互動 worker 可能長跑）。
+- **worker CLI 可選**：`--cli gemini`（或 `CCS_DISPATCH_CLI=gemini`）讓互動 worker
+  跑 gemini 而非 claude；claude 為預設。僅 agentpager 後端支援——headless 一律
+  claude，指定 gemini 會警告並退回 claude。gemini chain 各 hop 沿用同一 cli。
 - **完成判定**：worker 完成時把交接寫到 `tmp/handoff-<job-id>.md`（開場 prompt 已注入
   此規則）；ccs 偵測到即收席位、把交接存到 `results/<job-id>.handoff`，狀態記為
   `handoff-ready`。無交接但 session 自行結束 → `completed`；session 從未起來 → `failed`。

--- a/tests/test-dispatch-agentpager-cli.sh
+++ b/tests/test-dispatch-agentpager-cli.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-agentpager-cli.sh — ccs-dispatch --cli selector (issue #89).
+# Command-level parsing: --cli flag, CCS_DISPATCH_CLI env default, precedence,
+# validation, and the headless-backend downgrade warning. The spawn->inbound
+# threading itself is covered in test-dispatch-spawn-agentpager.sh.
+# Isolation: XDG_DATA_HOME sandbox; the spawn dispatcher is overridden to capture
+# the cli argument instead of running the real backend.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-agentpager-cli-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+DD="$(_ccs_dispatch_dir)"
+JOBS="$DD/jobs.jsonl"
+reset_jobs() { rm -f "$JOBS"; rm -rf "$DD/results" "$DD/pids"; mkdir -p "$DD/results" "$DD/pids"; }
+
+PROJ="$SCRIPT_DIR/tmp/test-ap-cli-proj"; mkdir -p "$PROJ"
+CAP="$SCRIPT_DIR/tmp/test-ap-cli-spawn.cli"
+
+# Capture the cli argument ccs-dispatch passes to the spawn dispatcher (slot 9),
+# instead of running the real backend. rc 0 so ccs-dispatch reports success.
+_ccs_dispatch_spawn() { printf '%s' "${9:-}" > "$CAP"; return 0; }
+
+echo "=== --cli gemini is threaded to the spawn dispatcher ==="
+reset_jobs; : > "$CAP"
+CCS_DISPATCH_BACKEND=agentpager ccs-dispatch --cli gemini --project "$PROJ" --yes "t" >/dev/null 2>&1
+assert_eq "flag selects gemini" "gemini" "$(cat "$CAP")"
+
+echo "=== default cli is claude ==="
+reset_jobs; : > "$CAP"
+CCS_DISPATCH_BACKEND=agentpager ccs-dispatch --project "$PROJ" --yes "t" >/dev/null 2>&1
+assert_eq "no flag -> claude" "claude" "$(cat "$CAP")"
+
+echo "=== CCS_DISPATCH_CLI env sets the default ==="
+reset_jobs; : > "$CAP"
+CCS_DISPATCH_BACKEND=agentpager CCS_DISPATCH_CLI=gemini \
+  ccs-dispatch --project "$PROJ" --yes "t" >/dev/null 2>&1
+assert_eq "env selects gemini" "gemini" "$(cat "$CAP")"
+
+echo "=== flag overrides env ==="
+reset_jobs; : > "$CAP"
+CCS_DISPATCH_BACKEND=agentpager CCS_DISPATCH_CLI=gemini \
+  ccs-dispatch --cli claude --project "$PROJ" --yes "t" >/dev/null 2>&1
+assert_eq "flag beats env" "claude" "$(cat "$CAP")"
+
+echo "=== invalid --cli aborts before any side effect ==="
+reset_jobs; : > "$CAP"
+before=$([ -f "$JOBS" ] && wc -l < "$JOBS" || echo 0)
+rc=0
+err="$(CCS_DISPATCH_BACKEND=agentpager ccs-dispatch --cli bogus --project "$PROJ" --yes "t" 2>&1 >/dev/null)" || rc=$?
+assert_eq "invalid --cli -> rc 1" "1" "$rc"
+assert_contains "error names the --cli flag" "$err" "cli"
+assert_eq "spawn not called on invalid cli" "" "$(cat "$CAP")"
+after=$([ -f "$JOBS" ] && wc -l < "$JOBS" || echo 0)
+assert_eq "no job record written on invalid cli" "$before" "$after"
+
+echo "=== --cli gemini on headless warns and downgrades to claude ==="
+reset_jobs; : > "$CAP"
+warn="$(CCS_DISPATCH_BACKEND=headless ccs-dispatch --cli gemini --project "$PROJ" --yes "t" 2>&1 >/dev/null)"
+assert_contains "headless --cli emits a warning" "$warn" "cli"
+assert_eq "headless downgrades to claude" "claude" "$(cat "$CAP")"
+
+rm -rf "$PROJ"; rm -f "$CAP"
+test_summary

--- a/tests/test-dispatch-chain.sh
+++ b/tests/test-dispatch-chain.sh
@@ -210,4 +210,42 @@ printf '# md\n' > "$DD/results/d-plain.md"
 po="$(ccs-jobs d-plain 2>/dev/null)"
 assert_not_contains "no Chain line for a plain job" "$po" "**Chain:**"
 
+echo "=== chain hop inherits the cli selector (AC4: gemini stays gemini) ==="
+reset_jobs
+acli_proj="$SCRIPT_DIR/tmp/test-chain-cli-proj"; mkdir -p "$acli_proj/tmp"
+acli_map="$SCRIPT_DIR/tmp/test-chain-cli-map"
+printf 'ccs-dashboard = %s\n' "$acli_proj" > "$acli_map"
+acli_pager="$SCRIPT_DIR/tmp/test-chain-cli-pager"; mkdir -p "$acli_pager/inbound"
+acli_cap="$SCRIPT_DIR/tmp/test-chain-cli.cap"; : > "$acli_cap"
+PAR="d-chain-cli-head"
+_ccs_dispatch_jsonl_append "$(jq -nc --arg jid "$PAR" --arg ca "$(date -Iseconds)" \
+  '{job_id:$jid,project:"ccs-dashboard",backend:"agentpager",created_at:$ca,
+    status:"handoff-ready",chain:true,chain_depth:0,chain_max:5}')"
+printf -- '---\noutcome: done\nnext: second step\n---\nbody\n' > "$DD/results/${PAR}.handoff"
+# Capture the cli arg (slot 6) the hop's launch receives; no-op the monitor re-entry.
+_ccs_dispatch_agentpager_launch_file() { printf '%s' "${6:-}" > "$acli_cap"; printf 'stub\n'; }
+_ccs_dispatch_agentpager_monitor() { :; }
+CCS_DISPATCH_PROJ_MAP="$acli_map" AGENT_PAGER_DIR="$acli_pager" CCS_DISPATCH_NOTIFY=0 \
+  _ccs_dispatch_chain_next "$PAR" "local-tester" "$acli_proj" "$acli_pager" 0 5 gemini
+assert_eq "hop launch inherits cli=gemini" "gemini" "$(cat "$acli_cap")"
+hopid=$(jq -rs 'map(select(.chain_parent=="'"$PAR"'"))|last|.job_id' "$JOBS")
+assert_eq "hop record records cli=gemini" "gemini" \
+  "$(_ccs_dispatch_jsonl_latest "$hopid" | jq -r '.cli')"
+rm -rf "$acli_proj" "$acli_map" "$acli_pager"; rm -f "$acli_cap"
+
+echo "=== agentpager->headless runtime fallback records cli=claude (honesty) ==="
+reset_jobs
+export CCS_DISPATCH_BACKEND=agentpager
+hbin="$SCRIPT_DIR/tmp/test-chain-honesty-bin"; mkdir -p "$hbin"
+printf '#!/bin/bash\necho "mock: $*"\n' > "$hbin/claude"; chmod +x "$hbin/claude"
+hproj="$SCRIPT_DIR/tmp/test-chain-honesty-proj"; mkdir -p "$hproj"
+# --sync makes the agentpager backend return 2 -> real fallback to headless-claude.
+PATH="$hbin:$PATH" ccs-dispatch --sync --cli gemini --project "$hproj" --yes "t" >/dev/null 2>&1
+hid=$(jq -rs 'map(.job_id)|last' "$JOBS")
+assert_eq "runtime fallback records cli=claude, not gemini" "claude" \
+  "$(_ccs_dispatch_jsonl_latest "$hid" | jq -r '.cli')"
+assert_eq "and records the headless fallback backend" "headless" \
+  "$(_ccs_dispatch_jsonl_latest "$hid" | jq -r '.backend')"
+rm -rf "$hbin" "$hproj"; unset CCS_DISPATCH_BACKEND
+
 test_summary

--- a/tests/test-dispatch-spawn-agentpager.sh
+++ b/tests/test-dispatch-spawn-agentpager.sh
@@ -39,6 +39,12 @@ assert_eq "kind is launch" "launch" "$kind"
 assert_eq "slot is the local key" "local-tester" "$slot"
 assert_eq "proj is the resolved key" "ccs-dashboard" "$projk"
 assert_contains "body carries the worker prompt" "$body" "hello worker body"
+assert_eq "cli defaults to claude" "claude" "$(sed -n 's/^cli: //p' "$lf" | head -1)"
+
+echo "=== launch file honors cli selector (gemini) ==="
+lfg="$(_ccs_dispatch_agentpager_launch_file "d-test-gem" "ccs-dashboard" "local-tester" "gem worker body" "$tmproot" gemini)"
+assert_eq "cli is gemini when selected" "gemini" "$(sed -n 's/^cli: //p' "$lfg" | head -1)"
+assert_eq "gemini launch kind still launch" "launch" "$(sed -n 's/^kind: //p' "$lfg" | head -1)"
 
 echo "=== stop file targets the local key ==="
 sf="$(_ccs_dispatch_agentpager_stop_file "local-tester" "$tmproot")"
@@ -120,6 +126,20 @@ assert_contains "inbound is a launch" "$(cat "$found" 2>/dev/null)" "kind: launc
 assert_contains "inbound carries the worker prompt" "$(cat "$found" 2>/dev/null)" "the prompt body"
 assert_contains "inbound carries handoff-gating invariant" "$(cat "$found" 2>/dev/null)" "tmp/handoff-d-ok.md"
 rm -rf "$projdir" "$pmap" "$pager"
+
+echo "=== spawn (async) threads cli=gemini into the launch inbound ==="
+_ccs_dispatch_agentpager_session_alive() { return 1; }  # no live seat -> guard passes
+gprojdir="$SCRIPT_DIR/tmp/test-spawn-ap-gem-proj"; mkdir -p "$gprojdir"
+gpmap="$SCRIPT_DIR/tmp/test-spawn-ap-gem-map"
+printf 'ccs-dashboard = %s\n' "$gprojdir" > "$gpmap"
+gpager="$SCRIPT_DIR/tmp/test-spawn-ap-gem-pager"; mkdir -p "$gpager/inbound"
+CCS_DISPATCH_PROJ_MAP="$gpmap" AGENT_PAGER_DIR="$gpager" CCS_DISPATCH_AGENTPAGER_MONITOR=0 \
+  _ccs_dispatch_spawn_agentpager "d-gem-ok" "$gprojdir" "gem prompt body" 60 async 0 5 gemini \
+  >/dev/null 2>&1
+gfound=$(ls "$gpager/inbound/"*-d-gem-ok.md 2>/dev/null | head -1)
+assert_eq "gemini spawn wrote an inbound" "yes" "$([ -n "$gfound" ] && echo yes)"
+assert_contains "spawned inbound selects gemini" "$(cat "$gfound" 2>/dev/null)" "cli: gemini"
+rm -rf "$gprojdir" "$gpmap" "$gpager"
 
 echo "=== last-activity reflects the out.stream mtime ==="
 la_root="$SCRIPT_DIR/tmp/test-spawn-ap-la"


### PR DESCRIPTION
## Summary

`ccs-dispatch` 的 agentpager（local-channel、互動）後端先前在 inbound launch
file 寫死 `cli: claude`，只能起 claude worker；gemini 只能走 headless run 路徑。
本 PR 加入 `--cli <claude|gemini>` 選擇器（env 預設 `CCS_DISPATCH_CLI`），一路
thread 到底，讓互動後端能起 gemini worker。

## Changes

- feat(dispatch): let agentpager backend launch a gemini worker
  - `--cli <claude|gemini>` flag + `CCS_DISPATCH_CLI` env 預設（預設 claude）
  - thread 過 `spawn -> spawn_agentpager -> launch_file`，以及
    `monitor -> chain_next -> launch_file`，讓 chained hop 繼承同一 cli
  - headless 後端無法支援非 claude 的 cli：warn 並降回 claude（decision-time
    與 runtime fallback 皆是），保持 job record 誠實
  - 非法 `--cli` 值在任何 side effect 前中止
  - `docs/commands.md` 同步（flag、env var、agentpager 行為）

## Test plan (reviewer checklist)

- [x] `--cli gemini` 在 inbound launch frontmatter 寫出 `cli: gemini`
- [x] 不帶旗標寫出 `cli: claude`；既有 claude 路徑不變
- [x] 非法 `--cli` -> 報錯、rc 1、無 job record、不 spawn
- [x] chained hop 繼承 cli（gemini chain 全程 gemini）
- [x] agentpager -> headless runtime fallback 記錄 `cli=claude`（非 gemini）
- [x] （整合，手動）經 local channel 起真實 gemini worker，確認互動跑 gemini
      且 handoff 完成 — smoke 已通過（見下方 Smoke tests）

## Test results (author verified)

**Unit tests：**
worktree 內 dispatch 全套綠：
- `test-dispatch-agentpager-cli.sh`：10 passed, 0 failed（新增）
- `test-dispatch-spawn-agentpager.sh`：47 passed, 0 failed
- `test-dispatch-chain.sh`：47 passed, 0 failed（含新增 AC4 + honesty）
- backend / preview / plan-* / executor-* / jobs-agentpager / provenance-trailer
  / dispatch.sh：全綠。無 regression。

**E2E tests：**
N/A — live local-channel worker loop 無自動化 E2E harness。

**Smoke tests：**
PASSED — AC4 整合 smoke 已於 argus（已在 `/launch` 白名單）跑通：
`ccs-dispatch --cli gemini --project <argus>` -> agentpager local channel ->
真實 gemini worker 互動執行 -> 建出 `tmp/gemini-pager-smoke/hello.txt`（恰一行
`plumbing ok`）-> 寫 handoff（`outcome: done`）-> monitor finalize（job
`handoff-ready`、record `cli:gemini` / `backend:agentpager`）。argus 本體未髒
（產物在 gitignored `tmp/`，smoke 後已清）。

## Reviewer summary

Fresh-context reviewer 判定：PASS-with-minor。三條路徑的 positional threading
皆驗證正確（initial dispatch、chain re-entry、nohup monitor spawn）；無 dead
param；validation 順序 + jq 合法性確認；全套綠。兩個 minor 已在本 branch 修：
1. runtime agentpager -> headless fallback 讓 job record 的 `cli` 留成 gemini
   -> 已修（fallback record 現設 `cli:claude`）+ 補 regression test。
2. chain cli inheritance 原僅 inspection、無測試 -> 補 test 驅動 gemini chain
   並斷言 hop record 帶 `cli:gemini`。

## Carry-forward Minor items

- 無 — 兩個 reviewer minor 已於 branch 內修。
- Out of scope（另軌 followup）：headless `ccs-dispatch-run` 的 gemini 需非互動
  shell 帶 `GOOGLE_CLOUD_PROJECT`；wingman 走互動路徑；gate 迴圈接 agentpager 後端。

## Related

- Closes #89
- Related: #71 (agent-pager backend progress in ccs-jobs)
