### PR TITLE
feat(dispatch): run the gate worker on the agentpager backend

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -104,6 +104,12 @@ _ccs_dispatch_gate_load_task() {
     and (if .executor == "wingman"
          then (.plan | type == "string" and (length > 0))
          else (.plan == null) end)
+    and ((.backend == null) or
+         (.backend | type == "string"
+          and (. == "headless" or . == "agentpager")))
+    and (if .backend == "agentpager"
+         then (.executor != "wingman")
+         else true end)
   ' >/dev/null 2>&1 \
     || { echo "gate: task validation failed: $yaml" >&2; return 1; }
   echo "$js"
@@ -348,7 +354,16 @@ _ccs_dispatch_chain_alloc_dir() {
 _ccs_dispatch_run_worker() {
   local cwd="$1" prompt="$2" run_dir="$3" attempt="$4"
   local timeout_sec="${5:-$CCS_DISPATCH_TIMEOUT}" executor="${6:-claude}"
-  local plan_abs="${7:-}"
+  local plan_abs="${7:-}" backend="${8:-headless}"
+  # backend=agentpager routes the worker through the interactive local channel
+  # (foreground blocking spawn+wait), so a gate-run can BOTH verify+retry AND run
+  # its worker in a monitorable/interruptible tmux session (issue #91). The gate
+  # stays the sole verdict source; this only changes HOW the worker is spawned.
+  if [ "$backend" = "agentpager" ]; then
+    _ccs_dispatch_run_worker_agentpager \
+      "$cwd" "$prompt" "$run_dir" "$attempt" "$timeout_sec" "$executor"
+    return 0
+  fi
   local ad="$run_dir/attempt-$(printf '%02d' "$attempt")"
   mkdir -p "$ad"
   # claude/gemini need auto-approve: headless has no tty, so a permission
@@ -385,11 +400,14 @@ _ccs_dispatch_run_worker() {
 # the terminal verdict word; rc 0 accepted / 10 escalated / 11 hard_stop.
 _ccs_dispatch_run_one() {
   local task="$1" task_yaml="$2" hop_dir="$3"
-  local cwd budget goal timeout_sec executor plan plan_abs=""
+  local cwd budget goal timeout_sec executor backend plan plan_abs=""
   cwd="$(echo "$task" | jq -r '.scope.cwd // "."')"
   budget="$(echo "$task" | jq -r ".execution_policy.loop_budget // $CCS_DISPATCH_GATE_LOOP_BUDGET")"
   goal="$(echo "$task" | jq -r '.goal')"
   executor="$(echo "$task" | jq -r '.executor // "claude"')"
+  # backend: headless (default, synchronous headless CLI) or agentpager (the
+  # interactive local-channel worker, run in the foreground under the gate).
+  backend="$(echo "$task" | jq -r '.backend // "headless"')"
   timeout_sec="$(echo "$task" | jq -r '.execution_policy.timeout_sec // empty')"
   [ -z "$timeout_sec" ] && timeout_sec="$CCS_DISPATCH_TIMEOUT"
   plan="$(echo "$task" | jq -r '.plan // empty')"
@@ -417,7 +435,7 @@ _ccs_dispatch_run_one() {
     fi
     printf '%s' "$prompt" > "$ad/prompt.md"
 
-    _ccs_dispatch_run_worker "$cwd" "$prompt" "$hop_dir" "$attempt" "$timeout_sec" "$executor" "$plan_abs"
+    _ccs_dispatch_run_worker "$cwd" "$prompt" "$hop_dir" "$attempt" "$timeout_sec" "$executor" "$plan_abs" "$backend"
     verdict="$(_ccs_dispatch_gate_run "$cwd" "$task" "$ad" "$attempt" "$budget")"
 
     case "$verdict" in
@@ -1362,6 +1380,160 @@ _ccs_dispatch_spawn_agentpager() {
     echo $! > "$dispatch_dir/pids/${job_id}.pid"
     disown
   fi
+  return 0
+}
+
+# Foreground blocking wait for an agentpager worker under the gate loop (#91).
+# Unlike the async monitor, this runs inline (no nohup) and does NOT touch the
+# job board (jobs.jsonl): the gate verifies ground truth, so this only needs to
+# (1) wait for the worker to signal done via its handoff file, (2) reclaim the
+# single per-user seat, and (3) collect the worker's stream frames as evidence.
+# Bounded by <timeout> -- the gate path is autonomous, so a stuck worker must
+# not hang the run; the jobs path's D2 "no wall-clock kill" governs the attended
+# backend, a different entry point. rc 0 = handoff observed (clean completion);
+# rc 1 = timeout / worker gone with no handoff / session never appeared. The seat
+# is reclaimed on any still-alive exit (retry-once, mirroring the async monitor).
+_ccs_dispatch_agentpager_wait_and_collect() {
+  local key="$1" pager_dir="$2" handoff_src="$3" sig="$4" stream="$5"
+  local start_offset="$6" dest="$7"
+  local startup="${8:-${CCS_DISPATCH_AGENTPAGER_STARTUP:-60}}"
+  local timeout="${9:-$CCS_DISPATCH_TIMEOUT}"
+  local tmux_session="agent-pager-$key"
+  local poll="${CCS_DISPATCH_AGENTPAGER_POLL:-3}"
+  [ "$poll" -ge 1 ] 2>/dev/null || poll=1   # a 0/invalid poll would spin forever
+  local stop_wait="${CCS_DISPATCH_AGENTPAGER_STOP_WAIT:-30}"
+  local state_json="$pager_dir/state/sessions/$key.json"
+  local rc=1 waited=0
+
+  # Phase A -- startup grace: the daemon starts the worker's tmux session a few
+  # seconds after the launch is written, so wait for it to appear (or an ultra-
+  # fast worker to have already dropped the handoff) before the completion loop.
+  while [ "$waited" -lt "$startup" ]; do
+    _ccs_dispatch_agentpager_session_alive "$tmux_session" && break
+    [ -f "$handoff_src" ] && break
+    sleep 1; waited=$((waited + 1))
+  done
+
+  # Re-resolve the handoff path against the cwd agent-pager ACTUALLY ran the
+  # worker in (its state json is the authority), so a proj-map / whitelist cwd
+  # mismatch cannot make us watch the wrong path (parity with the async monitor).
+  if [ -r "$state_json" ]; then
+    local real_cwd
+    real_cwd="$(jq -r '.cwd // empty' "$state_json" 2>/dev/null)"
+    [ -n "$real_cwd" ] && [ -d "$real_cwd" ] && \
+      handoff_src="$real_cwd/tmp/handoff-${sig}.md"
+  fi
+
+  # Phase B -- bounded completion: handoff appears, the wait times out, or the
+  # worker ends its own session.
+  waited=0
+  while _ccs_dispatch_agentpager_session_alive "$tmux_session"; do
+    [ -f "$handoff_src" ] && break
+    [ "$waited" -ge "$timeout" ] && break
+    sleep "$poll"; waited=$((waited + poll))
+  done
+
+  if [ -f "$handoff_src" ]; then
+    # Let the worker's turn-end frames flush before stopping (an eager stop
+    # truncates the captured output), copy the handoff as evidence (from the
+    # re-resolved path), then mark clean completion.
+    _ccs_dispatch_agentpager_wait_settle "$stream"
+    cp "$handoff_src" "$(dirname "$dest")/handoff.md" 2>/dev/null || true
+    rc=0
+  fi
+
+  # Reclaim the single per-user seat if the worker is still up (timeout, or a
+  # handoff written mid-turn without self-exit). Retry once; if it still will
+  # not die, leave an operator note (parity with the async monitor) so the
+  # orphaned seat is reclaimed manually rather than silently blocking retries.
+  if _ccs_dispatch_agentpager_session_alive "$tmux_session"; then
+    _ccs_dispatch_agentpager_stop_file "$key" "$pager_dir" >/dev/null
+    _ccs_dispatch_agentpager_wait_gone "$tmux_session" "$stop_wait"
+    if _ccs_dispatch_agentpager_session_alive "$tmux_session"; then
+      _ccs_dispatch_agentpager_stop_file "$key" "$pager_dir" >/dev/null
+      _ccs_dispatch_agentpager_wait_gone "$tmux_session" "$stop_wait"
+      _ccs_dispatch_agentpager_session_alive "$tmux_session" && \
+        printf 'worker session did not stop; reclaim manually (tmux %s)\n' \
+          "$tmux_session" > "$(dirname "$dest")/agentpager-reclaim-note.txt"
+    fi
+  fi
+
+  _ccs_dispatch_agentpager_collect "$stream" "$start_offset" "$dest"
+  return "$rc"
+}
+
+# SPAWN SEAM agentpager branch (#91): spawn the worker on the interactive local
+# channel and BLOCK in the foreground until it signals done, capturing evidence
+# into attempt-NN/ (mirrors the headless seam). Reuses the async backend's
+# low-level helpers but not its async monitor / job-board finalize. Each gate
+# attempt calls this fresh with the (feedback-prefixed) prompt, so retry == a
+# fresh interactive hop (Option B). The worker's rc is evidence only; the
+# deterministic gate that runs next is the sole verdict source.
+_ccs_dispatch_run_worker_agentpager() {
+  local cwd="$1" prompt="$2" run_dir="$3" attempt="$4"
+  local timeout_sec="${5:-$CCS_DISPATCH_TIMEOUT}" cli="${6:-claude}"
+  local ad="$run_dir/attempt-$(printf '%02d' "$attempt")"
+  mkdir -p "$ad"
+
+  # Fast-fail if the daemon is not available: without it no worker ever starts,
+  # so waiting out the startup grace per attempt only delays the inevitable gate
+  # FAIL. No fallback to headless -- an explicit backend request is honored or
+  # escalated, not degraded.
+  if ! _ccs_dispatch_agentpager_available; then
+    printf 'agent-pager backend not available (daemon down or spool missing)\n' \
+      > "$ad/agentpager-error.txt"
+    return 0
+  fi
+
+  # Resolve the proj KEY agent-pager maps to a cwd (its RCE whitelist). No entry
+  # / seat busy -> record why and return; the worker never ran, so the gate FAILs
+  # against ground truth (same terminal path as a no-op headless worker). No
+  # silent fallback to headless: an explicit backend request is honored or
+  # escalated, not degraded.
+  local proj
+  if ! proj="$(_ccs_dispatch_resolve_proj_from_dir "$cwd")"; then
+    printf 'no proj-map entry for %s\n' "$cwd" > "$ad/agentpager-error.txt"
+    return 0
+  fi
+  local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
+  local key; key="local-$(id -un)"
+  if _ccs_dispatch_agentpager_session_alive "agent-pager-$key"; then
+    printf 'a local agent-pager worker (agent-pager-%s) is already running\n' \
+      "$key" > "$ad/agentpager-error.txt"
+    return 0
+  fi
+
+  # Per-attempt completion signal, so a retry's wait cannot read the previous
+  # attempt's stale handoff. Clear any pre-existing one (belt-and-suspenders).
+  local sig; sig="$(basename "$run_dir")-a$(printf '%02d' "$attempt")"
+  local handoff_src="$cwd/tmp/handoff-${sig}.md"
+  rm -f "$handoff_src" 2>/dev/null || true
+
+  local stream="$pager_dir/channels/$key/out.stream"
+  local start_offset=0
+  [ -f "$stream" ] && start_offset="$(stat -c %s "$stream" 2>/dev/null || echo 0)"
+
+  # Wrap the attempt prompt with the handoff-gating rule so the worker writes
+  # tmp/handoff-<sig>.md as its done-signal (the prompt already carries the §6
+  # feedback for attempt >= 2).
+  local worker_prompt
+  worker_prompt="$(_ccs_dispatch_agentpager_prompt "$sig" "$prompt")"
+  if ! _ccs_dispatch_agentpager_launch_file \
+        "$sig" "$proj" "$key" "$worker_prompt" "$pager_dir" "$cli" \
+        > "$ad/launch-file.txt" 2>/dev/null; then
+    printf 'failed to write agent-pager launch\n' > "$ad/agentpager-error.txt"
+    return 0
+  fi
+
+  local wrc=0
+  _ccs_dispatch_agentpager_wait_and_collect "$key" "$pager_dir" "$handoff_src" \
+    "$sig" "$stream" "$start_offset" "$ad/executor-output.md" \
+    "${CCS_DISPATCH_AGENTPAGER_STARTUP:-60}" "$timeout_sec" || wrc=$?
+  printf '%s\n' "$wrc" > "$ad/agentpager-wait-rc"
+
+  # Ground-truth evidence (mirrors the headless seam).
+  (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
+  (cd "$cwd" && git diff) > "$ad/diff.patch" 2>/dev/null || true
   return 0
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -679,6 +679,7 @@ goal: "新增 greeter 並被 CLI 呼叫"
 scope:
   cwd: "/abs/path/to/project"   # worker 執行與 gate 驗收的目錄
 executor: gemini                # 可選：claude(預設) | gemini | wingman。claude/gemini 皆 auto-approve 跑 headless（claude `--permission-mode bypassPermissions`、gemini `--approval-mode yolo`）— 無 tty 下權限 prompt 會卡到 timeout；gate 為信任邊界，見 §8.4
+backend: agentpager             # 可選：headless(預設) | agentpager。agentpager 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 worker 的 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）。executor 映射為互動 worker CLI（claude|gemini）；`agentpager` + `executor: wingman` 不合法（wingman 非可互動 launch 的 CLI）。見下方「backend: agentpager」
 model: "local-chat-35b"         # 可選（advisory）：本次執行的 model，供收尾 X-Executor provenance trailer 的 <model> 段；缺省則 trailer 退化為 executor-only。不影響派工行為
 plan: "plan.md"                 # 僅 executor: wingman（互為充要）：wingman plan.md 路徑，相對本檔所在目錄解析（同 next:）；由主 session 依 wingman plan-template 撰寫
 next: "task-y.yaml"             # 可選：下一個要自動執行與驗收的任務路徑（相對於此 yaml）
@@ -711,6 +712,9 @@ ${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/runs/<first-task-id>-cha
       diff.patch         # git diff
       wingman-result.md  # 僅 wingman executor：scope.cwd/.wingman/result.md 凍結副本
       executor-exit-code # 僅 wingman executor：wingman process exit code（純 evidence，不參與 verdict）
+      launch-file.txt    # 僅 backend: agentpager：寫給 agent-pager 的 inbound launch 檔路徑
+      handoff.md         # 僅 backend: agentpager：worker per-attempt 完成訊號 handoff 副本
+      agentpager-wait-rc # 僅 backend: agentpager：前景 wait 結果（0=handoff / 1=timeout|無 handoff；純 evidence）
       gate/AC<n>.json    # per-AC 紀錄（verdict/exit/stdout tail…）
       gate/verdict.json  # gate verdict
     attempt-02/          # 重派時遞增；prompt.md 含前輪 FAIL 摘要
@@ -730,7 +734,9 @@ CCS_DISPATCH_GATE_CMD_TAIL_CHARS=2000  # per-AC stdout/stderr 擷取尾端字元
 
 > **安全註記（§8.4）：** AC `verify.cmd` 會執行 worker 產出的 code（`pytest`、`python -c` 等，驗證本質使然），僅靠 `execution_policy.timeout_sec` 設界。只對「你本就願意在本機執行」的 worker 開跑；不加 network / write-path 限制（單人本地 MVP）。
 
-**Scope C 限制（後續 sprint 補）：** 無 tier ladder（重派用同一 executor）、無 pager escalation ladder、不接 `--chain`（gated chain 續鏈為獨立層）、無 Stage-2 judgment review 自動化、guidance-AC 一律 SKIPPED_FOR_LLM。evidence 目前全留（未來加 TTL）。run loop 走同步 headless 執行；agentpager async 後端延後。
+**backend: agentpager（互動 worker 進 gate）：** 預設 `backend: headless` 走同步 headless CLI；`backend: agentpager` 讓 gate worker 改跑在 agent-pager 互動 local channel（tmux、可監看/中途接管），把「gate 驗收 + 重派」與「可觀察互動 worker」合流（issue #91）。實作為**前景阻塞式 spawn+wait**：寫 inbound launch → 等 worker 寫 per-attempt handoff 檔（`tmp/handoff-<hop>-a<NN>.md`）為完成訊號 → 收回單一 per-user seat → 回來後 gate 照常對現實跑 `verify.cmd`（handoff 內容不採信，gate 仍是唯一裁決來源）。**重派＝Option B**：gate 判 RETRY 時，attempt 迴圈重新前景 spawn 一個 fresh 互動 hop、把上輪 machine 事實 feedback 前綴進 prompt（與 headless 對稱；不同於 `wingman` 的不重派）。**bounded wait**：先有 startup grace 等 worker session 出現（`CCS_DISPATCH_AGENTPAGER_STARTUP`，預設 60s），再以 `execution_policy.timeout_sec` 綁定 completion 等待——逾時未見 handoff 即收回 seat、當作未完成（gate 隨即 FAIL）。故最壞上界約 startup + timeout。gate 路徑本質 autonomous，與 jobs/`--chain` 互動路徑的「no wall-clock kill（D2）」互不相干。`executor` 映射為互動 worker CLI（claude|gemini）；`agentpager` + `wingman` 不合法（wingman 非可互動 launch）。auth 註記：互動 gemini worker 的 `GOOGLE_CLOUD_PROJECT` 由 agent-pager runner daemon 的 process env 繼承（worker 經 `bash -c` 起、不 source `.bashrc`），非結構性保證；持久修復屬 agent-pager 側。
+
+**Scope C 限制（後續 sprint 補）：** 無 tier ladder（重派用同一 executor）、無 pager escalation ladder、不接 `--chain`（gated chain 續鏈為獨立層）、無 Stage-2 judgment review 自動化、guidance-AC 一律 SKIPPED_FOR_LLM。evidence 目前全留（未來加 TTL）。orchestrator-wake（worker 完成回灌派工 session）為獨立 followup。
 
 ## ccs-review
 

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -13,8 +13,9 @@ review。迴圈邏輯在 CLI 內，不要自己重新實作。
 
 - **用**：任務目標明確、驗收條件可寫成 shell 指令（exit 0 = PASS）、
   希望結果由現實（git diff / test / grep）裁決而非 worker 自述
-- **不用**：開放式探索或需要互動接管 → `ccs-dispatch`（agentpager
-  backend）；同 context 的小任務 → in-harness subagent
+- **不用**：開放式探索、驗收條件無法寫成 shell 指令 → `ccs-dispatch`
+  （agentpager backend，無 gate）；同 context 的小任務 → in-harness
+  subagent。（有 AC 但想要互動監看／接管 → 用本指令 `backend: agentpager`）
 - 與 `ccs-dispatch --chain`（agentpager 快速通道，無驗收）是兩層
   獨立機制，不可混用
 
@@ -121,5 +122,7 @@ PASS 後自動跟 `next:`（相對於當前 task.yaml 所在目錄解析）。
   verdict**（gate 是唯一裁決來源，worker 自述樂觀或悲觀皆不信）
 - `scope.allowed_paths` / `forbidden_paths` 未實作（僅 `scope.cwd`
   生效），worker 無路徑硬限制
-- worker 同步 headless 執行；agentpager async backend 未接入 gate 迴圈
+- worker 預設同步 headless；`backend: agentpager` 改跑互動 local channel
+  （前景阻塞式 spawn+wait、bounded by timeout、失敗不 fallback headless），
+  詳 commands.md「backend: agentpager」
 - Stage 2 無自動化（`final.json.stage2` 恆為 null，由你人工執行）

--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -12,6 +12,7 @@
 | `goal` | Yes | 非空字串；worker 收到的任務描述全文 |
 | `scope.cwd` | No | worker 執行與 gate 驗收目錄；預設 `.`（呼叫時的 cwd）；建議寫絕對路徑 |
 | `executor` | No | `claude`（預設）\| `gemini` \| `wingman`；頂層字串欄位。claude/gemini 以 auto-approve 跑 headless（gate 為信任邊界，見 SKILL.md § 邊界）；wingman 為本地 LLM 檔案驅動，需 `plan:` |
+| `backend` | No | `headless`（預設）\| `agentpager`；頂層字串欄位。`agentpager` 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）；bounded wait（逾 `timeout_sec` 收回 seat）。`executor` 映射為互動 worker CLI（claude\|gemini）；`agentpager` + `wingman` 不合法 |
 | `model` | No | 頂層字串欄位（advisory）；派工者宣告本次執行用的 model（如 wingman 的 `local-chat-35b`），供收尾 auto-suggest 的 `X-Executor` provenance trailer 填 `<model>` 段。缺省時 trailer 退化為 executor-only。不影響派工行為（script 不據此帶 `--model`） |
 | `plan` | 僅 wingman | 與 `executor: wingman` 互為充要（缺一驗證失敗）；wingman plan.md 路徑，相對**本檔所在目錄**解析（同 `next:`），執行時轉絕對路徑傳給 `wingman execute --plan`。plan 依 wingman plan-template 紀律由派工者撰寫 |
 | `next` | No | 下一個 task.yaml 路徑；相對路徑以**本檔所在目錄**解析 |

--- a/tests/test-gate-agentpager.sh
+++ b/tests/test-gate-agentpager.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# tests/test-gate-agentpager.sh — gate loop x agentpager interactive backend (#91)
+# The gate's SPAWN SEAM can route the worker through the agentpager interactive
+# channel (backend: agentpager) and still verify+retry against ground truth. The
+# live tmux+daemon loop is E2E (AC6 smoke); here the daemon is mocked via the
+# session-alive / stop-file / launch-file seams, so the wait + gate + retry logic
+# is driven deterministically.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-gate-agentpager-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+RS=$'\x1e'; US=$'\x1f'
+# Fast waits so the mocked completion loop does not sleep on real defaults.
+export CCS_DISPATCH_AGENTPAGER_STARTUP=3 CCS_DISPATCH_AGENTPAGER_POLL=1 \
+       CCS_DISPATCH_AGENTPAGER_STOP_WAIT=2 CCS_DISPATCH_AGENTPAGER_SETTLE=1 \
+       CCS_DISPATCH_AGENTPAGER_SETTLE_QUIET=1
+
+WORK="$SCRIPT_DIR/tmp/test-gate-agentpager"; rm -rf "$WORK"
+mkdir -p "$WORK/repo"; _TEST_DIRS+=("$WORK")
+
+# ── schema: backend enum ────────────────────────────────────────────────────
+echo "=== schema accepts backend: agentpager ==="
+cat > "$WORK/ok.yaml" <<YAML
+id: t
+goal: g
+backend: agentpager
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    verify: { cmd: "true" }
+YAML
+_ccs_dispatch_gate_load_task "$WORK/ok.yaml" >/dev/null 2>&1
+assert_eq "backend agentpager valid" "0" "$?"
+
+echo "=== schema accepts omitted backend (headless default) ==="
+cat > "$WORK/plain.yaml" <<YAML
+id: t
+goal: g
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    verify: { cmd: "true" }
+YAML
+_ccs_dispatch_gate_load_task "$WORK/plain.yaml" >/dev/null 2>&1
+assert_eq "omitted backend valid" "0" "$?"
+
+echo "=== schema rejects bogus backend value ==="
+cat > "$WORK/bogus.yaml" <<YAML
+id: t
+goal: g
+backend: sideways
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    verify: { cmd: "true" }
+YAML
+_ccs_dispatch_gate_load_task "$WORK/bogus.yaml" >/dev/null 2>&1
+assert_eq "bogus backend rejected" "1" "$?"
+
+echo "=== schema rejects backend: agentpager + executor: wingman ==="
+cat > "$WORK/apwing.yaml" <<YAML
+id: t
+goal: g
+backend: agentpager
+executor: wingman
+plan: p.md
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    verify: { cmd: "true" }
+YAML
+_ccs_dispatch_gate_load_task "$WORK/apwing.yaml" >/dev/null 2>&1
+assert_eq "agentpager+wingman rejected" "1" "$?"
+
+# ── foreground wait helper ──────────────────────────────────────────────────
+echo "=== wait_and_collect: handoff appears -> rc 0, seat reclaimed, output collected ==="
+SEAT="$WORK/seat"; : > "$SEAT"
+_ccs_dispatch_agentpager_session_alive() { [ -f "$SEAT" ]; }
+_ccs_dispatch_agentpager_stop_file() { rm -f "$SEAT"; echo "$WORK/stopfile"; }
+hs="$WORK/repo/tmp/handoff-sig1.md"; mkdir -p "$WORK/repo/tmp"
+printf -- '---\nsummary: did it\noutcome: done\n---\n' > "$hs"
+strm="$WORK/out.stream"
+printf '%sMSG%sprose%s\ndone task\n%sEND%s\n' "$RS" "$US" "$RS" "$RS" "$RS" > "$strm"
+dest="$WORK/out.md"
+_ccs_dispatch_agentpager_wait_and_collect "local-tester" "$WORK/pager" "$hs" "sig1" "$strm" 0 "$dest" 3 5
+rc=$?
+assert_eq "wait rc 0 on handoff" "0" "$rc"
+assert_eq "seat reclaimed" "no" "$([ -f "$SEAT" ] && echo yes || echo no)"
+assert_contains "collected this-job output" "$(cat "$dest")" "done task"
+
+echo "=== wait_and_collect: no handoff -> bounded timeout rc 1, seat reclaimed ==="
+: > "$SEAT"
+_ccs_dispatch_agentpager_wait_and_collect "local-tester" "$WORK/pager" "$WORK/nope.md" "sigT" "$strm" 0 "$WORK/o2.md" 2 1
+rc=$?
+assert_eq "wait rc 1 on timeout" "1" "$rc"
+assert_eq "seat reclaimed on timeout" "no" "$([ -f "$SEAT" ] && echo yes || echo no)"
+unset -f _ccs_dispatch_agentpager_session_alive _ccs_dispatch_agentpager_stop_file
+
+# ── integration: run_one drives the agentpager branch through the gate ───────
+export CCS_DISPATCH_PROJ_MAP="$WORK/proj-map"
+printf 'apkey=%s\n' "$WORK/repo" > "$CCS_DISPATCH_PROJ_MAP"
+export AGENT_PAGER_DIR="$WORK/pager"   # sandbox: no real state json / stream leaks in
+_ccs_dispatch_agentpager_available() { return 0; }   # mock: daemon "up"
+LAUNCHLOG="$WORK/launchlog"
+
+echo "=== integration: backend=agentpager, worker makes target -> gate PASS ==="
+cat > "$WORK/pass.yaml" <<YAML
+id: gp
+goal: "make x"
+backend: agentpager
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    text: "x exists"
+    verify: { cmd: "test -f x.txt" }
+YAML
+: > "$LAUNCHLOG"; rm -f "$WORK/seat" "$WORK/repo/x.txt"; rm -f "$WORK/repo/tmp"/handoff-*.md
+_ccs_dispatch_agentpager_session_alive() { [ -f "$WORK/seat" ]; }
+_ccs_dispatch_agentpager_stop_file() { rm -f "$WORK/seat"; echo "$WORK/stop"; }
+_ccs_dispatch_agentpager_launch_file() {   # mock the daemon: worker makes target + handoff
+  local sig="$1"; local prompt="$4"
+  mkdir -p "$WORK/repo/tmp"; : > "$WORK/seat"; : > "$WORK/repo/x.txt"
+  printf -- '---\nsummary: s\noutcome: done\n---\n' > "$WORK/repo/tmp/handoff-${sig}.md"
+  echo "$sig" >> "$LAUNCHLOG"; echo "$WORK/inbound-${sig}"
+}
+task_json="$(_ccs_dispatch_gate_load_task "$WORK/pass.yaml")"
+hop="$WORK/hop-pass"; rm -rf "$hop"
+term="$(_ccs_dispatch_run_one "$task_json" "$WORK/pass.yaml" "$hop")"; rc=$?
+assert_eq "PASS term" "PASS" "$term"
+assert_eq "PASS rc 0" "0" "$rc"
+assert_eq "PASS outcome" "accepted" "$(jq -r '.outcome' "$hop/final.json")"
+
+echo "=== integration: attempt1 FAIL -> retry -> attempt2 PASS (Option B) ==="
+cat > "$WORK/retry.yaml" <<YAML
+id: gr
+goal: "make y"
+backend: agentpager
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    text: "y exists"
+    verify: { cmd: "test -f y.txt" }
+YAML
+: > "$LAUNCHLOG"; rm -f "$WORK/seat" "$WORK/repo/y.txt"; rm -f "$WORK/repo/tmp"/handoff-*.md
+_ccs_dispatch_agentpager_launch_file() {   # only attempt>=2 (feedback-prefixed) makes the target
+  local sig="$1"; local prompt="$4"
+  mkdir -p "$WORK/repo/tmp"; : > "$WORK/seat"
+  case "$prompt" in *"未通過驗收"*) : > "$WORK/repo/y.txt" ;; esac
+  printf -- '---\nsummary: s\noutcome: done\n---\n' > "$WORK/repo/tmp/handoff-${sig}.md"
+  echo "$sig" >> "$LAUNCHLOG"; echo "$WORK/inbound-${sig}"
+}
+hop2="$WORK/hop-retry"; rm -rf "$hop2"
+term2="$(_ccs_dispatch_run_one "$(_ccs_dispatch_gate_load_task "$WORK/retry.yaml")" "$WORK/retry.yaml" "$hop2")"; rc2=$?
+assert_eq "retry then PASS term" "PASS" "$term2"
+assert_eq "retry PASS rc 0" "0" "$rc2"
+assert_eq "took 2 attempts" "2" "$(jq -r '.attempts' "$hop2/final.json")"
+# per-attempt handoff files do not collide (distinct sigs)
+assert_eq "two distinct launches" "2" "$(sort -u "$LAUNCHLOG" | wc -l | tr -d ' ')"
+assert_eq "two per-attempt handoff files" "2" \
+  "$(ls "$WORK/repo/tmp"/handoff-*.md 2>/dev/null | wc -l | tr -d ' ')"
+echo "=== integration: daemon unavailable -> fast-fail -> ESCALATE ==="
+cat > "$WORK/down.yaml" <<YAML
+id: gd
+goal: "make z"
+backend: agentpager
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    text: "z exists"
+    verify: { cmd: "test -f z.txt" }
+YAML
+rm -f "$WORK/repo/z.txt"
+_ccs_dispatch_agentpager_available() { return 1; }   # daemon down -> fast-fail
+hop3="$WORK/hop-down"; rm -rf "$hop3"
+term3="$(_ccs_dispatch_run_one "$(_ccs_dispatch_gate_load_task "$WORK/down.yaml")" "$WORK/down.yaml" "$hop3")"; rc3=$?
+assert_eq "daemon-down term ESCALATE" "ESCALATE" "$term3"
+assert_eq "daemon-down rc 10" "10" "$rc3"
+assert_eq "fast-fail error recorded" "yes" \
+  "$([ -f "$hop3/attempt-01/agentpager-error.txt" ] && echo yes || echo no)"
+
+unset -f _ccs_dispatch_agentpager_session_alive _ccs_dispatch_agentpager_stop_file \
+         _ccs_dispatch_agentpager_launch_file _ccs_dispatch_agentpager_available
+
+test_summary


### PR DESCRIPTION
## Summary

把兩條 dispatch 路徑合流：`ccs-dispatch-run` 的 gate（acceptance_criteria 驗收 +
retry）過去只能跑 headless worker，`ccs-dispatch`（jobs/chain）的 agentpager 互動
local channel 則無 gate。本 PR 讓 gate worker 可經 `backend: agentpager` 跑在互動
channel（tmux、可監看／中途接管），同時保留 gate 對現實的驗收與重派（issue #91）。

## Changes

- feat(dispatch): 新增 task.yaml `backend:` 欄位（headless 預設 | agentpager）+
  schema 驗證（含 `agentpager` + `wingman` 拒絕）；SPAWN SEAM 加前景阻塞式
  spawn+wait（`_ccs_dispatch_run_worker_agentpager` / `_ccs_dispatch_agentpager_wait_and_collect`），
  重用 async backend 的 launch/settle/stop/collect helpers（不走 nohup、不寫 job
  board）；retry ＝ 每 attempt 重啟 fresh 互動 hop 並前綴 feedback（對齊 headless）；
  bounded wait、daemon-down fast-fail、handoff 路徑對 agent-pager state json 重解析。
- docs(dispatch): commands.md + ccs-dispatch-run skill docs（SKILL.md、task-yaml.md）
  補 `backend:` 契約、前景 wait 流程、fresh-hop retry、bounded wait、agentpager +
  wingman 拒絕；記互動 gemini auth-env 註記；更正 stale「agentpager backend deferred」。

## Test plan (reviewer checklist)

- [x] 全套 `tests/run-all.sh` 綠（含新 suite）
- [x] 新 suite `tests/test-gate-agentpager.sh`：schema / 前景 wait 成功+timeout /
      run_one 整合 PASS / retry 兩 attempt / daemon-down fast-fail
- [x] headless 預設路徑行為不變、async jobs 路徑未被觸碰（fresh-context reviewer 驗）
- [x] committed 檔無 hardcoded credential / 個人 path / IP
- [x] **AC6 live smoke（已跑，PASS）**：真 daemon + 真 worker 經 local channel —
      claude gate PASS（建檔 + handoff + wait-rc=0）；gemini worker 解出
      `GOOGLE_CLOUD_PROJECT`（寫出 20 bytes）gate PASS。詳見 smoke comment

## Test results (author 已驗)

**Unit tests：** `bash tests/run-all.sh` → 47 suites passed, 0 failed, 1 skipped
（含新 `test-gate-agentpager.sh` 20 asserts 全綠）。`bash -n ccs-dispatch.sh` 通過。

**E2E tests：** N/A（hermetic 套件 mock daemon 邊界；互動 live 路徑屬 AC6 smoke）。

**Smoke tests（AC6，已跑，PASS）：** 經真 agent-pager daemon + 真 worker + local
channel、跑 worktree build。claude：gate PASS（argus 建 `ccs91-smoke.txt`、worker
寫 handoff、`agentpager-wait-rc=0`、per-attempt launch `...-a01`、outcome accepted）。
gemini：gate PASS，互動 worker 解出並寫入 `GOOGLE_CLOUD_PROJECT`（20 bytes，非空）
→ 印證互動路徑的 auth 由 runner daemon env 繼承（非 `.bashrc`）、當前環境可用。
scratch 檔已清。

## Reviewer summary

Fresh-context reviewer（capable tier，非作者）verdict：**APPROVE-WITH-FIXES**。
無 blocker/major；核心正確性（rc 語意、per-attempt handoff scoping、retry=fresh
hop、reachability、async 路徑無 regress、schema、security）逐項對源碼驗證通過，並
確認測試跑真實 call chain（非 tautology、無 false-green）。5 條 findings（2 minor +
3 nit）全數修正並已折進本 PR commit：state-json cwd 重解析（parity）、reclaim-fail
operator note、POLL floor、doc 措辭（startup+timeout）、daemon-down fast-fail（+ 新測）。
完整 report 見本 PR 的 review comment。

Drift（vs design doc，worklog Drift Log 蒸餾）：1 條 — 新前景 wait helper 未重構
async monitor 去共用其 Phase A/B 迴圈（monitor 是 jobs 路徑核心，重構有 regress
風險；且 gate=bounded、jobs=D2 unbounded，語意本就不同），僅共用 low-level helpers。
自裁為 non-scope-breaking。無其他 drift。

## Carry-forward Minor items

- Option A（餵 turn 進 live session）＝ conditional/deferred；重啟條件見 backlog § 0
  （context-rebuild-cost-dominated workload）。
- Orchestrator-wake 子缺口（worker 完成回灌派工 session）＝ 獨立 slice，另記 backlog。
- 測試未覆蓋（非阻擋）：retry-once reclaim 內層分支；session 先出現、handoff 後到的
  async timing（歸 AC6 smoke）。

## Related

- Issue: #91（Closes on merge）
- Prereq PR: #90（`--cli` selector，已 merge，master 22b20b9）
- Design: `internal/2026-07-22-gate-agentpager-integration-design.md`（gitignored）
- Related: #71（agent-pager backend in ccs-jobs）；agent-pager repo issue（headless
  gemini auth-env，另軌）
