### PR TITLE
feat(dispatch): orchestrator-wake — wake the dispatching session on async worker finish

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -912,6 +912,82 @@ _ccs_dispatch_agentpager_stop_file() {
   printf '%s\n' "$f"
 }
 
+# ── orchestrator-wake (#93) ─────────────────────────────────────────────────
+# Resolve the wake target (the dispatching "orchestrator" session's slot) from
+# its env, or empty when not wake-eligible. Captured at dispatch time into the
+# job record; the finalize / chain-end hooks read it back to wake that session
+# via the agent-pager input relay (do_input). CCS_DISPATCH_WAKE=0 opts out
+# (mirrors CCS_DISPATCH_NOTIFY). A pager-launched session carries a local channel
+# (AGENT_PAGER_CHANNEL=local + AGENT_PAGER_LOCAL_USER) or a numeric telegram slot
+# (AGENT_PAGER_BOT_SLOT); a non-pager (local terminal / headless) session has
+# neither -> empty -> no wake (case b: falls back to the ccs-jobs pull).
+_ccs_dispatch_resolve_wake_slot() {
+  [ "${CCS_DISPATCH_WAKE:-1}" != "0" ] || return 0
+  if [ "${AGENT_PAGER_CHANNEL:-}" = "local" ] && [ -n "${AGENT_PAGER_LOCAL_USER:-}" ]; then
+    printf '%s\n' "local-${AGENT_PAGER_LOCAL_USER}"
+  elif [ -n "${AGENT_PAGER_BOT_SLOT:-}" ]; then
+    printf '%s\n' "${AGENT_PAGER_BOT_SLOT}"
+  fi
+}
+
+# Write a kind:input inbound that wakes the dispatching session. Sibling of
+# _ccs_dispatch_agentpager_launch_file, but atomic (dotfile temp + mv): a partial
+# read of this loop signal would drop the wake, and the systemd .path *.md glob
+# never matches the dot-prefixed .tmp. Echoes the path; rc 1 on write failure.
+_ccs_dispatch_agentpager_wake_file() {  # $1=wake_slot $2=pager_dir $3=body
+  local slot="$1" pager_dir="$2" body="$3"
+  local inbound="$pager_dir/inbound"
+  mkdir -p "$inbound" || return 1
+  local name tmp final
+  name="$(date +%s%N)-${slot}-wake.md"
+  tmp="$inbound/.${name}.tmp"
+  final="$inbound/$name"
+  {
+    printf -- '---\n'
+    printf 'kind: input\n'
+    printf 'slot: %s\n' "$slot"
+    printf -- '---\n'
+    printf '%s\n' "$body"
+  } > "$tmp" || return 1
+  mv "$tmp" "$final" || return 1
+  printf '%s\n' "$final"
+}
+
+# Thin-pointer wake payload: a pointer into the conversation; the evidence stays
+# on disk (results/<id>.md) for the orchestrator to Read on demand (the board
+# carries pointers, disk carries evidence -- context-economy).
+_ccs_dispatch_wake_body() {  # $1=job_id $2=status $3=summary
+  printf '[ccs-wake] job %s %s\n' "$1" "$2"
+  [ -n "$3" ] && printf 'summary: %s\n' "$3"
+  printf 'artifact: results/%s.md\n' "$1"
+  printf '%s\n' "你派的 job 回來了——讀 artifact 後決定下一步（接鏈 / 收尾 / 再派）"
+}
+
+# Chain-termination wake payload: the chain unit is done -> the orchestrator's
+# turn. Names the last job + its artifact; intermediate hops never wake (item 11).
+_ccs_dispatch_chain_wake_body() {  # $1=last_job_id $2=reason $3=verb $4=artifact(optional)
+  printf '[ccs-wake] chain %s: %s\n' "$3" "$2"
+  printf 'last job: %s\n' "$1"
+  # Only point at an artifact that exists: a launch-failed terminal hop never
+  # produced results/<id>.md, so emitting the line would dangle (#93 review M1).
+  [ -n "$4" ] && printf 'artifact: %s\n' "$4"
+  printf '%s\n' "你派的 chain 跑完了——讀 last job 的 artifact / 狀態後決定下一步"
+}
+
+# Best-effort wake fire: write a kind:input inbound for wake_slot, or no-op when
+# wake_slot is empty or CCS_DISPATCH_WAKE=0. Never fails the caller (mirrors
+# _ccs_dispatch_notify_completion): the wake is fire-and-forget and does not
+# depend on do_input's delivery ack.
+_ccs_dispatch_wake_fire() {  # $1=wake_slot $2=body
+  local wake_slot="$1" body="$2"
+  [ -n "$wake_slot" ] || return 0
+  [ "${CCS_DISPATCH_WAKE:-1}" != "0" ] || return 0
+  local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"
+  _ccs_dispatch_agentpager_wake_file "$wake_slot" "$pager_dir" "$body" \
+    >/dev/null 2>&1 || true
+  return 0
+}
+
 # Decode only this job's frames from the per-user out.stream. The stream is
 # append-only and persists across jobs, so we read from the byte offset captured
 # at launch, not the whole file.
@@ -1092,6 +1168,16 @@ _ccs_dispatch_finish_agentpager() {
   [ "$handoff_flag" = true ] && notify_handoff="$handoff_dst"
   _ccs_dispatch_notify_completion "$job_id" "$status" "$project" \
     "$notify_handoff" "$note"
+
+  # orchestrator-wake (#93): a non-chain job wakes the dispatching session here.
+  # A chain job wakes only at termination (_ccs_dispatch_chain_notify), so an
+  # intermediate hop's finalize stays silent -- item 11: intermediate chain
+  # decisions do not surface to the orchestrator's context.
+  local wake_slot is_chain
+  wake_slot=$(echo "$initial" | jq -r '.wake_slot // empty')
+  is_chain=$(echo "$initial" | jq -r 'if .chain == true then 1 else 0 end')
+  [ "$is_chain" = "1" ] || _ccs_dispatch_wake_fire "$wake_slot" \
+    "$(_ccs_dispatch_wake_body "$job_id" "$status" "$summary")"
 }
 
 # Best-effort chain-termination pager notify (spec §7): one short message with
@@ -1099,13 +1185,26 @@ _ccs_dispatch_finish_agentpager() {
 # depth), "stopped" otherwise. Never fails the caller. CCS_DISPATCH_NOTIFY=0
 # opts out (shared with the per-job completion notify).
 _ccs_dispatch_chain_notify() {
-  [ "${CCS_DISPATCH_NOTIFY:-1}" != "0" ] || return 0
   local job_id="$1" reason="$2" project="$3" depth="$4"
+  local verb="stopped"
+  case "$reason" in empty-next|depth) verb="complete" ;; esac
+
+  # orchestrator-wake (#93): chain termination wakes the dispatching session (the
+  # chain unit is done -> the orchestrator's turn). Placed before the notify gate
+  # below: wake has its own CCS_DISPATCH_WAKE gate, so a pager-notify opt-out must
+  # not also suppress the wake.
+  local wake_slot wake_art wake_dd
+  wake_slot=$(_ccs_dispatch_jsonl_latest "$job_id" | jq -r '.wake_slot // empty')
+  wake_dd="$(_ccs_dispatch_dir)"
+  wake_art=""
+  [ -f "$wake_dd/results/${job_id}.md" ] && wake_art="results/${job_id}.md"
+  _ccs_dispatch_wake_fire "$wake_slot" \
+    "$(_ccs_dispatch_chain_wake_body "$job_id" "$reason" "$verb" "$wake_art")"
+
+  [ "${CCS_DISPATCH_NOTIFY:-1}" != "0" ] || return 0
   local sender
   sender="$(_ccs_dispatch_notify_sender)"
   [ -n "$sender" ] && [ -x "$sender" ] || return 0
-  local verb="stopped"
-  case "$reason" in empty-next|depth) verb="complete" ;; esac
   {
     echo "chain ${verb}: ${reason}"
     echo "last job: ${job_id} (depth ${depth})"
@@ -1173,9 +1272,11 @@ _ccs_dispatch_chain_next() {
     --arg cli "$cli" \
     --argjson cd "$next_depth" \
     --argjson cm "$max_depth" \
+    --arg ws "$(_ccs_dispatch_jsonl_latest "$job_id" | jq -r '.wake_slot // empty')" \
     '{job_id:$jid, project:$proj, task:$t, backend:$be, cli:$cli, status:"running",
       created_at:$ca, chain:true, chain_parent:$cp, chain_depth:$cd,
-      chain_max:$cm}')"
+      chain_max:$cm}
+     + (if $ws == "" then {} else {wake_slot:$ws} end)')"
   printf '%s' "$next_task" > "$dispatch_dir/results/${next_job_id}.prompt"
 
   # Build the next worker prompt: parent context bridge + verification rule +
@@ -1851,8 +1952,10 @@ HELP
     --arg cli "$cli" \
     --argjson ce "$chain_enabled" \
     --argjson md "$max_depth" \
+    --arg ws "$(_ccs_dispatch_resolve_wake_slot)" \
     '{job_id:$jid, project:$proj, task:$t, context_injected:$ctx, mode:$m, backend:$be, cli:$cli, status:"running", created_at:$ca}
-     + (if $ce == 1 then {chain:true, chain_depth:0, chain_max:$md} else {} end)'
+     + (if $ce == 1 then {chain:true, chain_depth:0, chain_max:$md} else {} end)
+     + (if ($ws == "" or $be != "agentpager") then {} else {wake_slot:$ws} end)'
   )"
 
   local spawn_rc=0

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -496,6 +496,7 @@ CCS_DISPATCH_RESULT_TTL_DAYS=7    # 結果檔保留天數
 CCS_DISPATCH_MAX_CONCURRENT_WARN=3  # 並行 job 警告閾值
 CCS_DISPATCH_BACKEND=auto         # auto | agentpager | headless
 CCS_DISPATCH_CLI=claude           # agentpager worker CLI: claude | gemini
+CCS_DISPATCH_WAKE=1               # 派工主 session 為 pager-launched 時完成回灌一個 turn；0 關閉
 CCS_DISPATCH_PREVIEW_TIMEOUT=60   # --preview 確認等待秒數
 CCS_DISPATCH_PREVIEW_MAX_CHARS=1500  # preview prompt 折疊長度
 CCS_DISPATCH_CHAIN_MAX_DEPTH=5    # --chain 預設最大接力跳數
@@ -548,6 +549,17 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
   混進互動對話串（slot role 的原生支援由 agent-pager 端追蹤——internal GitLab
   issue #76，落地後此預設會改為查詢保留 slot）。注意：只有 monitor 的
   即時 finalize 會通知；`ccs-jobs` sync 的事後補帳（stale 對帳）不通知。
+- **orchestrator-wake（回灌派工 session）**：若派工的主 session 本身也是 pager-launched
+  的 tmux session（env 帶 `AGENT_PAGER_BOT_SLOT`，或 `AGENT_PAGER_CHANNEL=local` +
+  `AGENT_PAGER_LOCAL_USER`），job 進終態時除了上述 operator 通知外，另寫一個
+  `kind: input` inbound 把一則 thin-pointer turn（job id / 狀態 / summary /
+  `results/<id>.md`）回灌主 session 自己的 slot，喚醒其對話 loop。重用 agent-pager 既有
+  input relay（agent-pager 端零改動）。Best-effort / fire-and-forget（寫檔即返回，不依賴
+  送達 ack）。`CCS_DISPATCH_WAKE=0` 可關閉。非 chain job 於 finalize 時 wake；chain 只在
+  **終點** wake（中繼 hop 不 wake，遵守鏈鎖「中繼不進 lead context」原則）。主 session 若
+  非 pager-launched（本地 terminal / headless）則無此管道，改用 `ccs-jobs` pull 追蹤。
+  同 notify：只有 live finalize 會 wake；monitor 若在 finalize 前死掉，`ccs-jobs` sync
+  的事後補帳不 wake（回退 pull）。
 
 **鏈鎖模式（`--chain`）：**
 
@@ -558,7 +570,8 @@ ccs-dispatch 有兩個執行後端，由 `CCS_DISPATCH_BACKEND` 選擇（預設 
   未達 max-depth 時，monitor 讀 `next:` 自動組下一跳（含前一跳 handoff 的
   context 橋接 + HANDOFF RULE + 自主性指令），繼承同一專案 proj key。
 - 停鏈原因：`partial` / `blocked` / `failed` / `empty-next` / `depth`，記入
-  `chain_stopped`，並發一則鏈終止 pager 通知。
+  `chain_stopped`，並發一則鏈終止 pager 通知；派工主 session 為 pager-launched 時，
+  另回灌一則 chain-end wake turn（見上方 orchestrator-wake）。
 - `ccs-jobs <job-id>` 顯示 `Chain: depth N/max, parent=…, stopped: …` 血緣。
 - 自主性指令套用**所有** agentpager 派工（不限鏈鎖）：worker 不問澄清問題、
   卡住時設 `outcome: blocked`（→ 停鏈浮回指揮席），不等終端輸入。

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -155,18 +155,31 @@ handoff 全文）是隨工作量線性膨脹的大 payload，一旦灌進指揮�
 
 ## Worker 完成的喚醒（orchestrator-wake）
 
-dispatched worker 完成時如何回到指揮席，取決於指揮席自己的啟動方式：
+dispatched worker 完成時，指揮席會被**自動 wake**（回灌一則 thin-pointer turn）
+**當且僅當兩條件同時成立**（兩軸正交——backend 選擇看 agent-pager 可用性，wake 看
+指揮席身份 + backend）：
 
-- **指揮席為 pager-launched session**（env 帶 `AGENT_PAGER_BOT_SLOT`，或
-  `AGENT_PAGER_CHANNEL=local` + `AGENT_PAGER_LOCAL_USER`）：ccs-dispatch 在 job 進
-  終態時**自動回灌**一則 thin-pointer turn（job id / 狀態 / summary /
-  `results/<id>.md`）到指揮席自己的 slot，喚醒對話 loop（重用 agent-pager input
-  relay；`CCS_DISPATCH_WAKE=0` 可關）。非 chain job 於 finalize wake、chain 只在
-  終點 wake（中繼 hop 不 wake）。**收到 wake turn 後依上方 Context Discipline 按需
-  Read artifact，不整檔灌入。**
-- **指揮席為本地 terminal / headless（非 pager-launched）**：無回灌管道（case b）。
-  指揮席在等待 dispatched job 期間，用 `ccs-jobs` **pull** 週期性檢查終態（poll，
-  非 push）；這是紀律而非機件——此情境不會自動醒來，須主動查看板。
+1. **指揮席自己是 pager-launched session**（env 帶 `AGENT_PAGER_BOT_SLOT`，或
+   `AGENT_PAGER_CHANNEL=local` + `AGENT_PAGER_LOCAL_USER`）；**且**
+2. **worker 跑 agentpager backend**（headless 不 wake——其 job record 不帶
+   `wake_slot`、`_ccs_dispatch_finish` 也無 wake 接線）。
+
+兩者皆成立 → ccs-dispatch 在 job 進終態時重用 agent-pager input relay，把一則 turn
+（job id / 狀態 / summary / `results/<id>.md`）回灌指揮席自己的 slot（`CCS_DISPATCH_WAKE=0`
+可關）。非 chain job 於 finalize wake、chain 只在終點 wake（中繼 hop 不 wake）。
+**收到 wake turn 後依上方 Context Discipline 按需 Read artifact，不整檔灌入。**
+
+**否則一律回退到 `ccs-jobs` pull（poll，非 push）紀律**——涵蓋**所有**不 wake 的情境，
+不只「指揮席非 pager-launched」：
+
+- 指揮席為本地 terminal / headless（無 slot 可 target）
+- worker fell back to / 明確用 headless backend（agent-pager daemon 掛、single-seat
+  被佔、`--sync`、或 `CCS_DISPATCH_BACKEND=headless`）
+- monitor 在 finalize 前死掉（`ccs-jobs` sync 補帳不 wake）
+- `CCS_DISPATCH_WAKE=0`
+
+**判斷自己屬哪種**：看 job record 的 `backend` 欄位——`agentpager` + 指揮席是
+pager-launched → 等 wake；否則主動 poll `ccs-jobs`，不要空等一個不會來的 turn。
 
 ## Agent Behavior
 

--- a/skills/ccs-orchestrator/SKILL.md
+++ b/skills/ccs-orchestrator/SKILL.md
@@ -153,6 +153,21 @@ handoff 全文）是隨工作量線性膨脹的大 payload，一旦灌進指揮�
 此紀律依據內部 context-economy 設計理念文件（§4 可操作設計原則）；核心是
 「看板只裝指標，證據留磁碟，compact 是 fallback 不是主策略」。
 
+## Worker 完成的喚醒（orchestrator-wake）
+
+dispatched worker 完成時如何回到指揮席，取決於指揮席自己的啟動方式：
+
+- **指揮席為 pager-launched session**（env 帶 `AGENT_PAGER_BOT_SLOT`，或
+  `AGENT_PAGER_CHANNEL=local` + `AGENT_PAGER_LOCAL_USER`）：ccs-dispatch 在 job 進
+  終態時**自動回灌**一則 thin-pointer turn（job id / 狀態 / summary /
+  `results/<id>.md`）到指揮席自己的 slot，喚醒對話 loop（重用 agent-pager input
+  relay；`CCS_DISPATCH_WAKE=0` 可關）。非 chain job 於 finalize wake、chain 只在
+  終點 wake（中繼 hop 不 wake）。**收到 wake turn 後依上方 Context Discipline 按需
+  Read artifact，不整檔灌入。**
+- **指揮席為本地 terminal / headless（非 pager-launched）**：無回灌管道（case b）。
+  指揮席在等待 dispatched job 期間，用 `ccs-jobs` **pull** 週期性檢查終態（poll，
+  非 push）；這是紀律而非機件——此情境不會自動醒來，須主動查看板。
+
 ## Agent Behavior
 
 1. **先 JSON 後呈現：** 內部先跑 `--json` 做判斷（需要哪些 options、有無殭屍等），再跑 `--md` 取人讀格式呈現。如果 `--md` 已包含所需資訊，可省略 `--json` 步驟。

--- a/tests/test-dispatch-wake.sh
+++ b/tests/test-dispatch-wake.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-wake.sh — orchestrator-wake (#93)
+# Units: _ccs_dispatch_resolve_wake_slot (env -> slot, CCS_DISPATCH_WAKE opt-out),
+#   _ccs_dispatch_agentpager_wake_file (atomic kind:input inbound writer),
+#   finish-hook integration (non-chain wakes; chain hop does NOT),
+#   chain-notify integration (chain end wakes).
+# Isolation: XDG_DATA_HOME sandbox; AGENT_PAGER_DIR points at a sandbox inbound;
+#   the Telegram notify path is suppressed (CCS_DISPATCH_NOTIFY=0) to isolate wake.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-wake-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+DD="$(_ccs_dispatch_dir)"
+JOBS="$DD/jobs.jsonl"
+SANDBOX="$SCRIPT_DIR/tmp/test-dispatch-wake"
+rm -rf "$SANDBOX"; mkdir -p "$SANDBOX"
+PAGER_DIR="$SANDBOX/pager"
+
+reset_case() {
+  rm -f "$JOBS"; rm -rf "$DD/results" "$DD/pids" "$PAGER_DIR"
+  mkdir -p "$DD/results" "$DD/pids" "$PAGER_DIR/inbound"
+  unset AGENT_PAGER_SESSION_TREE AGENT_PAGER_BOT_SLOT AGENT_PAGER_CHANNEL \
+    AGENT_PAGER_LOCAL_USER CCS_DISPATCH_WAKE 2>/dev/null || true
+  export CCS_DISPATCH_NOTIFY=0        # isolate wake from the Telegram notify path
+  export AGENT_PAGER_DIR="$PAGER_DIR" # wake writer resolves inbound dir from here
+}
+
+# Seed one agentpager job record (+ optional handoff source file).
+seed_job_wake() { # $1=job_id $2=wake_slot(empty=none) $3=chain(empty|true) $4=with_handoff(0|1)
+  local jid="$1" ws="$2" ch="$3" wh="$4"
+  local rec="{\"job_id\":\"$jid\",\"project\":\"proj-x\",\"backend\":\"agentpager\",\"status\":\"running\",\"created_at\":\"2026-07-07T10:00:00+08:00\""
+  [ -n "$ws" ] && rec="$rec,\"wake_slot\":\"$ws\""
+  [ "$ch" = "true" ] && rec="$rec,\"chain\":true"
+  rec="$rec}"
+  printf '%s\n' "$rec" >> "$JOBS"
+  HANDOFF_SRC="$SANDBOX/handoff-$jid.md"; rm -f "$HANDOFF_SRC"
+  [ "$wh" = 1 ] && printf '# handoff\n' > "$HANDOFF_SRC"
+}
+
+wake_files() { ls "$PAGER_DIR/inbound"/*-wake.md 2>/dev/null; }
+wake_count() { wake_files | wc -l | tr -d ' '; }
+latest_wake() { ls -t "$PAGER_DIR/inbound"/*-wake.md 2>/dev/null | head -1; }
+wake_field() { sed -n "s/^$2: //p" "$1" | head -1; }          # $1=file $2=field
+wake_body()  { awk 'f>=2{print; next} /^---$/{f++}' "$1"; }   # $1=file
+
+# ── AC1/AC2/AC3: _ccs_dispatch_resolve_wake_slot ────────────────────────────
+echo "=== resolve: telegram numeric slot (AC1) ==="
+reset_case
+export AGENT_PAGER_SESSION_TREE="slot-3" AGENT_PAGER_BOT_SLOT="3"
+assert_eq "numeric slot resolves to N" "3" "$(_ccs_dispatch_resolve_wake_slot)"
+
+echo "=== resolve: local channel slot (AC1) ==="
+reset_case
+export AGENT_PAGER_SESSION_TREE="local-alice" AGENT_PAGER_CHANNEL="local" \
+  AGENT_PAGER_LOCAL_USER="alice"
+assert_eq "local channel resolves to local-<user>" "local-alice" \
+  "$(_ccs_dispatch_resolve_wake_slot)"
+
+echo "=== resolve: local precedence over a stray numeric slot (AC1) ==="
+reset_case
+export AGENT_PAGER_SESSION_TREE="local-bob" AGENT_PAGER_CHANNEL="local" \
+  AGENT_PAGER_LOCAL_USER="bob" AGENT_PAGER_BOT_SLOT="9"
+assert_eq "local channel wins over numeric" "local-bob" \
+  "$(_ccs_dispatch_resolve_wake_slot)"
+
+echo "=== resolve: no pager env -> empty (AC2, case b) ==="
+reset_case
+assert_eq "no env -> empty" "" "$(_ccs_dispatch_resolve_wake_slot)"
+
+echo "=== resolve: CCS_DISPATCH_WAKE=0 opts out (AC3) ==="
+reset_case
+export AGENT_PAGER_SESSION_TREE="slot-3" AGENT_PAGER_BOT_SLOT="3" CCS_DISPATCH_WAKE=0
+assert_eq "opt-out -> empty even with env" "" "$(_ccs_dispatch_resolve_wake_slot)"
+
+echo "=== resolve: local channel with empty user falls through to numeric (N3) ==="
+reset_case
+export AGENT_PAGER_SESSION_TREE="slot-7" AGENT_PAGER_CHANNEL="local" AGENT_PAGER_BOT_SLOT="7"
+# AGENT_PAGER_LOCAL_USER intentionally unset -> local branch must not fire
+assert_eq "empty local user -> fall through to numeric slot" "7" \
+  "$(_ccs_dispatch_resolve_wake_slot)"
+
+# ── AC4 writer unit: _ccs_dispatch_agentpager_wake_file ─────────────────────
+echo "=== wake writer: atomic kind:input inbound (AC4) ==="
+reset_case
+wf="$(_ccs_dispatch_agentpager_wake_file "3" "$PAGER_DIR" $'first line\nsecond line')"
+assert_eq "wake file created" "yes" "$([ -n "$wf" ] && [ -f "$wf" ] && echo yes)"
+assert_eq "kind is input" "input" "$(wake_field "$wf" kind)"
+assert_eq "slot is the target" "3" "$(wake_field "$wf" slot)"
+assert_contains "body carried" "$(wake_body "$wf")" "first line"
+assert_eq "filename matches the *.md glob" "yes" \
+  "$(case "$wf" in *.md) echo yes;; *) echo no;; esac)"
+assert_eq "no leftover .tmp dotfile" "0" \
+  "$(find "$PAGER_DIR/inbound" -name '.*.tmp' 2>/dev/null | wc -l | tr -d ' ')"
+
+# ── AC4 integration: finish (non-chain) fires wake ──────────────────────────
+echo "=== finish non-chain: wake inbound written, thin pointer (AC4) ==="
+reset_case
+seed_job_wake "w-nc" "3" "" 1
+_ccs_dispatch_finish_agentpager "w-nc" "$HANDOFF_SRC"
+wf="$(latest_wake)"
+assert_eq "non-chain finalize wrote one wake" "1" "$(wake_count)"
+assert_eq "wake kind input" "input" "$(wake_field "$wf" kind)"
+assert_eq "wake slot 3" "3" "$(wake_field "$wf" slot)"
+assert_contains "body names the job" "$(wake_body "$wf")" "w-nc"
+assert_contains "body carries status" "$(wake_body "$wf")" "handoff-ready"
+assert_contains "body points to the on-disk artifact" "$(wake_body "$wf")" "results/w-nc.md"
+
+# ── AC2 integration: no wake_slot -> no wake (case b path) ───────────────────
+echo "=== finish: no wake_slot -> no wake (AC2) ==="
+reset_case
+seed_job_wake "w-none" "" "" 1
+_ccs_dispatch_finish_agentpager "w-none" "$HANDOFF_SRC"
+assert_eq "no wake_slot -> zero wake inbounds" "0" "$(wake_count)"
+
+# ── AC3 integration: finalize honors opt-out even if a slot is present ───────
+echo "=== finish: CCS_DISPATCH_WAKE=0 suppresses wake (AC3) ==="
+reset_case
+export CCS_DISPATCH_WAKE=0
+seed_job_wake "w-off" "3" "" 1
+_ccs_dispatch_finish_agentpager "w-off" "$HANDOFF_SRC"
+assert_eq "opt-out at finalize -> zero wake inbounds" "0" "$(wake_count)"
+
+# ── AC5 status-agnostic: handoff-ready / completed / failed ──────────────────
+echo "=== finish status-agnostic: handoff-ready (AC5) ==="
+reset_case; seed_job_wake "w-hr" "3" "" 1
+_ccs_dispatch_finish_agentpager "w-hr" "$HANDOFF_SRC"
+assert_contains "payload carries handoff-ready" "$(wake_body "$(latest_wake)")" "handoff-ready"
+
+echo "=== finish status-agnostic: completed (AC5) ==="
+reset_case; seed_job_wake "w-cp" "3" "" 0
+_ccs_dispatch_finish_agentpager "w-cp" "$SANDBOX/nonexistent-handoff"
+assert_contains "payload carries completed" "$(wake_body "$(latest_wake)")" "completed"
+
+echo "=== finish status-agnostic: failed (AC5) ==="
+reset_case; seed_job_wake "w-fl" "3" "" 0
+_ccs_dispatch_finish_agentpager "w-fl" "$SANDBOX/nonexistent-handoff" "failed"
+assert_contains "payload carries failed" "$(wake_body "$(latest_wake)")" "failed"
+
+# ── AC5b chain semantics: intermediate hop silent, chain end wakes ──────────
+echo "=== chain hop finalize does NOT wake (AC5b, item 11) ==="
+reset_case
+seed_job_wake "w-chop" "3" "true" 1
+_ccs_dispatch_finish_agentpager "w-chop" "$HANDOFF_SRC"
+assert_eq "chain intermediate hop stays silent" "0" "$(wake_count)"
+
+echo "=== chain end wakes once, with artifact when it exists (AC5b) ==="
+reset_case
+seed_job_wake "w-cend" "3" "true" 1
+printf '# result\n' > "$DD/results/w-cend.md"   # terminal hop produced an artifact
+_ccs_dispatch_chain_notify "w-cend" "empty-next" "proj-x" 2
+wf="$(latest_wake)"
+assert_eq "chain end wrote one wake" "1" "$(wake_count)"
+assert_eq "chain-end wake slot 3" "3" "$(wake_field "$wf" slot)"
+assert_contains "chain-end body mentions chain" "$(wake_body "$wf")" "chain"
+assert_contains "chain-end body names the last job" "$(wake_body "$wf")" "w-cend"
+assert_contains "chain-end body points to the existing artifact" \
+  "$(wake_body "$wf")" "results/w-cend.md"
+
+echo "=== chain end omits a dangling artifact when the md is absent (M1) ==="
+reset_case
+seed_job_wake "w-cfail" "3" "true" 0        # launch-failed terminal hop: no results md
+_ccs_dispatch_chain_notify "w-cfail" "failed" "proj-x" 3
+wf="$(latest_wake)"
+assert_eq "chain end still wakes on a launch-failed hop" "1" "$(wake_count)"
+assert_not_contains "no dangling artifact pointer" "$(wake_body "$wf")" "results/w-cfail.md"
+assert_contains "failure signal still names the last job" "$(wake_body "$wf")" "w-cfail"
+
+echo "=== chain-end wake_slot survives jsonl reduce-merge (M2) ==="
+reset_case
+seed_job_wake "w-cmerge" "3" "true" 1
+printf '# result\n' > "$DD/results/w-cmerge.md"
+# a later chain_stopped record carries no wake_slot; reduce-merge keeps absent
+# keys, so the creation record's wake_slot must still drive the wake.
+printf '%s\n' '{"job_id":"w-cmerge","chain_stopped":"empty-next"}' >> "$JOBS"
+_ccs_dispatch_chain_notify "w-cmerge" "empty-next" "proj-x" 2
+assert_eq "wake_slot survives merge with a later chain_stopped record" "1" "$(wake_count)"
+assert_eq "merged wake targets the captured slot" "3" "$(wake_field "$(latest_wake)" slot)"
+
+echo "=== chain end without wake_slot stays silent (AC2/AC5b) ==="
+reset_case
+seed_job_wake "w-cend2" "" "true" 1
+_ccs_dispatch_chain_notify "w-cend2" "depth" "proj-x" 5
+assert_eq "chain end without wake_slot -> no wake" "0" "$(wake_count)"
+
+test_summary


### PR DESCRIPTION
## Summary

orchestrator-wake（#93）：async agentpager worker 完成時，重用 agent-pager 既有的
input relay（`kind: input` inbound → `do_input`）把一則 thin-pointer turn 回灌派工的
orchestrator session，閉合「worker 完成 → orchestrator 醒來」的縫。此前 finalize 只更新
`jobs.jsonl` + 推 Telegram 給 operator，派工主 session 無從得知，須手動 poll `ccs-jobs`。
依主 session 啟動方式分流：pager-launched（case a）走 push-wake（本 slice），本地
terminal / headless（case b）無 push 管道、記為 `ccs-jobs` pull 紀律。agent-pager 端零改動。

## Changes

- **feat(dispatch) 8ccca2a**：`_ccs_dispatch_resolve_wake_slot`（env → wake target，
  `CCS_DISPATCH_WAKE=0` opt-out）、atomic（dotfile+mv）`kind: input` inbound writer、
  非 chain finalize 於 `_ccs_dispatch_finish_agentpager` wake / chain 終點於
  `_ccs_dispatch_chain_notify` wake（中繼 hop 不 wake）、兩個 creation site 擷取
  `wake_slot`（初始 resolve、chain-next 繼承 parent）。
- **docs(dispatch) d93714b**：commands.md 加 `CCS_DISPATCH_WAKE` env、wake / chain-end
  語意、degraded sync caveat；ccs-orchestrator skill 加 case-a（push）/ case-b（pull）分流。

## Test plan (reviewer checklist)

- [x] AC1-AC3 resolve：env → slot（numeric / local）、local precedence、opt-out（unit）
- [x] AC4 wake writer（atomic、格式）+ 非 chain finalize 整合（呼叫鏈可達、產出檔正確）
- [x] AC5 status-agnostic（handoff-ready / completed / failed）
- [x] AC5b chain 語意（中繼 hop 靜默、終點 wake、launch-failed 不帶懸空 artifact、merge-survival）
- [x] AC6 live smoke（真實 ccs code 經真實 relay 喚醒 slot-1）
- [x] AC7 security（新增行無 hardcoded cred / 個人 path / IP）
- [x] AC8 既有全套測試綠

## Test results (author 已驗)

**Unit tests：** `bash tests/test-dispatch-wake.sh` — 35 passed, 0 failed。

**E2E tests：** `bash tests/run-all.sh` — 48 passed, 0 failed, 1 skipped（live-only
`test-crash-detect.sh`）。

**Smoke tests：** AC6 live — 真實 `_ccs_dispatch_finish_agentpager`（worktree code）寫出
真實 wake inbound 到 `~/.agent-pager/inbound`（slot-1）→ inbound-handler 送達成派工
session 的一個 turn → drain + archive。走 §6 busy-race 路徑（mid-turn 注入、送達但
agent-pager 誤報「可能未送達」——已記 agent-pager GitLab #109）。

## Reviewer summary

獨立 fresh-context reviewer（非作者 context）：**APPROVE-WITH-FIXES**。correctness /
reachability / regression / security 全 CLEAN，無 blocker / major。pre-merge findings
全修 + 補測：M1（launch-failed chain hop 的懸空 artifact 指標 → artifact 行條件化）、
M2（merge-survival 未觸發 → 補 chain_stopped record）、N1（headless record 惰性
wake_slot → gate on agentpager）、N3（resolve precedence edge → 補測）、N4（degraded
sync 不 wake → doc 記已知限制）。完整 report 與 CIA 見本 PR comment。

## Carry-forward Minor items

- N2：chain-next 繼承 jq 無直接單測（需 `_ccs_dispatch_chain_next` fixture）；由
  merge-survival 測試 + live smoke 間接覆蓋。→ ccs backlog。
- agent-pager GitLab #109：`do_input` verify 對「wake 落在 orchestrator 忙碌 turn」
  誤報「可能未送達」（busy-race）；純噪音、非遺失，upstream 追蹤。

## Related

- Design: `internal/2026-07-22-ccs-orchestrator-wake-design.md`
- Issue: #93（parent #91）
