### PR TITLE
docs(agents): declare this repo's mr-review-artifacts specifics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,91 @@ committed `docs/internal/`。）
 - **目錄位置：** repo 內 `.worktrees/<name>`（已 gitignore，不進版控）
 - **Branch prefix：** `feat/`（新功能）、`fix/`（修復）、`refactor/`（重構）、`docs/`（文件）
 
+## MR/PR 產出物 provenance（本 repo 作為 `mr-review-artifacts` 消費者）
+
+契約層（§0 欄位規則、§1 independent review report、§2 CIA、§3 description 與其他
+comment）由個人 `mr-review-artifacts` skill 定義。該契約要求**每個消費 repo 自持
+三件 repo-specific 事項**，本節即是——寫在這裡才對非-Claude executor（Gemini /
+wingman worker）可達，放個人全域層等於未送達。
+
+### CIA 觸發清單（§2）
+
+diff 命中以下任一面 → 必跑 Change Impact Analysis 並貼為 PR comment，**merge 前完成**：
+
+- **共用模組**：`ccs-core.sh`（所有指令共用的 session parse / 格式 helper）、
+  `ccs_collect.py`（統一收集層，session-list 類指令的上游——ADR-002；
+  `ccs-review` / `ccs-project` **不經過**它，兩者各自逐 JSONL 解析）、
+  `ccs-dashboard.sh` 的 source 順序（唯一入口；模組增減的同步義務見
+  `docs/sync-checklist.md`，本清單只管影響分析）。
+- **住在 feature 模組裡的 cross-module helper**（最易被誤判為 leaf）：
+  `ccs-review.sh` 的 `_ccs_session_stats` / `_ccs_tool_use_stats`（被 `ccs-project.sh`
+  消費）、`ccs-health.sh` 的 `_ccs_health_badge_md` / `_ccs_health_events` /
+  `_ccs_health_score`（被 `ccs-overview.sh` 消費）。
+- **後端 / executor 分流點**：`ccs-dispatch.sh` 的 backend 選擇
+  （`headless` ↔ `agentpager`）與 executor 分派（`claude` / `gemini` / `wingman`）。
+- **task.yaml schema**（對外契約）：`_ccs_dispatch_gate_load_task` 的 jq 驗證。
+  使用者的 task 檔與已分發的 `skills/ccs-dispatch-run` 共同依賴它，加一個必填欄位
+  會讓既有 task.yaml 全部 validation 失敗（對應文件
+  `skills/ccs-dispatch-run/references/task-yaml.md`）。
+- **outbound chain**：agent-pager 通知路徑（outbound sender 解析、job 完成通知）、
+  handoff 續鏈（`--chain`）。
+- **部署面**：`install.sh`（modules array、`~/.bashrc` source line、skill symlink）、
+  `skills/` 下已分發的 skill。
+- **上游 CLI 相容面**：`ccs-canary-versions.txt`（`ccs_collect.py` 讀取的 known-good
+  claude CLI 版本清單）。注意風險方向：沒有 parsing 邏輯讀這份清單，誤列一筆的後果
+  是**消音**「版本未驗證、偵測可能失準」那行警示，讓解析靜默失準。
+- 未命中但自判有跨模組影響 → 可自主加跑（advisory 加分，不算違規）。
+
+新增共用模組時同步維護本清單。
+
+### CIA 第 3 欄變體軸（§2）
+
+本 repo 有四條變體軸，填該欄時逐條比對，不適用者明寫「無」：
+
+- **Provider**：Claude `[C]` ↔ Gemini `[G]` 的 session 收集與解析（ADR-002 duck-typing）
+- **Executor**：`claude` / `gemini` / `wingman`（wingman 無 model 旗標、僅作
+  provenance，且 FAIL 直接 escalate 不 retry；`backend=agentpager` 與
+  `executor=wingman` 互斥，schema 層直接擋）
+- **Backend**：`headless` ↔ `agentpager`。**兩個分流點行為不同，須分開比對**——
+  別套用單一的「同步 / 非同步」標籤，那在兩邊都不成立：
+  - **gate-run**（task.yaml 的 `.backend`）：兩者皆同步，agentpager 走前景阻塞
+    spawn+wait（非 async monitor），且**不 fallback**——daemon 不在就記錯誤讓 gate
+    對 ground truth FAIL，不降級。
+  - **job spawn**（`CCS_DISPATCH_BACKEND`）：headless 預設 `nohup` 非同步
+    （`--sync` 才同步）；agentpager async-only，且會在三種條件下 fallback 回 headless。
+  - 共同點：agentpager 單 seat（key `local-<user>`，multi-worker 為 v2）。
+- **語言層**：bash ↔ python 的邊界。主軸是 collector 的 11 欄 pipe 協定
+  （ADR-002 格式定義）；另有三個 JSON-over-stdin 邊界（`ccs_resume.py`、
+  `ccs-project-render.py`、`ccs-review-render.py`），動到時一併比對。
+
+### §0 Channel 的啟動路徑
+
+Channel 欄寫「工具 + 啟動路徑」粒度——只寫工具名分不出「遠端無人值守」與「桌前有人
+盯著」，而那正是 audit 要的區分。
+
+**precedence：prompt 給的值優先於下表。** launched session 的 system prompt 已由
+agent-pager 的 `provenance_footer()` 注入**解好的 Channel 字串**（handler 在啟動時
+權威知道 channel 與 slot）——收到就照抄，不要再自行 env 判定。下表是桌前直跑與注入
+缺席時的 fallback。
+
+**判定順序（先判 channel，再判 launched）**——web launch 會同時注入
+`AGENT_PAGER_SESSION_TREE` 與 `AGENT_PAGER_CHANNEL=web`，反序會把 web 誤標成 Path B：
+
+1. `AGENT_PAGER_CHANNEL=web` → `agent-pager Path C (web slot <N>)`
+   （slot 取 `AGENT_PAGER_BOT_SLOT` 並剝掉 `web-` 前綴）
+2. `AGENT_PAGER_CHANNEL=local` → `agent-pager local channel`
+   （此路徑**不注入** `AGENT_PAGER_BOT_SLOT`，別去取）
+3. 否則 `AGENT_PAGER_SESSION_TREE` 有值 → `agent-pager Path B (telegram slot <N>)`
+   （slot 取 `AGENT_PAGER_BOT_SLOT`，此路徑下為數字）
+4. 皆不成立（桌前直跑）→ `inline (desktop Path A)`
+
+字樣與判定順序對齊 agent-pager repo 的同名 section（該 repo 是 Path A/B/C 分類法的
+SoT）。另有一條本 repo 專屬：由 `ccs-dispatch` 派出的 worker 所產出的內容，stamp
+**worker 自身**的 model，Channel 寫該 worker 的 backend（`headless` / `agentpager`）。
+
+判定信號 best-effort：env 會被繼承（背景 monitor fork、dispatched worker 繼承
+parent 的 session 標記），讀不到或失真時以實際執行者為準，或省略路徑後綴不猜。
+
 ## GitHub Issue 語言規則
 
 - **標題：** 英文


### PR DESCRIPTION
## Summary

`mr-review-artifacts` 契約要求每個消費 repo 在自己的 `AGENTS.md` 自持三件 repo-specific
事項（CIA 觸發清單、CIA 第 3 欄的變體軸、§0 Channel 的啟動路徑字樣與偵測方式），本 repo
一直沒寫，agent 只能借用別的 repo 字樣——而那份字樣對本 repo 是錯的。本 PR 補齊三節。
寫在 `AGENTS.md` 才對非-Claude executor（Gemini / wingman worker）可達，放個人全域層
等於未送達。

## Changes

- `docs(agents): declare provenance artifact specifics` — `AGENTS.md` 新增
  「MR/PR 產出物 provenance」section（+85 行），含三個 subsection。

## Test plan (reviewer checklist)

- [x] 三個 subsection 對應 skill「與消費 repo 的關係」要求的三件事，無半答
- [x] 所有對 code 的事實斷言查證到 file:line（backend 行為、executor 特性、部署面、
      env 判定信號）
- [x] Channel 判定順序與字樣對齊 agent-pager repo 的同名 section（Path A/B/C SoT）
- [x] `docs/sync-checklist.md` 三節逐項對照，判定不觸發
- [x] public repo 脫敏：無個人 path、無內網 hostname / IP、無 credential
- [ ] 協作者確認 CIA 觸發清單沒漏掉自己會動到的高影響面

## Test results (author 已驗)

**Unit tests：** N/A — 純文件變更，不含可執行碼（`git diff --stat` = `AGENTS.md`
1 file changed, 85 insertions）。

**E2E tests：** N/A — 同上。

**Smoke tests：** 對 diff 跑脫敏 grep（個人 path / IPv4 / credential 三組 pattern），
無 hit。

## Reviewer summary

獨立 fresh-context reviewer verdict：**fix-then-ship**，4 個 blocking 全部查證成立、
全部已在本 PR 修正（完整報告見 PR comment）。

兩個是實質錯誤而非風格問題：

1. **Channel 判定順序反了。** 原稿先判 `AGENT_PAGER_SESSION_TREE`，但 web launch 會
   同時注入 `SESSION_TREE` 與 `AGENT_PAGER_CHANNEL=web`（sentinel 注入每一種 channel），
   反序會把 web session 誤標成 Path B，且 slot 會寫成 `telegram slot web-1`。已改為
   有序四步（先 channel 後 launched）並保留理由。
2. **Backend 的「同步 / 非同步」標籤兩邊都反。** gate-run 路徑的 agentpager 是前景阻塞
   spawn+wait（async monitor 版本明寫 deferred）；job spawn 路徑的 headless 預設
   `nohup` 非同步（`--sync` 才同步）。已改為分兩個分流點各自描述，並明寫「別套用單一
   標籤」——CIA 第 2 欄（部署影響／生效時機）會直接吃這個標籤。

另兩個 blocking：漏了「prompt 注入的 Channel 字串優先於 env 判定」這條 precedence；
local / web 只寫「寫對應通道」等於沒定名，已補 canonical 字面值。

同時採納 4 個 non-blocking（皆為原稿的過度概括或因果寫反）：`ccs_collect.py` 的射程
（`ccs-review` / `ccs-project` 不經過它）、canary 的風險方向（誤列一筆是**消音**警示
而非影響解析）、兩組住在 feature 模組裡的 cross-module helper、task.yaml schema 這個
對外契約面。

**本 PR 不需 CIA**：diff 只動 `AGENTS.md`，未命中本 PR 新寫入的任何觸發面。

## Carry-forward Minor items

- ADR-002 把 `ccs_collect.py` 寫成 `internal/ccs_collect.py`，檔案已在 repo root —
  既存 path drift，非本次造成，未動。
- 字樣本 PR 對齊 agent-pager（`inline (desktop Path A)` / `Path C`），averloop 的
  `AGENTS.md` 寫的是 `inline (desktop)` — 兩邊不一致，可另議統一。
- `install.sh` 只 symlink `skills/ccs-orchestrator`，但安裝完成訊息把 `ccs-dispatch-run`
  也列出來（後者需使用者手動建 symlink，README 有記）— 落差非本 PR 範圍。

## Related

- Design / plan: N/A — 契約層在個人 `mr-review-artifacts` skill，本 PR 只落地
  repo-specific 那三節。
- Issue: 無（由 #71 收攤時發現本 repo 缺這三節而起）

---
**Provenance**
- Model: Claude Opus 5 1M · effort high
- Channel: agent-pager Path B (telegram slot 1)
