### PR TITLE
fix(core): scope process scans to the invoking uid

### DIFF
--- a/ccs-core.sh
+++ b/ccs-core.sh
@@ -652,7 +652,7 @@ HELP
 
     printf "\033[33m  PID %-8s  %4d MB  %-25s  %s → %s\033[0m\n" "$pid" "$mb" "$cwd" "$started" "$last_active"
     printf "\033[33m  %17s Topic: %s\033[0m\n\n" "" "$topic"
-  done < <(ps -eo pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
+  done < <(ps -u "$(id -u)" -o pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
 
   if [ ${#pids[@]} -eq 0 ]; then
     echo "No stopped claude processes found."
@@ -842,7 +842,7 @@ _ccs_resurrect_prompt_archived() {
   local _counts; _counts=$(_ccs_running_cwd_counts)
 
   local _sids=""
-  _sids=$(ps -eo args 2>/dev/null \
+  _sids=$(ps -u "$(id -u)" -o args 2>/dev/null \
     | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' \
     | sort -u || true)
 
@@ -931,7 +931,7 @@ _ccs_detect_crash() {
   # Get running session info (once)
   # Method 1: session IDs from --resume or --session args
   local running_sids=""
-  running_sids=$(ps -eo args 2>/dev/null | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' | sort -u)
+  running_sids=$(ps -u "$(id -u)" -o args 2>/dev/null | grep -oP '(?<=--resume )[0-9a-f-]{36}|(?<=--session )[0-9a-f-]{36}' | sort -u)
   # Method 2: per-(provider,cwd) live entry-process counts.
   # A single session spawns many helper processes (launcher bash, Bash-tool
   # children), so only the comm=claude / comm=gemini entry process is a reliable

--- a/ccs-dashboard.sh
+++ b/ccs-dashboard.sh
@@ -201,7 +201,7 @@ HELP
 
     printf "\033[31m  PID %-8s  %4d MB  %-25s  %s → %s\033[0m\n" "$pid" "$mb" "$cwd" "$started" "$last_active"
     printf "\033[31m  %17s Topic: %s\033[0m\n\n" "" "$topic"
-  done < <(ps -eo pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
+  done < <(ps -u "$(id -u)" -o pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
 
   if [ "$zombie_count" -eq 0 ]; then
     printf "  \033[32m(none)\033[0m\n"
@@ -378,7 +378,7 @@ _ccs_status_md() {
       echo "> ${topic}"
       echo
     fi
-  done < <(ps -eo pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
+  done < <(ps -u "$(id -u)" -o pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
 
   if ! $has_zombie; then
     echo "_(none)_ ✓"

--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -282,10 +282,10 @@ _ccs_overview_md() {
   local zombie_count
   zombie_count=$(ps aux 2>/dev/null | grep -c '[c]laude.*--session' || echo 0)
   local stopped_count
-  stopped_count=$(ps -eo pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
+  stopped_count=$(ps -u "$(id -u)" -o pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
   if [ "$stopped_count" -gt 0 ]; then
     local zombie_ram
-    zombie_ram=$(ps -eo stat,rss,comm 2>/dev/null | awk '$1 ~ /T/ && $3 ~ /claude/ {sum+=$2} END {printf "%d", sum/1024}')
+    zombie_ram=$(ps -u "$(id -u)" -o stat,rss,comm 2>/dev/null | awk '$1 ~ /T/ && $3 ~ /claude/ {sum+=$2} END {printf "%d", sum/1024}')
     printf '## Zombie Processes\n\n'
     printf '%d stopped process(es), ~%d MB RAM. Run `ccs-cleanup --dry-run` for details.\n\n' "$stopped_count" "$zombie_ram"
   else
@@ -411,7 +411,7 @@ _ccs_overview_json() {
 
   # Zombie count
   local stopped_count
-  stopped_count=$(ps -eo pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
+  stopped_count=$(ps -u "$(id -u)" -o pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
 
   # crash_detected field (4th arg is optional)
   local -a crash_high_sids=()
@@ -923,7 +923,7 @@ _ccs_overview_terminal() {
 
   # Zombie summary
   local stopped_count
-  stopped_count=$(ps -eo pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
+  stopped_count=$(ps -u "$(id -u)" -o pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
   if [ "$stopped_count" -gt 0 ]; then
     printf '\n\033[31m⚠ %d zombie process(es)\033[0m — run \033[1mccs-cleanup --dry-run\033[0m\n' "$stopped_count"
   fi

--- a/ccs-overview.sh
+++ b/ccs-overview.sh
@@ -279,8 +279,6 @@ _ccs_overview_md() {
   fi
 
   # Zombie processes (count only)
-  local zombie_count
-  zombie_count=$(ps aux 2>/dev/null | grep -c '[c]laude.*--session' || echo 0)
   local stopped_count
   stopped_count=$(ps -u "$(id -u)" -o pid,stat,comm 2>/dev/null | awk '$2 ~ /T/ && $3 ~ /claude/' | wc -l)
   if [ "$stopped_count" -gt 0 ]; then

--- a/ccs-viewer.sh
+++ b/ccs-viewer.sh
@@ -114,7 +114,7 @@ HELP
   <td>${topic}</td>
 </tr>
 "
-  done < <(ps -eo pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
+  done < <(ps -u "$(id -u)" -o pid,stat,rss,etime,args | awk '$2 ~ /^T/ && /claude/ && !/awk/')
 
   # ── Generate HTML ──
   cat > "$html_file" << 'HTMLHEAD'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,6 +135,8 @@ ccs-pick --md --full 3:9  # 完整展開第 3 個 session 的第 9 個 prompt re
 
 找出 Stopped 狀態（`Tl`/`T`）的 Code CLI process (如 claude) 並終止。
 這些通常是 waveterm `/exit` 後被 SIGTSTP suspend 的殭屍，每個佔 190-500 MB RAM。
+**只掃呼叫者自己的 uid**——共享主機上不會列出、也不會嘗試終止其他帳號的
+process（同樣適用於 `ccs-status` 的 Zombie Processes 區塊與各 overview 的統計）。
 
 ```bash
 ccs-cleanup           # 互動確認後清理

--- a/tests/test-process-scan-scope.sh
+++ b/tests/test-process-scan-scope.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# tests/test-process-scan-scope.sh
+# Run: bash tests/test-process-scan-scope.sh
+#
+# Invariant: every process enumeration in this repo is scoped to the invoking
+# EUID. On a shared host an unscoped scan reads other accounts' claude/gemini
+# processes, and the tool then treats them as the caller's own (issue #101:
+# wrong session-liveness verdicts, a cleanup summary reporting memory it never
+# freed, and stats counting strangers).
+#
+# This is a STATIC check, not a behavioural one. Reproducing the bug needs a
+# second account running claude, which is not available in CI or on a dev box,
+# and the failure it guards against is a NEW call site written unscoped -- the
+# actual way this bug recurs. It also catches unscoped scans whose result is
+# discarded, which no behavioural test can see (one such dead scan existed in
+# ccs-overview.sh and was removed with this test).
+#
+# Allowed: `ps -u <uid>`, `ps -p <pid>` (pid already from a scoped source),
+# `pgrep -u <uid>`. Forbidden: an all-process selector (`-e`, `-A`, `aux`,
+# `ax`) or a `pgrep` with no `-u`/`-U`.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+source "$ROOT/tests/fixture-helper.sh"
+
+# An all-process `ps` selector, or a pgrep with no user filter. Comment lines
+# are stripped by the caller: prose about `pgrep -x` is not a call site.
+BAD_PS_RE='(^|[^[:alnum:]_-])ps[[:space:]]+(-[[:alpha:]]*[eA][[:alpha:]]*|aux|ax)([^[:alnum:]]|$)'
+BAD_PGREP_RE='(^|[^[:alnum:]_-])pgrep([[:space:]]+-[^uU[:space:]]+)*[[:space:]]'
+
+scan_file() {
+  local f="$1" out=""
+  # Drop whole-line comments before matching.
+  local body; body=$(grep -vE '^[[:space:]]*#' "$f" || true)
+  out=$(printf '%s\n' "$body" | grep -nE "$BAD_PS_RE" || true)
+  printf '%s' "$out"
+  out=$(printf '%s\n' "$body" | grep -nE "$BAD_PGREP_RE" \
+        | grep -vE '\-[uU][[:space:]]' || true)
+  printf '%s' "$out"
+}
+
+# ── 1. The detector itself must work (guards against a rotted regex) ──
+_probe() {
+  local tmp; tmp=$(mktemp "$ROOT/tmp/scan-probe.XXXXXX")
+  printf '%s\n' "$1" > "$tmp"
+  local hit; hit=$(scan_file "$tmp")
+  rm -f "$tmp"
+  [ -n "$hit" ] && echo "detected" || echo "clean"
+}
+mkdir -p "$ROOT/tmp"
+assert_eq "detector flags ps -eo"        "detected" "$(_probe 'x=$(ps -eo pid,comm)')"
+assert_eq "detector flags ps aux"        "detected" "$(_probe 'n=$(ps aux | grep -c x)')"
+assert_eq "detector flags ps -A"         "detected" "$(_probe 'ps -A -o args')"
+assert_eq "detector flags bare pgrep"    "detected" "$(_probe 'pgrep -x claude')"
+assert_eq "detector allows ps -u"        "clean"    "$(_probe 'ps -u "$(id -u)" -o pid,comm')"
+assert_eq "detector allows ps -p"        "clean"    "$(_probe 'ps -p "$pid" -o lstart=')"
+assert_eq "detector allows pgrep -u"     "clean"    "$(_probe 'pgrep -u "$_uid" -x claude')"
+assert_eq "detector ignores comments"    "clean"    "$(_probe '# count source (pgrep -x) never misses')"
+
+# ── 2. No unscoped scan anywhere in the shipped sources ──
+offenders=""
+for f in ccs-*.sh install.sh *.py; do
+  [ -f "$f" ] || continue
+  hits=$(scan_file "$f")
+  [ -n "$hits" ] && offenders="${offenders}${f}: ${hits}"$'\n'
+done
+assert_eq "no unscoped process enumeration in shipped sources" "" "$offenders"
+
+test_summary


### PR DESCRIPTION
## Summary

共享主機上十處 process 列舉用的是系統全域掃描，工具因此把別的帳號的 claude session
當成呼叫者自己的。repo 內本來就有正確樣板（`pgrep -u "$_uid"`），所以這是一致性修正，
不是新增能力。第二個 commit 補一條 static invariant 測試守住「新 call site 不要再犯」，
並移除它抓到的一處死掃描。

## Changes

- `829184b` **fix(core): scope process scans to the invoking uid** — 十處
  `ps -eo <fields>` → `ps -u "$(id -u)" -o <fields>`（`ccs-core.sh` ×3、`ccs-overview.sh` ×4、
  `ccs-dashboard.sh` ×2、`ccs-viewer.sh` ×1），一行換一行、pipeline 不動；
  `docs/commands.md` 補一句說明 `ccs-cleanup` 只掃自己的 uid。
- `d37b567` **test(core): forbid unscoped process enumeration** —
  `tests/test-process-scan-scope.sh`（靜態檢查 ＋ detector 自檢），並移除
  `ccs-overview.sh` 那處死掃描（`zombie_count` 由 `ps aux` 賦值後從未被讀）。

## Test plan (reviewer checklist)

- [x] 十處轉換形狀一致、無漏引號、未誤用 `ps -U`（RUID）
- [x] 下游 awk / grep pipeline 的欄位位置與 header 排除行為不變
- [x] `ps -u` / `id -u` / `pgrep -u` 三者同為 EUID 語意
- [x] 測試套件無新增失敗
- [x] 新測試對真實 pre-fix 內容會 FAIL（正向對照，非只驗合成 probe）
- [x] repo 內已無其他未 scoped 的 process 列舉
- [x] public repo 脫敏（diff 無個人路徑 / 內網資訊）
- [ ] 於實際共享主機情境再觀察一輪（需第二個帳號有 stopped process 才能端到端重現）

## Test results (author 已驗)

**Unit tests：** `bash tests/run-all.sh` → **Total 49 / Passed 48 / Failed 1 / Skipped 1**。
唯一 failed = `test-resurrect.sh`，**既存環境問題非本次引入**（`tests/test-resurrect.sh:52`
的 `mktemp -d` 指向一個已不存在的 worktree 絕對路徑）；baseline 為 48/47/1/1，故**零新增
失敗**。新測試 9 項全 PASS。

**E2E tests：** N/A —— 本 repo 的 e2e（`tests/e2e/`）由 `run-all.sh` 一併執行，已含在上列
數字內；針對本變更的 e2e 不可行（需第二個帳號在同機跑 claude 並製造 stopped process）。

**Smoke tests：** 手動行為驗證（本機恰有第二個帳號在跑 claude）——
系統全域掃到 7 個 claude process、uid-scoped 掃到 4 個，delta 恰為該帳號的 3 個。
另以一個假的 stopped `claude --resume <uuid>` probe 對十處 pipeline 逐條比對舊／新兩版，
輸出逐字元相同。

## Reviewer summary

獨立 fresh-context review（非作者）：**1 blocking ＋ 7 non-blocking**。

- **blocking（已修）**：`docs/commands.md` 的說明留在未 commit 狀態 → 就這樣發 PR 會是
  「code 改了、user-facing 文件沒改」，清 worktree 還會丟掉。已 amend 進 `829184b`。
- **已採納的 non-blocking**：移除死掃描 ＋ 補 static invariant 測試（`d37b567`）；修正
  commit message 兩處措辭。
- **review 順手修正了 issue 本身的敘述**：`:845`/`:934` 的舊 bug 要誤判需要**兩個帳號持有
  同一個 session UUID**（比對是 `grep -qw` 對 36 字元 UUID，包含即等於相等），故 issue
  impact 1 的描述誇大。修法方向仍正確——真正的收穫是拿掉「UUID 不會跨帳號碰撞」這個
  隱性假設。commit body 已照此改寫。
- 完整 report 見本 PR 的 review comment；Change Impact Analysis 另一則 comment。

## Carry-forward Minor items

- 共用 helper（`_ccs_ps_self()`）等到真要加「顯示全機」的 explicit flag 時再抽——現在
  十處 inline 的價值是一行換一行、易 review 與 revert。
- `$(id -u)` 為空（`id` 不在 PATH）時 `ps -u ""` 會失敗；帶 `2>/dev/null` 的六處會靜默
  回空 → 活著的 session 可能被判 crash。既有 `pgrep -u "$_uid"` 有同樣曝險，屬一致的
  既有 pattern。
- 同一人以不同 euid 跑 session（`sudo` / `su`）時該 session 現在掃不到。issue 框架已
  接受 uid scoping 為正確語意，此處只記錄方向。
- `tests/test-resurrect.sh:52` 的 hardcoded 個人絕對路徑（public repo）另開 issue 處理。

## Related

- Issue: #101
- Plan / design: 無獨立 design doc（單一 issue 的機械修正；派工契約與驗收條件見
  `internal/` 下的 gitignored task.yaml）

---
**Provenance**
- Model: Claude Opus 5 (1M context) · effort xhigh
- Channel: agent-pager Path B (telegram slot 1)