### PR TITLE
feat(skills): add a lightweight, idempotent skills installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,10 @@ diff 命中以下任一面 → 必跑 Change Impact Analysis 並貼為 PR commen
   `skills/ccs-dispatch-run/references/task-yaml.md`）。
 - **outbound chain**：agent-pager 通知路徑（outbound sender 解析、job 完成通知）、
   handoff 續鏈（`--chain`）。
-- **部署面**：`install.sh`（modules array、`~/.bashrc` source line、skill symlink）、
-  `skills/` 下已分發的 skill。
+- **部署面**：`install.sh`（modules array、`~/.bashrc` source line）、
+  `skills/install.sh`（skill 連結的唯一實作處，且被個人 config 層的 sync 在**每次
+  push 收尾**呼叫——改壞它等於讓所有 skill 對 agent 靜默消失）、`skills/` 下已分發
+  的 skill。
 - **上游 CLI 相容面**：`ccs-canary-versions.txt`（`ccs_collect.py` 讀取的 known-good
   claude CLI 版本清單）。注意風險方向：沒有 parsing 邏輯讀這份清單，誤列一筆的後果
   是**消音**「版本未驗證、偵測可能失準」那行警示，讓解析靜默失準。

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you use Code CLI Sessions heavily — multiple providers, multiple repos, mul
 ```bash
 git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
 cd ~/tools/ccs-dashboard
-./install.sh              # Check deps, add source line to ~/.bashrc, create skill symlink
+./install.sh              # Check deps, add source line to ~/.bashrc, link the skills
 ```
 
 `./install.sh --check` reports status; `./install.sh --uninstall` removes it.
@@ -32,9 +32,8 @@ Or wire it up manually:
 # Add to .bashrc:
 source ~/tools/ccs-dashboard/ccs-dashboard.sh
 
-# Skill symlinks (optional):
-ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
-ln -s ~/tools/ccs-dashboard/skills/ccs-dispatch-run ~/.claude/skills/ccs-dispatch-run
+# Skill links (optional) — idempotent, and repairs a missing or dangling link:
+./skills/install.sh
 ```
 
 Then just ask Claude:
@@ -55,13 +54,13 @@ Claude: (runs /ccs-orchestrator)
 ☐ Write integration tests               (backend-api)
 ```
 
-The bundled [skill](https://docs.anthropic.com/en/docs/claude-code/skills) gives you an interactive orchestrator with context-aware follow-up options — no commands to memorize. See [docs/commands.md](docs/commands.md) for a full walkthrough.
+The bundled [skills](https://docs.anthropic.com/en/docs/claude-code/skills) give you an interactive orchestrator with context-aware follow-up options — no commands to memorize. See [docs/commands.md](docs/commands.md) for a full walkthrough.
 
 ## Usage
 
 ccs-dashboard has two layers:
 
-**1. Claude Code skill** (`/ccs-orchestrator`) — the primary interface. Ask in natural language ("work status", "what am I working on") and get an interactive orchestrator with context-aware options. Read-only: it observes and presents, it does not control other sessions.
+**1. Claude Code skills** — `/ccs-orchestrator` is the primary interface. Ask in natural language ("work status", "what am I working on") and get an interactive orchestrator with context-aware options. Read-only: it observes and presents, it does not control other sessions. `/ccs-dispatch-run` is the second one, driving a dispatch through its review gate; it doubles as a CLI command of the same name.
 
 **2. CLI commands** — shell functions you can call directly from the terminal, for scripting, piping, or quick one-off lookups.
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -21,7 +21,7 @@ Code CLI 工具將對話存放在特定目錄中，但缺乏統一的管理介�
 ```bash
 git clone https://github.com/a60708090xun/ccs-dashboard.git ~/tools/ccs-dashboard
 cd ~/tools/ccs-dashboard
-./install.sh              # 檢查依賴、加 source 行到 ~/.bashrc、建立 skill symlink
+./install.sh              # 檢查依賴、加 source 行到 ~/.bashrc、建立 skill 連結
 ```
 
 `./install.sh --check` 檢查狀態；`./install.sh --uninstall` 移除。
@@ -32,9 +32,8 @@ cd ~/tools/ccs-dashboard
 # 在 .bashrc 加入：
 source ~/tools/ccs-dashboard/ccs-dashboard.sh
 
-# Skill symlinks（選用）：
-ln -s ~/tools/ccs-dashboard/skills/ccs-orchestrator ~/.claude/skills/ccs-orchestrator
-ln -s ~/tools/ccs-dashboard/skills/ccs-dispatch-run ~/.claude/skills/ccs-dispatch-run
+# Skill 連結（選用）——冪等，且會修復不見或斷掉的連結：
+./skills/install.sh
 ```
 
 接著直接問 Claude：
@@ -55,13 +54,13 @@ Claude: (runs /ccs-orchestrator)
 ☐ Write integration tests               (backend-api)
 ```
 
-內建的 [skill](https://docs.anthropic.com/en/docs/claude-code/skills) 會啟動互動式指揮台和 context-aware follow-up options，不用記指令。完整操作流程見 [commands.md](commands.md)。
+內建的 [skill](https://docs.anthropic.com/en/docs/claude-code/skills) 會啟動互動式指揮台和 context-aware follow-up options，不用記指令。完整操作流程見 [commands.md](commands.md)。共兩支，見下方「使用方式」。
 
 ## 使用方式
 
 ccs-dashboard 分兩層：
 
-**1. Claude Code Skill**（`/ccs-orchestrator`）— 主要介面。用自然語言問（「工作狀態」「我在做什麼」），得到互動式指揮台和 context-aware options。唯讀：只讀取和呈現資訊，不控制其他 session。
+**1. Claude Code Skills** — `/ccs-orchestrator` 是主要介面。用自然語言問（「工作狀態」「我在做什麼」），得到互動式指揮台和 context-aware options。唯讀：只讀取和呈現資訊，不控制其他 session。另一支是 `/ccs-dispatch-run`，把一次 dispatch 帶過它的 review gate；同名的 CLI 指令也存在，兩種身分共用一個名字。
 
 **2. CLI 指令** — 可以從 terminal 直接呼叫的 shell function，適合腳本、pipe、快速查詢。
 

--- a/docs/sync-checklist.md
+++ b/docs/sync-checklist.md
@@ -12,6 +12,15 @@ Phase 3 收尾時，確認以下檔案的對應欄位已同步。
 - `skills/ccs-orchestrator/SKILL.md` — Command Palette
 - `docs/commands.md` — 詳細用法與範例
 
+## Skill 清單
+
+新增或移除 `skills/<name>/` 下的 skill 時：
+
+- `skills/install.sh` — `SKILLS` array（連結的唯一實作處）
+- `install.sh` — 安裝完成後的 "Skills installed" 列表
+- `tests/test-skills-install.sh` — `SKILLS` array
+- `README.md` / `docs/README.zh-TW.md` — skill 說明段落
+
 ## 狀態圖示
 
 修改 session 狀態分類時：

--- a/install.sh
+++ b/install.sh
@@ -152,19 +152,23 @@ do_install() {
     ok "Added to ${BASHRC}"
   fi
 
-  # Install skill symlink (idempotent)
-  local skill_src="${SCRIPT_DIR}/skills/ccs-orchestrator"
-  local skill_dst="$HOME/.claude/skills/ccs-orchestrator"
-  if [ -d "$skill_src" ]; then
-    if [ -L "$skill_dst" ]; then
-      warn "Skill symlink already exists: ${skill_dst}"
-    elif [ -e "$skill_dst" ]; then
-      warn "Skill path exists but is not a symlink: ${skill_dst} — skipping"
+  # Install skill links — delegated to skills/install.sh, which owns this
+  # logic because the config-layer sync re-runs it on every push. Keeping a
+  # second copy here is how the two drift apart.
+  # Tested with -f, not -x: it is invoked as `bash <path>`, so the exec bit is
+  # irrelevant and requiring it would skip a perfectly usable installer.
+  local skills_installer="${SCRIPT_DIR}/skills/install.sh"
+  local skills_ok=true
+  if [ -f "$skills_installer" ]; then
+    if bash "$skills_installer" | sed 's/^/  /'; then
+      ok "Skill links installed"
     else
-      mkdir -p "$HOME/.claude/skills"
-      ln -s "$skill_src" "$skill_dst"
-      ok "Skill symlink: ${skill_dst} → ${skill_src}"
+      warn "Skill links incomplete — see the messages above"
+      skills_ok=false
     fi
+  else
+    warn "${skills_installer} missing — skill links not installed"
+    skills_ok=false
   fi
 
   echo
@@ -195,8 +199,15 @@ do_install() {
   echo "  ccs-review          — session review report (md/html/pdf)"
   echo "  ccs-project         — per-project insight report (md/html)"
   echo
-  echo "Skills installed:"
+  # Heading follows the verdict above: announcing both as installed after a
+  # warning that the links are incomplete would contradict the run's own output.
+  if $skills_ok; then
+    echo "Skills installed:"
+  else
+    echo "Skills (NOT fully linked — see the warning above):"
+  fi
   echo "  ccs-orchestrator    — interactive work orchestrator (Code CLI skill)"
+  echo "  ccs-dispatch-run    — dispatch-with-gate driver (Code CLI skill)"
 }
 
 # ── Uninstall ──
@@ -210,15 +221,16 @@ do_uninstall() {
   sed -i '/# ccs-dashboard/d; /ccs-dashboard\.sh/d' "$BASHRC"
   ok "Removed from ${BASHRC}"
 
-  # Remove skill symlink if it points to us
-  local skill_dst="$HOME/.claude/skills/ccs-orchestrator"
-  if [ -L "$skill_dst" ]; then
-    local target
-    target=$(readlink "$skill_dst")
-    if [[ "$target" == *"ccs-dashboard"* ]]; then
-      rm "$skill_dst"
-      ok "Removed skill symlink: ${skill_dst}"
-    fi
+  # Remove skill links — same delegation as install; that script only removes
+  # links resolving to this checkout, so a second clone's links survive.
+  local skills_installer="${SCRIPT_DIR}/skills/install.sh"
+  if [ -f "$skills_installer" ]; then
+    # The `||` branch is required, not decorative: without it `set -e` would
+    # abort before the data directory is cleaned, leaving uninstall half done.
+    # It reports rather than swallowing — a link that cannot be removed (say a
+    # read-only skills dir) used to exit 0 with nothing said.
+    bash "$skills_installer" --uninstall | sed 's/^/  /' ||
+      warn "Skill links not fully removed — see the messages above"
   fi
 
   # Remove data directory

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# skills/install.sh — link this repo's skills into ~/.claude/skills/
+#
+# Scope is deliberately narrow: symlinks only. No ~/.bashrc edit, no
+# dependency check, no banner — those stay in the top-level install.sh, which
+# calls this script so the linking logic has a single home.
+#
+# Why a separate entry point: a personal config layer mirrors ~/.claude/skills/
+# with `rsync --delete`, which removes any symlink that repo does not own. The
+# contract is that every repo creating a link there also offers a cheap,
+# idempotent rebuild entry point for the sync flow to call at the end of each
+# push. The top-level installer cannot serve that role — it appends to
+# ~/.bashrc, checks dependencies and prints a banner, none of which belongs in
+# a per-push step.
+#
+# Claude Code only. Claude Code does not read ~/.agents/skills/, so the link
+# goes straight under ~/.claude/skills/. Making these two visible to Gemini CLI
+# would need either an ~/.agents/skills/ entry or `gemini extensions link`;
+# neither is done here, because nothing has asked for these skills from Gemini
+# yet and both add per-push side effects outside ~/.claude/.
+#
+# Idempotent and safe to re-run.
+#
+# Usage:
+#   ./skills/install.sh              Link skills (default)
+#   ./skills/install.sh --uninstall  Remove links that point at this repo
+#   ./skills/install.sh --help       Show usage
+
+set -euo pipefail
+
+SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_BASE="$HOME/.claude/skills"
+SKILLS=(ccs-dispatch-run ccs-orchestrator)
+
+fail_count=0
+
+usage() {
+  echo "Usage: $0 [--uninstall|--help]"
+  echo
+  echo "  (no args)     Link ${#SKILLS[@]} skills into ${TARGET_BASE}"
+  echo "  --uninstall   Remove links pointing at this repo"
+  echo
+  echo "Skills: ${SKILLS[*]}"
+}
+
+link_one() {
+  local name="$1"
+  local src="$SKILLS_DIR/$name"
+  local target="$TARGET_BASE/$name"
+
+  if [ ! -f "$src/SKILL.md" ]; then
+    echo "ERROR: $src/SKILL.md missing, skipping $name"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  if [ -L "$target" ]; then
+    # The path comparison alone already catches a dangling link: `readlink -f`
+    # resolves all but the last component, so a link pointing nowhere reports
+    # its missing target rather than $src — which the SKILL.md check above has
+    # just proved exists. The -e test is therefore defensive, not load-bearing;
+    # it starts mattering only if that check is ever relaxed to tolerate a
+    # missing $src. Verified by differential: without it, 11 target states
+    # (live, dangling, deep-dangling, wrong target, self-loop, chained, real
+    # file, real dir, ...) behave identically.
+    if [ -e "$target" ] &&
+       [ "$(readlink -f "$target")" = "$(readlink -f "$src")" ]; then
+      echo "OK: $target already points correctly"
+      return
+    fi
+    ln -sfn "$src" "$target"
+    echo "Repaired: $target -> $src"
+    return
+  fi
+
+  if [ -e "$target" ]; then
+    # A real file or directory of that name may hold the only copy of
+    # something. Report it, never clobber it.
+    echo "WARN: $target exists and is not a symlink, left untouched"
+    fail_count=$((fail_count + 1))
+    return
+  fi
+
+  ln -s "$src" "$target"
+  echo "Installed: $target -> $src"
+}
+
+unlink_one() {
+  local name="$1"
+  local src="$SKILLS_DIR/$name"
+  local target="$TARGET_BASE/$name"
+
+  if [ -L "$target" ]; then
+    # Only remove a link that resolves to this checkout: the same skill name
+    # may be served from another clone on the same machine.
+    if [ "$(readlink -f "$target")" = "$(readlink -f "$src")" ]; then
+      rm "$target"
+      echo "Removed: $target"
+    else
+      echo "Kept: $target points elsewhere ($(readlink "$target"))"
+    fi
+  elif [ -e "$target" ]; then
+    echo "WARN: $target is not a symlink, left untouched"
+  fi
+}
+
+case "${1:-}" in
+  --uninstall)
+    for skill in "${SKILLS[@]}"; do unlink_one "$skill"; done
+    ;;
+  --help | -h)
+    usage
+    ;;
+  "")
+    mkdir -p "$TARGET_BASE"
+    for skill in "${SKILLS[@]}"; do link_one "$skill"; done
+    ;;
+  *)
+    echo "Unknown option: $1"
+    usage
+    exit 2
+    ;;
+esac
+
+# A skill left unlinked means the link chain is incomplete; say so with the
+# exit code, so a caller (the sync flow, or the top-level installer) can see it.
+[ "$fail_count" -eq 0 ] || exit 1

--- a/tests/test-process-scan-scope.sh
+++ b/tests/test-process-scan-scope.sh
@@ -59,7 +59,7 @@ assert_eq "detector ignores comments"    "clean"    "$(_probe '# count source (p
 
 # ── 2. No unscoped scan anywhere in the shipped sources ──
 offenders=""
-for f in ccs-*.sh install.sh *.py; do
+for f in ccs-*.sh install.sh skills/install.sh *.py; do
   [ -f "$f" ] || continue
   hits=$(scan_file "$f")
   [ -n "$hits" ] && offenders="${offenders}${f}: ${hits}"$'\n'

--- a/tests/test-skills-install.sh
+++ b/tests/test-skills-install.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# tests/test-skills-install.sh
+# Run: bash tests/test-skills-install.sh
+#
+# Contract for skills/install.sh (issue #103): a cheap, idempotent rebuild
+# entry point for the ~/.claude/skills/ links this repo owns. The config-layer
+# sync mirrors that directory with `rsync --delete` and calls this script at the
+# end of every push, so the shapes below are not hypothetical — a deleted link
+# is what the mirror actually does, and a dangling one is what a moved checkout
+# leaves behind. Both make the skill invisible to Claude Code while the repo
+# content stays perfectly intact, which is why it went unnoticed for two months.
+#
+# Runs against a throwaway HOME, so it never touches the real ~/.claude/skills/.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+source "$ROOT/tests/fixture-helper.sh"
+
+INSTALLER="$ROOT/skills/install.sh"
+SKILLS=(ccs-dispatch-run ccs-orchestrator)
+
+setup_test_dir "skills-install"
+FAKE_HOME="$TEST_DIR/home"
+SKILL_DIR="$FAKE_HOME/.claude/skills"
+mkdir -p "$FAKE_HOME"
+
+# Results land in globals rather than on stdout: `x=$(run_installer)` would run
+# the function in a subshell, where the exit code it recorded dies with it.
+LAST_RC=0
+LAST_OUT=""
+run_installer() {
+  local rc=0
+  LAST_OUT=$(HOME="$FAKE_HOME" bash "$INSTALLER" "$@" 2>&1) || rc=$?
+  LAST_RC=$rc
+}
+
+# resolves | dangling | missing | not-a-link
+# Second argument overrides the skills dir, for the top-level-installer case
+# that needs its own throwaway HOME.
+link_state() {
+  local p="${2:-$SKILL_DIR}/$1"
+  if [ -L "$p" ]; then
+    [ -e "$p" ] && echo "resolves" || echo "dangling"
+  elif [ -e "$p" ]; then
+    echo "not-a-link"
+  else
+    echo "missing"
+  fi
+}
+
+# ── 1. Fresh install links every skill ──
+run_installer; out="$LAST_OUT"
+assert_eq "fresh install exits 0" "0" "$LAST_RC"
+for s in "${SKILLS[@]}"; do
+  assert_eq "fresh install: $s resolves" "resolves" "$(link_state "$s")"
+  assert_eq "fresh install: $s points at this repo" \
+    "$(readlink -f "$ROOT/skills/$s")" "$(readlink -f "$SKILL_DIR/$s")"
+done
+
+# ── 2. Re-running changes nothing ──
+run_installer; out="$LAST_OUT"
+assert_eq "second run exits 0" "0" "$LAST_RC"
+assert_eq "second run touches nothing" \
+  "${#SKILLS[@]}" "$(printf '%s\n' "$out" | grep -c 'already points correctly')"
+assert_not_contains "second run creates no link" "$out" "Installed:"
+assert_not_contains "second run repairs nothing" "$out" "Repaired:"
+
+# ── 3. A deleted link (what `rsync --delete` does) comes back ──
+rm "$SKILL_DIR/ccs-orchestrator"
+run_installer; out="$LAST_OUT"
+assert_eq "deleted link restored" "resolves" "$(link_state ccs-orchestrator)"
+assert_contains "restore is reported" "$out" "Installed:"
+assert_eq "restore leaves the other link alone" \
+  "1" "$(printf '%s\n' "$out" | grep -c 'already points correctly')"
+
+# ── 4. A dangling link is repaired ──
+# The failure the old top-level installer could not fix: it skipped on `-L`
+# alone, so a link pointing nowhere survived every re-run.
+ln -sfn "$TEST_DIR/gone" "$SKILL_DIR/ccs-orchestrator"
+assert_eq "precondition: link dangles" "dangling" "$(link_state ccs-orchestrator)"
+run_installer; out="$LAST_OUT"
+assert_eq "dangling link repaired" "resolves" "$(link_state ccs-orchestrator)"
+assert_contains "repair is reported" "$out" "Repaired:"
+
+# ── 5. A link pointing at the wrong place is repaired ──
+mkdir -p "$TEST_DIR/other-clone/ccs-orchestrator"
+ln -sfn "$TEST_DIR/other-clone/ccs-orchestrator" "$SKILL_DIR/ccs-orchestrator"
+run_installer; out="$LAST_OUT"
+assert_eq "misdirected link repointed at this repo" \
+  "$(readlink -f "$ROOT/skills/ccs-orchestrator")" \
+  "$(readlink -f "$SKILL_DIR/ccs-orchestrator")"
+assert_contains "repoint is reported" "$out" "Repaired:"
+
+# ── 6. A real directory in the way is reported, never clobbered ──
+rm "$SKILL_DIR/ccs-orchestrator"
+mkdir -p "$SKILL_DIR/ccs-orchestrator"
+echo "the only copy" > "$SKILL_DIR/ccs-orchestrator/SKILL.md"
+run_installer; out="$LAST_OUT"
+assert_eq "occupied path fails the run" "1" "$LAST_RC"
+assert_contains "occupied path warns" "$out" "is not a symlink"
+assert_eq "occupied path left as a directory" "not-a-link" \
+  "$(link_state ccs-orchestrator)"
+assert_eq "occupant content untouched" "the only copy" \
+  "$(cat "$SKILL_DIR/ccs-orchestrator/SKILL.md")"
+rm -rf "$SKILL_DIR/ccs-orchestrator"
+run_installer
+
+# ── 7. --uninstall removes our links ──
+run_installer --uninstall; out="$LAST_OUT"
+assert_eq "uninstall exits 0" "0" "$LAST_RC"
+for s in "${SKILLS[@]}"; do
+  assert_eq "uninstall removed $s" "missing" "$(link_state "$s")"
+done
+
+# ── 8. --uninstall leaves another clone's link alone ──
+run_installer
+ln -sfn "$TEST_DIR/other-clone/ccs-orchestrator" "$SKILL_DIR/ccs-orchestrator"
+run_installer --uninstall; out="$LAST_OUT"
+assert_contains "foreign link kept" "$out" "points elsewhere"
+assert_eq "foreign link still there" "resolves" "$(link_state ccs-orchestrator)"
+assert_eq "our own link still removed" "missing" "$(link_state ccs-dispatch-run)"
+
+# ── 9. An unknown option is rejected, not treated as install ──
+run_installer --frobnicate; out="$LAST_OUT"
+assert_eq "unknown option exits 2" "2" "$LAST_RC"
+assert_eq "unknown option installs nothing" "missing" \
+  "$(link_state ccs-dispatch-run)"
+
+# ── 10. A skill missing its SKILL.md is reported and fails the run ──
+# The shape when a skill is renamed or dropped while its name stays in SKILLS:
+# nothing links it, and the exit code is the only thing that tells the caller.
+# Exercised against a copy of the installer, so the repo's own skills stay put.
+FAKE_SKILLS="$TEST_DIR/fake-skills"
+mkdir -p "$FAKE_SKILLS/ccs-orchestrator" "$FAKE_SKILLS/ccs-dispatch-run"
+cp "$INSTALLER" "$FAKE_SKILLS/install.sh"
+echo "stub" > "$FAKE_SKILLS/ccs-orchestrator/SKILL.md"  # ccs-dispatch-run: none
+rm -f "$SKILL_DIR/ccs-orchestrator" "$SKILL_DIR/ccs-dispatch-run"
+fake_rc=0
+fake_out=$(HOME="$FAKE_HOME" bash "$FAKE_SKILLS/install.sh" 2>&1) || fake_rc=$?
+assert_eq "missing SKILL.md fails the run" "1" "$fake_rc"
+assert_contains "missing SKILL.md is reported" "$fake_out" "SKILL.md missing"
+assert_eq "the healthy skill is still linked" "resolves" \
+  "$(link_state ccs-orchestrator)"
+assert_eq "the broken skill is not linked" "missing" \
+  "$(link_state ccs-dispatch-run)"
+
+# ── 11. The top-level installer reaches this script (issue #103 AC 4) ──
+# Without this case, deleting the delegation block from install.sh leaves the
+# whole suite green while both skills silently stop being linked — the exact
+# failure mode this work exists to close. Needs its own HOME: the top-level
+# installer appends to ~/.bashrc, and XDG_DATA_HOME is pinned so its uninstall
+# cannot reach the real data directory.
+if command -v jq >/dev/null 2>&1; then
+  TOP_HOME="$TEST_DIR/top-home"
+  TOP_SKILLS="$TOP_HOME/.claude/skills"
+  mkdir -p "$TOP_HOME"
+  top_rc=0
+  HOME="$TOP_HOME" XDG_DATA_HOME="$TOP_HOME/.local/share" \
+    bash "$ROOT/install.sh" >/dev/null 2>&1 || top_rc=$?
+  assert_eq "top-level install exits 0" "0" "$top_rc"
+  for s in "${SKILLS[@]}"; do
+    assert_eq "top-level install linked $s" "resolves" \
+      "$(link_state "$s" "$TOP_SKILLS")"
+  done
+
+  top_rc=0
+  HOME="$TOP_HOME" XDG_DATA_HOME="$TOP_HOME/.local/share" \
+    bash "$ROOT/install.sh" --uninstall >/dev/null 2>&1 || top_rc=$?
+  assert_eq "top-level uninstall exits 0" "0" "$top_rc"
+  for s in "${SKILLS[@]}"; do
+    assert_eq "top-level uninstall removed $s" "missing" \
+      "$(link_state "$s" "$TOP_SKILLS")"
+  done
+else
+  echo "  SKIP: jq missing, top-level installer not exercised"
+fi
+
+test_summary


### PR DESCRIPTION
## Summary

`skills/ccs-dispatch-run` 與 `skills/ccs-orchestrator` 的 `~/.claude/skills/` 連結
沒有可重跑的安裝入口：前者從來沒有任何 installer 建它（現存連結都是手動建的），
後者由頂層 `install.sh` 建，而那支同時會 append `~/.bashrc`、檢查依賴、印橫幅——
不能被別的工具在每次同步收尾時反覆呼叫。結果是個人 config 層的 `rsync --delete`
把兩條連結刪掉後沒有任何機制補回，skill 對 Claude Code 靜默消失（repo 內容完好，
所以不容易被發現）。本 PR 補上只做 symlink 的輕量 installer，並讓頂層 installer
改為呼叫它，避免兩份邏輯漂移。

## Changes

- `f86d045` **feat(skills): add a symlink-only, idempotent skills installer** —
  新 `skills/install.sh`：兩支 skill 各建 `~/.claude/skills/<name>`，已正確就 no-op、
  dangling 或指錯就修回、同名真實檔案／目錄只警告不覆蓋、有 skill 沒接上就 exit 非零、
  支援 `--uninstall`（只移除 resolve 到本 checkout 的連結）。頂層 `install.sh` 的
  install 與 uninstall 兩條路徑改為委派。新 `tests/test-skills-install.sh`
  （39 assertions，跑在 throwaway HOME）。`tests/test-process-scan-scope.sh` 的掃描面
  加入這支新 shipped script。
- `0baa49e` **docs: point the install instructions at the skills installer** —
  兩份 README 的手動 `ln -s` 段落改為 `./skills/install.sh`，且 usage 段從「一支
  bundled skill」改為正確的兩支；`docs/sync-checklist.md` 新增「Skill 清單」四檔
  同步點；`AGENTS.md` 的 CIA 觸發清單把部署面拆細，明寫這支 installer 是連結邏輯的
  唯一實作處。

## Test plan (reviewer checklist)

- [x] issue 四條驗收條件逐條實測（刪除復原 / dangling 修回 / 連跑兩次無變更 / 頂層
      installer 走完兩支皆在位）
- [x] 冪等不是「刪了再建」的假冪等（inode 未變）
- [x] 同名真實目錄佔位時不覆蓋，佔位內容原封不動
- [x] `--uninstall` 不誤刪另一個 clone 的同名連結
- [x] 頂層 `install.sh` 的委派有自動測試守門（install ＋ uninstall 兩條路徑）
- [x] 測試有效性以 mutation 驗證（見下方 Test results）
- [x] 行為不退化：base 版只建 `ccs-orchestrator` 一支，且對 dangling 連結永遠修不回
- [x] 測試套件無新增失敗
- [x] public repo 脫敏（對實際要 push 的 diff 跑，非只對「我改的那幾個檔」）
- [ ] config 層接線後的端到端（sync push → 連結自動復原）——需該 repo 的後續變更，
      本 PR 範圍外，見 Carry-forward

## Test results (author 已驗)

**Unit tests：** `bash tests/run-all.sh` → **Total 50 / Passed 49 / Failed 1 / Skipped 1**。
唯一 failed = `test-resurrect.sh`，**既存環境問題非本次引入**（`tests/test-resurrect.sh:52`
的 `mktemp -d` 指向一個已不存在的 worktree 絕對路徑，追蹤於 #104）；baseline 為
49/48/1/1，故**零新增失敗**。新測試 39 項全 PASS。

**Mutation 驗證（測試真的抓得到 regression，而非只是跑得過）：**

- 把頂層委派的呼叫換成 `true` → `top-level install linked <skill>` 2 條 FAIL。
- 把 missing-`SKILL.md` 分支的 `fail_count` 累加拿掉 → 1 條 FAIL。
- 兩次 mutation 後都以備份還原並 `diff` 確認與原檔一致；`git diff --summary` 空，
  確認 exec bit 未被 mutation 留下副作用。

**E2E tests：** N/A —— 本 repo 的 e2e（`tests/e2e/`）由 `run-all.sh` 一併執行，已含在
上列數字內。

**Smoke tests：** 三個 review 修正逐條實機驗證——read-only skills dir 下 uninstall
現在印 `Skill links not fully removed`（修正前靜默 exit 0）；清掉 exec bit 後頂層
installer 仍正常建連結（守衛改 `[ -f ]` 生效）；佔位情境下結尾標頭改為
`Skills (NOT fully linked — see the warning above)`，不再與它自己剛印的警告矛盾。

## Reviewer summary

獨立 fresh-context review（非作者）：**0 blocking ＋ 8 non-blocking**，verdict 可 merge。
採納 7 條、carry-forward 1 條。

- **最有價值的一條**：頂層委派完全沒有測試覆蓋，所以驗收條件 4 只靠人工驗證守著——
  刪掉委派區塊會讓全套測試保持全綠而兩支 skill 靜默停止連結，正是本 issue 要消除的
  失效型態。已補測試並以 mutation 確認會抓到。
- **抓到我一個寫錯的斷言**：`link_one` 裡 `[ -e "$target" ]` 前置檢查的註解聲稱
  「dangling link 的 `readlink -f` 會 canonicalise 成與正常 link 相同的路徑」。實測與
  coreutils man page 都不支持——`-f` 只要求 last component 之外都存在，dangling link
  回傳的是那個不存在的 target 路徑，所以單靠 path 比對就已排除 dangling。reviewer 用
  11 種 target 狀態的 differential 證明拿掉該檢查行為完全相同。檢查本身保留（若上方
  `SKILL.md` guard 日後放寬才會變成 load-bearing），但註解已改成誠實版本。這條錯誤
  源於我沿用了另一支 script 的註解說法而沒有實測。
- **其餘採納**：uninstall 的 `|| true` 改成 `|| warn`（read-only skills dir 下原本靜默
  成功）；兩處守衛 `[ -x ]` → `[ -f ]`（呼叫方式是 `bash <path>`，exec bit 不相關，
  且 else 訊息會對存在的檔案說 "not found"）；結尾 "Skills installed" 標頭受前面
  verdict 節制；missing-`SKILL.md` 失敗分支補測試；兩份 README 的 usage 段落補上第二支
  skill（我自己新增的 checklist bullet 指向這個落點，卻沒同步）。
- 完整 report 見本 PR 的 review comment；Change Impact Analysis 另一則 comment。

## Carry-forward Minor items

- **`install.sh --check` 看不到 skill link 狀態**（既有行為，非本次退化）。要補需要在
  `skills/install.sh` 加唯讀模式（`--check` / `--dry-run`）再接到頂層——否則 `--check`
  重用 installer 會產生修復副作用。這與「config 層的 `sync.sh diff` 也看不見斷鏈」是
  同一個盲點，兩者一起處理比較合理，故不在本 PR 擴張範圍。
- **契約尚未閉合**：config 層 sync 的 `EXTERNAL_SKILL_INSTALLERS` 還沒有這支 installer、
  `CLAUDE_SKILLS_EXCLUDES` 還沒有這兩個名字，所以**下一次 sync push 仍會刪掉這兩條連結
  且不會補回**。閉合要等該 repo 接線（另含 wingman 那支同型 installer）。
- **Gemini CLI 看不到這兩支 skill**（只建 `~/.claude/skills/` 一層）。這是既有狀態的
  延續而非本 PR 造成的退化——被取代的 inline 邏輯同樣只建那一層。刻意不做的理由寫在
  script 註解。
- **merge 後需在主 checkout 跑一次 `bash skills/install.sh`**：這台機器上兩支 skill
  目前都還沒安裝，本 PR 只是讓安裝變得可重跑。
- **review 另外指出**：`tests/test-dispatch-proj.sh` 與 `tests/test-project.sh` 也有
  hardcoded 個人絕對路徑（public repo）。#104 目前只涵蓋 `test-resurrect.sh`，值得擴充
  或另開；依 surgical-change 紀律本 PR 未動。

## Related

ref #103

---
**Provenance**
- Model: Claude Opus 5 (1M context) · effort xhigh
- Channel: agent-pager Path B (telegram slot 1)
