### PR TITLE
docs(internal): seed committed architecture docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ tmp/
 *~
 .worktrees/
 
-# Agent internal documents (AGENTS.md rules)
-internal/
+# Ephemeral agent scratch: handoffs, per-sprint design/plan drafts (AGENTS.md
+# rules). Leading slash anchors to repo root so it does NOT match the committed
+# docs/internal/ dev-facing architecture docs.
+/internal/
 
 # Debug artifacts
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,13 +62,27 @@ Phase 3 收尾: （worktree）→ 整理 → review → merge → 清理
 
 ## 內部文件規則
 
-以下文件放 `internal/`（已 gitignore），**禁止 commit 進 repo**：
-- 交接文件（handoff）
-- 設計 spec（`*-design.md`）
-- 實作計畫（`*-plan.md`）
-- brainstorming / superpowers 產出
+專案文件依「durable 與否」分兩落點：
 
-Phase 1 規劃時，spec/plan 寫在 `internal/` 或 worktree 的 `internal/`，不加入 git。
+**Durable dev-facing 架構文件 → committed `docs/internal/`（進版控）：**
+- 跨函式才看得出的架構不變量、狀態檔生命週期、orchestration 設計等，對後續
+  developer / agent 有長期參考價值者。
+- 例：`docs/internal/architecture-invariants.md`、`docs/internal/state-file-lifecycle.md`。
+- 這類文件是**蒸餾**產物（synthesized、對 code 逐條驗證後才寫），不是把 per-sprint
+  草稿直接搬進版控。
+- ⚠ 本 repo 為 **public**：commit 前必須脫敏——無個人 path、內網 hostname / IP、
+  credential（per cross-repo-docs 紀律）。
+
+**Ephemeral 開發產出 → `internal/`（已 gitignore），禁止 commit：**
+- 交接文件（handoff）
+- per-sprint 設計 spec（`*-design.md`）、實作計畫（`*-plan.md`）
+- brainstorming / superpowers 產出
+- per-sprint worklog 放 worktree `tmp/sprint/worklog.md`（隨 worktree 刪除閉合）
+
+Phase 1 規劃時，per-sprint spec/plan 寫在 `internal/`（gitignore，不進 git）。某設計
+成熟、對後續有 durable 價值時，再蒸餾成 committed `docs/internal/` 架構文件。
+（`.gitignore` 用 `/internal/` anchor repo root，只 ignore 頂層 `internal/`，不影響
+committed `docs/internal/`。）
 
 ## Worktree 與 Branch
 

--- a/docs/internal/architecture-invariants.md
+++ b/docs/internal/architecture-invariants.md
@@ -1,0 +1,293 @@
+# Dispatch orchestration — architecture invariants
+
+> **Why this exists:** the dispatch subsystem (`ccs-dispatch.sh`) has
+> load-bearing rules that only emerge from tracing across functions — how
+> `auto` picks a backend, why "resolve chose agent-pager" does not mean
+> "the worker ran on agent-pager", when the orchestrator gets woken. These
+> live in code + gitignored handoffs, so a reader (or agent) asking "how
+> does dispatch decide X?" had nowhere to look. This doc is the committed,
+> dev-facing answer.
+>
+> **When to read:** before changing backend selection
+> (`_ccs_dispatch_resolve_backend` / `_ccs_dispatch_agentpager_available` /
+> `_ccs_dispatch_spawn*`), the gate loop, the chain driver, the async
+> monitor / finalize, or the orchestrator-wake path. Behaviour of flags and
+> file interfaces is defined by the code; this doc records the invariants
+> and cites the functions. Line numbers drift — anchors are **function
+> names**, not lines.
+>
+> **Scope:** the `ccs-dispatch` / `ccs-dispatch-run` orchestration only.
+> Module layout (which `ccs-*.sh` owns which command) is in the
+> user-facing [`docs/architecture.md`](../architecture.md); per-command
+> reference is in [`docs/commands.md`](../commands.md).
+
+## 1. Two dispatch entry points
+
+There are two distinct dispatch paths, and their backend behaviour differs.
+Confusing them is the most common source of misjudgement.
+
+| Entry | Function | Nature | Backend source | Falls back to headless? |
+|---|---|---|---|---|
+| `ccs-dispatch` | `_ccs_dispatch_spawn` | fire-and-forget job (job board) | `CCS_DISPATCH_BACKEND` (auto default) | **Yes** — spawn-layer, 4 triggers (I3) |
+| `ccs-dispatch-run` | `_ccs_dispatch_run` → `_ccs_dispatch_run_one` | synchronous gate loop (+ chain) | `backend:` field in `task.yaml` (default `headless`) | **No** — explicit request honoured (I5) |
+
+The **async job path** auto-resolves a backend and may silently fall back.
+The **gate path** takes an explicit per-task backend and never falls back —
+the gate is autonomous, so an explicit request is honoured or the run fails.
+
+```mermaid
+flowchart TD
+    A["ccs-dispatch (async)"] --> B["_ccs_dispatch_spawn<br/>backend = _ccs_dispatch_resolve_backend"]
+    B -->|"backend = agentpager"| C["_ccs_dispatch_spawn_agentpager"]
+    C -->|"return 2<br/>(--sync / no proj-map /<br/>seat busy / write fail)"| D["_ccs_dispatch_spawn_headless<br/>_CCS_DISPATCH_LAST_BACKEND = headless"]
+    C -->|"ok"| E["nohup monitor<br/>(_ccs_dispatch_agentpager_monitor)"]
+    B -->|"backend = headless"| D
+    E --> F["handoff file appears<br/>→ stop seat → _ccs_dispatch_finish*"]
+    D --> F
+    F --> G["jobs.jsonl finalize<br/>+ optional orchestrator-wake"]
+```
+
+## 2. Backend selection — the two-layer model
+
+`auto` is resolved in one function and can be **overridden by reality** in
+another. Both layers matter.
+
+### Layer 1 — resolve (`_ccs_dispatch_resolve_backend`)
+
+`CCS_DISPATCH_BACKEND` is `auto` (default) | `agentpager` | `headless`.
+Under `auto`, the backend is `agentpager` iff
+`_ccs_dispatch_agentpager_available` returns 0, else `headless`. Any
+unrecognised value resolves to `headless`.
+
+`_ccs_dispatch_agentpager_available` is a strict AND-chain (any failure →
+`headless`), in order:
+
+1. `systemctl` exists on `PATH`.
+2. `agent-pager.service` (user unit) is active (`systemctl --user is-active`).
+3. `${AGENT_PAGER_DIR:-$HOME/.agent-pager}` exists.
+4. `${AGENT_PAGER_DIR}/inbound/` exists.
+5. **Hybrid Detection (design Decision A)** on spool ownership:
+   - **same-uid** — the spool dir is owned by the caller (personal
+     workflow, the common case): trust it, **skip** the group / setgid
+     checks. Passes here.
+   - **cross-uid** — the spool is owned by another user (shared seat):
+     enforce the strict checks — the caller must be in the `claude-broker`
+     group **and** the `inbound/` dir must carry that group (setgid
+     evidence). Both required, else `headless`.
+
+So on your own machine (same-uid), `auto` selects `agentpager` from just
+three facts: daemon active + `~/.agent-pager/inbound/` present + spool is
+yours. The group/setgid gate is a shared-seat-only concern.
+
+### Layer 2 — spawn (`_ccs_dispatch_spawn_agentpager`)
+
+Resolving to `agentpager` does **not** guarantee the worker runs on
+agent-pager. `_ccs_dispatch_spawn` tries `_ccs_dispatch_spawn_agentpager`
+first and, on `return 2`, falls through to `_ccs_dispatch_spawn_headless`,
+recording the **actual** backend in `_CCS_DISPATCH_LAST_BACKEND`. The
+finalize/preview surfaces read that variable, not the resolved intent.
+
+This is why the operator preview prints "(falls back to headless if the
+seat is unavailable)" and why the orchestrator-wake case-b handling must
+cover "resolved agentpager but fell back" — see I2 / I3.
+
+## 3. Critical invariants
+
+Each: **Rule / Why / Test backstop / Cite**.
+
+### I1. Backend Hybrid Detection is ownership-branched (Decision A)
+
+**Rule:** `_ccs_dispatch_agentpager_available` must keep the same-uid short
+circuit (`stat -c %u "$pager_dir" == id -u` → pass) ahead of the cross-uid
+`claude-broker` group + `inbound/` setgid checks. Do not collapse to a
+single always-strict path, and do not drop the group/setgid path.
+
+**Why:** the personal workflow owns its own spool and has full access, so
+demanding a `claude-broker` group there would break the common case for no
+security gain. The strict checks exist only to make a *shared* seat safe
+(a caller must prove group membership + setgid provenance). Both halves are
+load-bearing for their respective deployment.
+
+**Test backstop:** `tests/test-dispatch-backend.sh` (resolve + availability
+branches).
+
+**Cite:** `_ccs_dispatch_agentpager_available`, `_ccs_dispatch_resolve_backend`
+in `ccs-dispatch.sh`; multi-provider backend rationale in
+[`docs/adr/002-unified-multi-provider-architecture.md`](../adr/002-unified-multi-provider-architecture.md).
+
+### I2. Resolved backend ≠ effective backend
+
+**Rule:** the resolved backend (`_ccs_dispatch_resolve_backend`) is an
+*intent*. The effective backend is whatever `_ccs_dispatch_spawn` actually
+spawned, tracked in `_CCS_DISPATCH_LAST_BACKEND`. Any code that needs to
+know how the worker actually ran (finalize records, preview, wake routing)
+must read `_CCS_DISPATCH_LAST_BACKEND`, never re-derive from
+`CCS_DISPATCH_BACKEND` / resolve.
+
+**Why:** `_ccs_dispatch_spawn_agentpager` can `return 2` after resolve
+already chose `agentpager`; the dispatcher then falls back to headless. A
+consumer that trusts the resolved intent will mislabel the job's backend
+and, for wake, mis-route (an agent-pager wake to a session that actually
+ran headless, or vice-versa).
+
+**Test backstop:** `tests/test-dispatch-spawn-agentpager.sh` (fallback sets
+last-backend), `tests/test-dispatch-backend.sh`.
+
+**Cite:** `_ccs_dispatch_spawn`, `_CCS_DISPATCH_LAST_BACKEND` in
+`ccs-dispatch.sh`.
+
+### I3. agent-pager spawn falls back to headless on exactly four triggers
+
+**Rule:** `_ccs_dispatch_spawn_agentpager` returns 2 (→ headless) on, and
+only on:
+
+1. `--sync` mode — the agent-pager backend is async-only.
+2. No `proj-map` entry for the project dir
+   (`CCS_DISPATCH_PROJ_MAP` / `~/.config/ccs-dashboard/proj-map`).
+3. The single per-user seat (`agent-pager-local-<user>` tmux session) is
+   already alive — one interactive worker per user; a second would share
+   the same session + `out.stream` and corrupt both. Multi-worker is v2.
+4. Writing the agent-pager inbound launch file failed.
+
+Adding a new hard-failure path here must return 2 (fall back), not abort
+the dispatch.
+
+**Why:** the async agent-pager worker is a scarce, stateful resource (one
+tmux seat, one stream). When it is unavailable or inapplicable, headless is
+the always-available path that still completes the job. Aborting instead of
+falling back would make `auto` less reliable than plain headless.
+
+**Test backstop:** `tests/test-dispatch-spawn-agentpager.sh`,
+`tests/test-dispatch-proj.sh` (proj-map resolution).
+
+**Cite:** `_ccs_dispatch_spawn_agentpager`,
+`_ccs_dispatch_resolve_proj_from_dir`,
+`_ccs_dispatch_agentpager_session_alive` in `ccs-dispatch.sh`.
+
+### I4. The gate is the sole verdict source; backend changes only HOW the worker spawns
+
+**Rule:** the deterministic Stage-1 gate (`_ccs_dispatch_gate_run`) is the
+only thing that decides PASS / RETRY / ESCALATE / HARD_STOP. The `backend:`
+choice (headless vs agentpager) changes only how the worker process is
+launched, never the verdict, evidence layout, or retry logic.
+
+**Why:** the gate re-runs every `verify.cmd` against ground truth, which is
+what catches an auto-approved false success (a headless `claude -p
+--permission-mode bypassPermissions` or `gemini --approval-mode yolo`
+worker that confabulates completion). If the backend could influence the
+verdict, that guarantee would leak. For the same reason every task must
+carry at least one `cmd`-track AC — each AC declares exactly one of
+`verify.cmd` / `verify.guidance`, and an all-`guidance` task is rejected
+at load (`_ccs_dispatch_gate_load_task`).
+
+**Test backstop:** `tests/test-gate-verdict.sh`, `tests/test-gate-run.sh`,
+`tests/test-gate-loop.sh`, `tests/test-gate-ac.sh`.
+
+**Cite:** `_ccs_dispatch_gate_run`, `_ccs_dispatch_gate_verdict`,
+`_ccs_dispatch_gate_load_task` (AC validation) in `ccs-dispatch.sh`;
+confabulation root-cause in
+[`docs/case-studies/2026-06-23-opus-fabricated-output.md`](../case-studies/2026-06-23-opus-fabricated-output.md).
+
+### I5. The gate path takes an explicit backend and never falls back
+
+**Rule:** the gate-loop worker (`_ccs_dispatch_run_worker`, agentpager
+branch) uses the task's explicit `backend:` and must NOT fall back to
+headless. Contrast I3 (the async path falls back). An explicit
+`backend: agentpager` in a task is honoured or the run fails.
+
+**Why:** the gate path is autonomous (no operator watching to notice a
+silent downgrade). A task that declared `agentpager` did so to get a
+monitorable/interruptible tmux worker; silently running it headless would
+defeat that intent without anyone noticing. The async job path is different
+— an operator signs off the dispatch and sees the "fell back" note.
+
+**Test backstop:** `tests/test-gate-agentpager.sh`,
+`tests/test-dispatch-agentpager-cli.sh`.
+
+**Cite:** `_ccs_dispatch_run_worker` (agentpager branch),
+`_ccs_dispatch_run_worker_agentpager` in `ccs-dispatch.sh`.
+
+### I6. Chains advance only on PASS, and only the terminal hop wakes
+
+**Rule:** `_ccs_dispatch_run` follows a task's `next:` only after a PASS
+verdict. The chain stops on non-PASS, empty-`next` (complete), max depth
+(`CCS_DISPATCH_CHAIN_MAX_DEPTH`, default 5), a cycle, or a next-load
+failure (`_ccs_dispatch_chain_stop_reason`). A mid-chain hop must not fire
+an orchestrator-wake; only the terminal hop does.
+
+**Why:** intermediate hops are machine-to-machine handoffs the orchestrator
+should not surface as turns (context economy — the board carries the
+pointer, evidence stays on disk). Waking on every hop would flood the
+orchestrator with intermediate state.
+
+**Test backstop:** `tests/test-dispatch-chain.sh`,
+`tests/test-gate-chain-loop.sh`, `tests/test-gate-chain-guards.sh`.
+
+**Cite:** `_ccs_dispatch_run`, `_ccs_dispatch_chain_stop_reason`,
+`_ccs_dispatch_resolve_next` in `ccs-dispatch.sh`.
+
+### I7. Orchestrator-wake = pager-orchestrator AND agentpager-backend (else pull)
+
+**Rule:** a completed async job wakes the dispatching orchestrator only
+when **both**: (a) the dispatching session was itself pager-launched (a
+resolvable wake slot exists) **and** (b) the worker ran on the agentpager
+backend. Otherwise there is no push channel and the orchestrator relies on
+`ccs-jobs` pull. Wake is fire-and-forget (never fails the caller, does not
+depend on delivery ack) and opts out with `CCS_DISPATCH_WAKE=0`. A
+non-chain job wakes on finalize regardless of terminal status; a chain
+wakes only at the terminal hop (I6).
+
+**Why:** the wake mechanism reuses agent-pager's `do_input` relay, which
+needs a target slot; a local-terminal/headless dispatcher has no slot to
+target. Coupling wake to the agentpager backend keeps the AND explicit
+rather than firing blind writes.
+
+**Test backstop:** `tests/test-dispatch-wake.sh`.
+
+**Cite:** `_ccs_dispatch_resolve_wake_slot`, `_ccs_dispatch_wake_fire`,
+`_ccs_dispatch_agentpager_wake_file` in `ccs-dispatch.sh`; GitHub issues
+#91 / #93.
+
+### I8. Worker completion is a handoff file; the attended backend has no wall-clock kill
+
+**Rule:** the async agent-pager worker signals completion by writing
+`tmp/handoff-<job_id>.md` (design Decision B); the monitor
+(`_ccs_dispatch_agentpager_monitor`) polls for that file, then stops the
+seat and finalizes. There is deliberately **no** wall-clock kill on the
+attended job path (design D2) — a stuck worker stays up for the operator to
+`/stop`. (The autonomous gate path IS bounded by a timeout, a different
+entry point — see I5.)
+
+**Why:** the attended worker runs in a monitorable tmux seat; killing it on
+a timer would destroy operator-inspectable state mid-task. The job path
+trades automatic reaping for operator control; the gate path, being
+autonomous, takes the opposite trade.
+
+**Test backstop:** `tests/test-jobs-agentpager.sh`,
+`tests/test-handoff.sh`.
+
+**Cite:** `_ccs_dispatch_agentpager_monitor`, `_ccs_dispatch_agentpager_prompt`
+(handoff-gating rule), `_ccs_dispatch_finish` in `ccs-dispatch.sh`.
+
+## 4. Maintenance
+
+Adding an invariant:
+
+1. Add a § 3 entry: **Rule / Why / Test backstop / Cite** (cite function
+   names + `tests/test-*.sh`, not line numbers).
+2. Add / point to a test backstop where the rule is mechanically checkable.
+3. Keep cites pointing at **committed** artifacts (code, `docs/`, GitHub
+   issues). Do NOT cite `internal/` design docs — they are gitignored and
+   are dangling references for anyone reading this public repo.
+4. This repo is **public**: no personal paths, no internal hostnames/IPs,
+   no credentials in this file.
+
+### Ruled-out (do not re-propose)
+
+- **Wall-clock kill on the attended job path** — deliberately absent (D2);
+  operator `/stop` reclaims a stuck seat (I8).
+- **Multi-worker per user on the agent-pager seat** — the single seat is a
+  v1 constraint; a second concurrent worker would corrupt the shared
+  `out.stream` (I3 trigger 3). Multi-worker is a v2 design, not a bug.
+- **Backend influencing the gate verdict** — the gate must stay the sole,
+  backend-independent verdict source (I4).

--- a/docs/internal/state-file-lifecycle.md
+++ b/docs/internal/state-file-lifecycle.md
@@ -1,0 +1,152 @@
+# Dispatch state-file lifecycle
+
+> **Why this exists:** the dispatch subsystem coordinates across layers via
+> files on disk, not in-memory IPC. `jobs.jsonl` in particular is
+> **append-only with last-write-wins merge** — a job's "current" record is
+> reconstructed, not stored — which is non-obvious and easy to break. This
+> doc is the committed reference for what each dispatch file is, who writes
+> it, and how it transitions.
+>
+> **When to read:** before changing how a job record is written or read
+> (`_ccs_dispatch_jsonl_*`, `_ccs_dispatch_finish*`), the result/evidence
+> layout, the cleanup policy, or the worker completion signal. The code
+> owns the exact schema; this doc records the lifecycle and cites the
+> functions. Companion: [`architecture-invariants.md`](architecture-invariants.md).
+>
+> **This repo is public** — no personal paths / hostnames / credentials
+> here. Paths below are relative to the dispatch data dir
+> (`_ccs_dispatch_dir`, itself under `_ccs_data_dir`); the absolute location
+> is environment-derived, not hardcoded.
+
+## 1. File inventory
+
+| Path (under dispatch dir) | Writer | Reader | Persistence |
+|---|---|---|---|
+| `jobs.jsonl` | `_ccs_dispatch_jsonl_append` (dispatch + each finalize + fallback + chain hop) | `_ccs_dispatch_jsonl_latest`, `ccs-jobs` | permanent (append-only) |
+| `results/<job_id>.md` | `_ccs_dispatch_finish` / `_ccs_dispatch_finish_agentpager` | `ccs-jobs <id>`, operator | TTL (`CCS_DISPATCH_RESULT_TTL_DAYS`, default 7) |
+| `results/<job_id>.raw` | worker stdout capture | `_ccs_dispatch_finish` (folds into `.md`) | transient — removed once `.md` is built; else pruned after 60 min |
+| `results/<job_id>.err` | worker stderr capture | `_ccs_dispatch_finish` (folds into `.md`) | kept for debugging (TTL) |
+| `results/<job_id>.prompt` | dispatch (pre-spawn) | `_ccs_dispatch_finish` (Task field, first 200 chars) | transient — removed at finish; else pruned after 60 min |
+| `results/<job_id>.handoff` | `_ccs_dispatch_finish_agentpager` (captured worker handoff) | `ccs-jobs`, chain bridge | TTL |
+| `pids/<job_id>.pid` | async spawn (`nohup` monitor pid) | `_ccs_dispatch_running_count`, `_ccs_dispatch_lazy_cleanup` | removed at finish / when pid dead |
+| `runs/<id>-chain-NN/` | gate path (`_ccs_dispatch_run`) | operator, review | permanent (evidence tree) |
+| `<project>/tmp/handoff-<job_id>.md` | the **worker** (in its own repo) | monitor (completion signal) | worker-owned; not in dispatch dir |
+
+## 2. jobs.jsonl — append-only, last-write-wins merge
+
+The central invariant: **`jobs.jsonl` is never edited in place.** Every
+state change appends a new JSON line keyed by `job_id`.
+`_ccs_dispatch_jsonl_latest` reconstructs the current record with
+`reduce .[] as $r ({}; . + $r)` — all records for that `job_id` merged in
+file order, later fields overriding earlier ones.
+
+Consequence: a partial record is legal. A finalize line carrying only
+`{job_id, status, finished_at, summary}` merges onto the initial record's
+`{project, backend, created_at, ...}` to form the complete view. Any reader
+MUST go through `_ccs_dispatch_jsonl_latest`, never read a single line.
+
+### Record lifecycle for one job
+
+```
+1. dispatch (ccs-dispatch)          append: full initial record, status="running"
+   ├─ context_injected, mode, backend, cli, created_at
+   ├─ if --chain:  chain=true, chain_depth=0, chain_max
+   └─ if wake-eligible: wake_slot   (resolvable slot AND backend==agentpager)
+
+2. (optional) fallback correction   append: {backend:<actual>, cli:"claude", fallback:true}
+   └─ only when _CCS_DISPATCH_LAST_BACKEND != resolved backend (I2/I3)
+      — a later line overrides backend/cli via the reduce-merge
+
+3. finalize                         append: terminal status + finished_at + summary
+   ├─ headless (_ccs_dispatch_finish):        + exit_code
+   └─ agentpager (_ccs_dispatch_finish_agentpager): + handoff (bool)
+```
+
+### Status vocabulary
+
+| Status | Set by | Meaning |
+|---|---|---|
+| `running` | dispatch (initial) + chain-hop lineage | dispatched, not yet finalized |
+| `completed` | headless exit 0; agentpager no-handoff default | finished, success |
+| `timeout` | headless exit 124 | wall-clock timeout (headless only; see I8) |
+| `failed` | headless other exit; agentpager worker gone; chain next-hop launch failure | finished, failure |
+| `handoff-ready` | agentpager worker wrote + capture succeeded | worker signalled done via handoff file |
+
+`exit_code → status` mapping lives in `_ccs_dispatch_finish` (0→completed,
+124→timeout, *→failed). `handoff-ready` vs the no-handoff default is decided
+in `_ccs_dispatch_finish_agentpager` (see I8 — a captured handoff file is
+the completion signal).
+
+Note: a chain *stopping* (non-PASS / depth / cycle / next-load failure) does
+not overwrite a hop's `status`; it records a separate `chain_stopped` field
+on the record (`_ccs_dispatch_chain_next`). The gate-path chain driver
+(`_ccs_dispatch_run`) writes nothing to `jobs.jsonl` at all — its evidence
+lives only under `runs/` (§4).
+
+## 3. Per-job result files
+
+`_ccs_dispatch_finish` builds `results/<job_id>.md` — a structured summary
+(Project / Task / Status / Exit code / Backend / Created / Finished /
+Duration, then `## Output` from `.raw` and `## Errors` from `.err`). It then
+appends the finalize line, and cleans up: the `.raw` is removed once folded
+into `.md`, the `.prompt` is removed, the `.pid` is removed; `.err` is kept
+for debugging.
+
+`ccs-jobs <id>` reads the merged record for the board line; the full `.md`
+stays on disk and is read on demand (context economy — the board carries a
+thin pointer, not the transcript).
+
+## 4. runs/ — gate evidence tree (gate path only)
+
+`ccs-dispatch-run` writes a per-chain evidence tree under `runs/`
+(`_ccs_dispatch_chain_alloc_dir` allocates `<first_id>-chain-NN`):
+
+```
+runs/<first_id>-chain-NN/
+├── chain.json                     # chain-level summary (hops[], stop_reason, outcome, depth)
+└── hop-NN-<task_id>/
+    ├── task.yaml                  # frozen at dispatch (AC immutable — §1 of the gate)
+    ├── attempt-NN/
+    │   ├── prompt.md              # attempt 1 = goal; ≥2 = §6 feedback + goal
+    │   ├── executor-output.md     # worker stdout+stderr
+    │   ├── git-status.txt         # ground-truth porcelain
+    │   ├── diff.patch             # ground-truth diff
+    │   └── gate/<ac-id>.json      # per-AC verdict evidence
+    └── final.json                 # {outcome, attempts, escalation}
+```
+
+`task.yaml` is frozen on entry — acceptance criteria must not change
+mid-run. The gate re-derives ground truth (`git-status.txt` / `diff.patch`)
+independently of the worker's self-report (see I4).
+
+## 5. Cleanup
+
+`_ccs_dispatch_lazy_cleanup` (best-effort, on dispatch calls):
+
+- deletes `results/*` older than `CCS_DISPATCH_RESULT_TTL_DAYS` (default 7);
+- prunes `pids/*.pid` whose process is dead (`kill -0`);
+- deletes stray `results/*.raw` / `*.prompt` older than 60 min (transient
+  files a crashed run left behind before `_ccs_dispatch_finish` could).
+
+`_ccs_dispatch_running_count` counts live pidfiles and warns past
+`CCS_DISPATCH_MAX_CONCURRENT_WARN` (default 3).
+
+## 6. Worker completion signal
+
+The async agent-pager worker signals completion by writing
+`tmp/handoff-<job_id>.md` **in its own project repo** (not the dispatch
+dir). `_ccs_dispatch_agentpager_prompt` injects a non-negotiable handoff
+rule instructing the worker to write that exact path last, with a YAML
+frontmatter block (`summary` / `outcome` / `next`) the dispatcher parses
+for the board. The monitor (`_ccs_dispatch_agentpager_monitor`) polls for
+this file; on appearance it stops the seat and finalizes, capturing the
+file to `results/<job_id>.handoff`. There is no wall-clock kill on this
+path (design D2 — see I8).
+
+## How to update
+
+1. Change the code first; this doc follows the code, not the reverse.
+2. Update the § 1 inventory row and, if a status or record-shape changed,
+   § 2. Keep cites as **function names** + `tests/test-*.sh`.
+3. Test backstops: `tests/test-dispatch.sh`, `tests/test-jobs-agentpager.sh`,
+   `tests/test-dispatch-chain.sh`, `tests/test-handoff.sh`.


### PR DESCRIPTION
## Summary

把 dev-facing 的 dispatch orchestration 設計從「只存在 code + gitignored
handoff、隨 worktree 蒸發、後續 developer / agent 查不到」縫成 committed
`docs/internal/`。動機典型受害者：backend `auto` / Hybrid Detection 的判準
只在程式碼裡，上一個 session 才逐函式重建了一次。

採 agent-pager 的二分模型：**durable 架構設計 → committed `docs/internal/`**、
**ephemeral（handoff / per-sprint design·plan / worklog）→ gitignored**。附帶
效益：committed（非 gitignored）文件讓 gemini / 其他 agent worker 直接讀得到，
不需 `respectGitIgnore:false` workaround。

## Changes

- **`.gitignore`**：`internal/` → `/internal/`（leading slash anchor 到 repo
  root）。原本無 leading slash 依 gitignore 語意會同時 match `docs/internal/`，
  導致該目錄下的檔案其實從未進版控；anchor 後只 ignore 頂層 `internal/`
  scratch，解鎖 committed `docs/internal/`。
- **新增 `docs/internal/architecture-invariants.md`**：dispatch orchestration
  的 runtime 不變量——兩個 dispatch 入口（async job vs 同步 gate loop）、
  backend Hybrid Detection（Decision A：same-uid 直連 / cross-uid
  claude-broker + setgid）、resolve-layer vs spawn-layer 兩層（resolve 選
  agentpager ≠ 最終跑 agentpager）、spawn→headless fallback 的 4 個觸發、
  gate 為唯一 verdict 來源、chain 只 PASS 推進 + 只終點 wake、orchestrator-wake
  的 AND 條件、handoff 完成信號。八條 invariant 皆四段式
  Rule / Why / Test backstop / Cite。
- **新增 `docs/internal/state-file-lifecycle.md`**：`jobs.jsonl`
  append-only + reduce-merge（last-write-wins）記錄模型、5 個 status、
  單 job 記錄生命週期（initial → fallback correction → finalize）、
  `results/` 檔、`runs/` gate evidence 樹、`lazy_cleanup` TTL、worker
  completion signal。
- **`AGENTS.md`「內部文件規則」翻轉**：durable 蒸餾架構文件 → committed
  `docs/internal/`（附 PUBLIC repo 脫敏提醒）；per-sprint design / plan /
  handoff / worklog 維持 gitignored。

不 promote 既有 `internal/` 的 legacy design / plan 堆（依設計決策，日後可
逐批脫敏 promote）；不重寫 file-layout（模組地圖已在 user-facing
`docs/architecture.md`）。

## Test plan

- [x] `git check-ignore` 驗 `.gitignore` 行為：`docs/internal/*` 可 track、
      頂層 `internal/*` 仍 ignored。
- [x] architecture-invariants.md 每條主張對 `ccs-dispatch.sh` function 逐條
      驗證（fresh-context reviewer 獨立複驗）。
- [x] state-file-lifecycle.md 的記錄模型 / status / cleanup 對 code 驗證。
- [x] 兩份 committed 文件 + AGENTS.md 變更脫敏檢查（無個人 path / IP /
      內網 GitLab / credential）——PUBLIC repo。
- [x] `tests/run-all.sh` 全綠（純 doc + gitignore 變更，不應動 code 行為）。

## Test results

- `git check-ignore`：`docs/internal/architecture-invariants.md` /
  `state-file-lifecycle.md` 皆 NOT ignored；`internal/foo-design.md` /
  `internal/handoffs/x.md` 皆由 `.gitignore:/internal/` ignored。✓
- `tests/run-all.sh`：**48 test files PASS / 0 failed / 1 skipped**
  （skip = `test-crash-detect.sh`，需 live session data）。✓
- 脫敏 grep（個人 path / IPv4 / 內網 hostname / credential pattern）：
  兩份文件 + AGENTS.md diff 皆 **無 hit**。✓

## Reviewer summary

Fresh-context reviewer 對 `ccs-dashboard.sh` 逐條複驗：invariants I1-I8 與
state-file 記錄模型全部準確，dangling reference / 脫敏 / `.gitignore`↔AGENTS.md
consistency 全 clean。發現 2 個措辭精確度 nit，皆已修並 amend 進本 commit：
(1) I4「every AC 需 cmd check」→ 正確為「task 需 ≥1 cmd-track AC」；(2) state-file
`failed` 列「chain stopped」過廣 → async chain 停止寫獨立 `chain_stopped` 欄、
非 `status`。**No design drift**（本 sprint 無正式 design doc，scope 由 internal
backlog § 0 界定，實作與其一致）。

## Carry-forward

- 逐批脫敏 promote legacy `internal/` design docs（followup，非本 sprint）。
- 可選：`development.md`、doc-vs-code drift 紀律（specman doc-freshness）。
- 可選：user-facing `docs/architecture.md` 加一行 cross-link 指向
  `docs/internal/` 深掘 dispatch internals。
- Housekeeping（merge 後於主工作區執行）：把 `docs/internal/` 下 3 個
  gitignored draft 移回 `internal/`，讓 committed `docs/internal/` 乾淨只放
  架構文件。

## Related

- 本 repo internal backlog 的 dev-doc-discoverability 項；對齊 agent-pager
  已驗證的 committed `docs/internal/` 慣例（durable committed / ephemeral
  gitignored 二分）。
