### PR TITLE
fix(dispatch): record worker exit codes and escalate on infra failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), versioning follo
 
 ### Fixed
 
+- **ccs-dispatch-run no longer spends a retry on infrastructure** — the gate loop used to drop the worker's exit code on the headless path, so a crashed worker, a missing CLI and a worker that ran and did nothing were indistinguishable, and a failure that had nothing to do with the task still burned `loop_budget`. Every headless executor now records `attempt-NN/executor-exit-code` as evidence, and the deterministic subset of failures (exit 125/126/127, plus `backend: agentpager`'s daemon-down and no-proj-map) also writes `attempt-NN/worker-error`, which the gate turns into the ERROR verdict its pure judgement function already accepted — escalating on attempt 1 instead of retrying, and outranking a passing AC set. A timeout (124), a plain non-zero rc, an occupied agentpager seat and a failed launch write deliberately stay on the FAIL path, since those can still self-heal on the next attempt. `final.json` gains `worker_rc` and an `escalation.reason` of `gate` | `worker_error`, so the terminal state is readable without opening the worker trace. (#106)
 - `ccs-jobs` status sync is now agent-pager-aware: resolves effective status via the same reduce-merge as the board (fallback markers no longer skip liveness), uses the worker tmux session instead of the monitor pid as the liveness signal, and defers to a live monitor during worker startup to avoid falsely completing a just-dispatched job. (PR #72)
 
 ## [0.3.3] — 2026-04-17

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -283,9 +283,25 @@ _ccs_dispatch_gate_run() {
     i=$((i + 1))
   done
 
+  # A deterministic worker infra failure (issue #106) enters the verdict as
+  # a synthetic ERROR record, which the existing pure verdict function maps
+  # to ESCALATE without spending loop_budget. It is deliberately NOT written
+  # as gate/<id>.json: AC ids are any [A-Za-z0-9_.-]+ token, so any such
+  # filename could collide with a user's AC. The reason lands in
+  # verdict.json.worker_error instead. No file = fail-open (unchanged).
+  local werr=""
+  [ -f "$attempt_dir/worker-error" ] \
+    && werr="$(head -n1 "$attempt_dir/worker-error")"
+  if [ -n "$werr" ]; then
+    verdicts="$(jq -n --argjson a "$verdicts" \
+      '$a + [{ac_id:"_worker", track:"infra", verdict:"ERROR"}]')"
+  fi
+
   local verdict_json
   verdict_json="$(_ccs_dispatch_gate_verdict "$verdicts" "$attempt" "$budget" \
-    | jq --arg ts "$(date -Iseconds)" '.timestamp = $ts')"
+    | jq --arg ts "$(date -Iseconds)" --arg we "$werr" \
+        '.timestamp = $ts
+         | .worker_error = (if $we == "" then null else $we end)')"
   echo "$verdict_json" > "$gate_dir/verdict.json"
   echo "$verdict_json" | jq -r '.verdict'
 }
@@ -389,8 +405,18 @@ _ccs_dispatch_run_worker() {
   local wrc=0
   (cd "$cwd" && timeout "$timeout_sec" "${cmd[@]}") \
     > "$ad/executor-output.md" 2>&1 || wrc=$?
+  # Every executor records its rc: a crashed worker, a missing CLI and a
+  # worker that ran and did nothing are otherwise indistinguishable in the
+  # evidence tree. Evidence only -- the gate stays the sole verdict source.
+  echo "$wrc" > "$ad/executor-exit-code"
+  # Deterministic infra failures only, where a retry provably cannot pass:
+  # 125 (timeout itself failed), 126 (CLI not executable), 127 (CLI not
+  # found). 124 (timeout) and a plain non-zero can self-heal on attempt 2,
+  # so they stay on the FAIL -> RETRY path.
+  case "$wrc" in
+    125|126|127) printf 'exit-%s\n' "$wrc" > "$ad/worker-error" ;;
+  esac
   if [ "$executor" = "wingman" ]; then
-    echo "$wrc" > "$ad/executor-exit-code"
     cp "$cwd/.wingman/result.md" "$ad/wingman-result.md" 2>/dev/null || true
   fi
   (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
@@ -430,7 +456,10 @@ _ccs_dispatch_run_one() {
   cp "$task_yaml" "$hop_dir/task.yaml"   # freeze (§1)
 
   local attempt=1 verdict outcome="escalated" rc=10 term="ESCALATE"
-  local ad prev prompt fb
+  # ad is read after the loop; seed it so a budget that makes the loop body
+  # never run (a hand-written negative or non-integer loop_budget) degrades to
+  # "no evidence" instead of an unbound-variable abort under `set -u`.
+  local ad="" prev prompt fb
   while [ "$attempt" -le $(( budget + 1 )) ]; do
     ad="$hop_dir/attempt-$(printf '%02d' "$attempt")"
     mkdir -p "$ad"
@@ -454,9 +483,26 @@ _ccs_dispatch_run_one() {
     attempt=$((attempt + 1))
   done
 
+  # worker_rc + escalation.reason let the orchestrator tell "the gate judged
+  # it failed" from "the worker never finished" without reading the trace.
+  # The reason is read back from the gate's own verdict, not from the evidence
+  # file: the gate is the sole verdict source (I4), so its record of what it
+  # judged must be what final.json reports.
+  local worker_rc=null esc_reason="gate" wrc_line=""
+  [ -s "$ad/executor-exit-code" ] && wrc_line="$(head -n1 "$ad/executor-exit-code")"
+  case "$wrc_line" in
+    ''|*[!0-9]*) : ;;
+    *) worker_rc="$wrc_line" ;;
+  esac
+  if [ -f "$ad/gate/verdict.json" ] \
+     && [ -n "$(jq -r '.worker_error // empty' "$ad/gate/verdict.json" 2>/dev/null)" ]; then
+    esc_reason="worker_error"
+  fi
+
   jq -n --arg o "$outcome" --argjson n "$attempt" \
-    '{outcome:$o, attempts:$n, stage2:null,
-      escalation:(if $o=="escalated" then {reason:"gate"} else null end)}' \
+    --argjson wrc "$worker_rc" --arg er "$esc_reason" \
+    '{outcome:$o, attempts:$n, stage2:null, worker_rc:$wrc,
+      escalation:(if $o=="escalated" then {reason:$er} else null end)}' \
     > "$hop_dir/final.json"
   echo "$term"
   return "$rc"
@@ -1595,6 +1641,7 @@ _ccs_dispatch_run_worker_agentpager() {
   if ! _ccs_dispatch_agentpager_available; then
     printf 'agent-pager backend not available (daemon down or spool missing)\n' \
       > "$ad/agentpager-error.txt"
+    printf 'agentpager-daemon-down\n' > "$ad/worker-error"
     return 0
   fi
 
@@ -1606,6 +1653,7 @@ _ccs_dispatch_run_worker_agentpager() {
   local proj
   if ! proj="$(_ccs_dispatch_resolve_proj_from_dir "$cwd")"; then
     printf 'no proj-map entry for %s\n' "$cwd" > "$ad/agentpager-error.txt"
+    printf 'agentpager-no-proj-map\n' > "$ad/worker-error"
     return 0
   fi
   local pager_dir="${AGENT_PAGER_DIR:-$HOME/.agent-pager}"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -681,8 +681,31 @@ ccs-dispatch-run <task.yaml>
 
 - `PASS` — 全部 cmd-AC PASS（guidance-AC 記 SKIPPED_FOR_LLM，不參與判定）
 - `RETRY` — 有 FAIL 且 `attempt <= loop_budget` → 重派
-- `ESCALATE` — budget 耗盡、或任一 AC ERROR
-- `HARD_STOP` — 破壞性操作（判定函式已支援）
+- `ESCALATE` — budget 耗盡、或 worker 發生確定性基礎設施故障（ERROR）
+- `HARD_STOP` — 破壞性操作（判定函式已支援，目前無 producer）
+
+**Worker 故障 vs 驗收失敗（ERROR 的來源）：** worker 根本沒起來或沒跑完、且
+重派一定不會過時，gate 產生一筆合成 ERROR 記錄，判定直接走 ESCALATE（不吃
+`loop_budget`）。判定輸入是 `attempt-NN/worker-error` 這個單行類別檔，由**產生
+現場**寫出——headless 的 exit `125`（timeout 自身失敗）/ `126`（CLI 不可執行）/
+`127`（CLI 不存在），以及 `backend: agentpager` 的 daemon 不在、`cwd` 無
+proj-map entry。類別記進 `verdict.json.worker_error`；該記錄刻意不落
+`gate/<id>.json`，因為 AC id 可為任意 `[A-Za-z0-9_.-]+` token、任何檔名都可能
+與使用者的 AC 撞名。
+
+**ERROR 蓋過 AC 結果：** 有 `worker-error` 時即使全部 cmd-AC 都 PASS 也照樣
+ESCALATE。worker 沒跑就不該接受驗收結果——現實可能是前一輪 hop 或既有狀態剛好
+滿足了 AC。
+
+**刻意不算 ERROR 的（都可能在下一次 attempt 自癒，維持在 FAIL 路徑）：**
+`124`（timeout）、一般非零 rc、agentpager 的 seat 被占與 launch 檔寫入失敗。
+註：「FAIL 路徑」在 budget 未耗盡時是 RETRY，耗盡時（或 `executor: wingman`，
+其 budget 被 clamp 成 0）仍是 ESCALATE。
+
+要分辨終態是「gate 判失敗」還是「worker 沒跑完」，讀 `final.json` 的
+`worker_rc`（`backend: agentpager` 恆為 `null`，該 backend 看
+`agentpager-wait-rc`）與 `escalation.reason`（`gate` / `worker_error`），不必翻
+worker trace。無 `worker-error` 檔 = fail-open（行為與未導入前一致）。
 
 **收尾輸出（stdout）：** 除了 `run: <run-dir>` 與 `outcome:`／`chain:` 摘要，收尾另印一行 **advisory** commit trailer 供收尾 commit 的人 copy：`suggested trailer: X-Executor: <executor>/<model> (ccs-dispatch-run)`（`model` 缺省時退化為 executor-only、無斜線）。對所有終態皆印、chain 內每個 distinct `executor[/model]` 各印一行。純建議：dispatch-run 不 commit、不強制，語意與 `Co-Authored-By`（orchestrator 署名）正交。詳 `skills/ccs-dispatch-run/references/task-yaml.md`。
 
@@ -726,14 +749,15 @@ ${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/runs/<first-task-id>-cha
       git-status.txt     # gate 當下 git status --porcelain
       diff.patch         # git diff
       wingman-result.md  # 僅 wingman executor：scope.cwd/.wingman/result.md 凍結副本
-      executor-exit-code # 僅 wingman executor：wingman process exit code（純 evidence，不參與 verdict）
+      executor-exit-code # 僅 headless backend（claude / gemini / wingman 皆落）：worker process exit code（純 evidence，不參與 verdict）。backend: agentpager 沒有 process rc，對應證據是 agentpager-wait-rc
+      worker-error       # 僅確定性基礎設施故障：故障類別單行（exit-125|126|127 / agentpager-daemon-down / agentpager-no-proj-map）；gate 據此發 ERROR
       launch-file.txt    # 僅 backend: agentpager：寫給 agent-pager 的 inbound launch 檔路徑
       handoff.md         # 僅 backend: agentpager：worker per-attempt 完成訊號 handoff 副本
       agentpager-wait-rc # 僅 backend: agentpager：前景 wait 結果（0=handoff / 1=timeout|無 handoff；純 evidence）
       gate/AC<n>.json    # per-AC 紀錄（verdict/exit/stdout tail…）
       gate/verdict.json  # gate verdict
     attempt-02/          # 重派時遞增；prompt.md 含前輪 FAIL 摘要
-    final.json           # 終態 outcome: accepted | escalated | hard_stop
+    final.json           # 終態 outcome: accepted | escalated | hard_stop；worker_rc（最後一輪 exit code，無則 null）；escalation.reason: gate | worker_error
   hop-02-<task-id-2>/
     ...
 ```

--- a/docs/internal/architecture-invariants.md
+++ b/docs/internal/architecture-invariants.md
@@ -168,8 +168,11 @@ falling back would make `auto` less reliable than plain headless.
 
 **Rule:** the deterministic Stage-1 gate (`_ccs_dispatch_gate_run`) is the
 only thing that decides PASS / RETRY / ESCALATE / HARD_STOP. The `backend:`
-choice (headless vs agentpager) changes only how the worker process is
-launched, never the verdict, evidence layout, or retry logic.
+choice (headless vs agentpager) changes how the worker is launched and what
+spawn-side evidence exists (`executor-exit-code` vs `agentpager-wait-rc`);
+it must never influence the *acceptance* judgement. A backend may report
+that the work never happened (see the corollary below) — it may not hold an
+opinion on whether the work is good.
 
 **Why:** the gate re-runs every `verify.cmd` against ground truth, which is
 what catches an auto-approved false success (a headless `claude -p
@@ -180,8 +183,25 @@ carry at least one `cmd`-track AC — each AC declares exactly one of
 `verify.cmd` / `verify.guidance`, and an all-`guidance` task is rejected
 at load (`_ccs_dispatch_gate_load_task`).
 
+**Corollary — worker infra failure does not become a second verdict
+source.** A worker that never started (missing CLI, agentpager daemon
+down, no proj-map entry) writes a one-line class to
+`attempt-NN/worker-error`; the classification lives at the site that
+knows how the spawn failed, never in the gate. The gate reads that single
+signal and appends a synthetic ERROR record to the verdict input, so the
+existing pure `_ccs_dispatch_gate_verdict` still produces the terminal
+word (ERROR -> ESCALATE, no retry spent), and it outranks a fully passing
+AC set — the worker never ran, so a green gate only means reality already
+matched. `_ccs_dispatch_run_one` keeps branching on the gate's output
+only, and reads `escalation.reason` back out of that verdict rather than
+re-deriving it from the evidence file. A failure class that could
+self-heal on a retry (timeout 124, plain non-zero rc, agentpager seat
+busy or launch-file write failure) is deliberately left off that file and
+stays on the FAIL path; a missing file is fail-open.
+
 **Test backstop:** `tests/test-gate-verdict.sh`, `tests/test-gate-run.sh`,
-`tests/test-gate-loop.sh`, `tests/test-gate-ac.sh`.
+`tests/test-gate-loop.sh`, `tests/test-gate-ac.sh`,
+`tests/test-gate-worker-error.sh`.
 
 **Cite:** `_ccs_dispatch_gate_run`, `_ccs_dispatch_gate_verdict`,
 `_ccs_dispatch_gate_load_task` (AC validation) in `ccs-dispatch.sh`;

--- a/docs/internal/state-file-lifecycle.md
+++ b/docs/internal/state-file-lifecycle.md
@@ -109,15 +109,31 @@ runs/<first_id>-chain-NN/
     ├── attempt-NN/
     │   ├── prompt.md              # attempt 1 = goal; ≥2 = §6 feedback + goal
     │   ├── executor-output.md     # worker stdout+stderr
+    │   ├── executor-exit-code     # worker rc, headless backend only (evidence)
+    │   ├── worker-error           # deterministic infra failure class, if any
     │   ├── git-status.txt         # ground-truth porcelain
     │   ├── diff.patch             # ground-truth diff
     │   └── gate/<ac-id>.json      # per-AC verdict evidence
-    └── final.json                 # {outcome, attempts, escalation}
+    └── final.json                 # {outcome, attempts, worker_rc, escalation}
 ```
 
 `task.yaml` is frozen on entry — acceptance criteria must not change
 mid-run. The gate re-derives ground truth (`git-status.txt` / `diff.patch`)
 independently of the worker's self-report (see I4).
+
+`worker-error` exists only when the worker demonstrably never ran to
+completion and a retry cannot change that (`exit-125` / `exit-126` /
+`exit-127`, `agentpager-daemon-down`, `agentpager-no-proj-map`). Failures
+that a retry might survive — a timeout, a plain non-zero rc, an occupied
+agentpager seat, a launch file that could not be written — deliberately
+do not write it. It is the gate's ERROR input; its class is copied into
+`gate/verdict.json.worker_error`, and `final.json` carries the last
+attempt's `worker_rc` plus `escalation.reason` (`gate` | `worker_error`,
+read back from that verdict) so a reader can separate "judged failed"
+from "never finished" without opening the trace. `worker_rc` comes from
+`executor-exit-code`, which only the headless seam writes — under
+`backend: agentpager` it is always `null` and `agentpager-wait-rc` is the
+corresponding signal.
 
 ## 5. Cleanup
 

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -69,10 +69,12 @@ ccs-dispatch-run <task.yaml>
 chain.json                     # 鏈終態：hops[]、stop_reason、outcome
 hop-NN-<task-id>/
 ├── task.yaml                  # dispatch 當下凍結的驗收條件
-├── final.json                 # 本 hop 終態：outcome / attempts
+├── final.json                 # 本 hop 終態：outcome / attempts / worker_rc
 └── attempt-NN/
     ├── prompt.md              # worker 收到的完整 prompt
     ├── executor-output.md     # worker 原始輸出（僅供鑑識，勿當依據）
+    ├── executor-exit-code     # worker process exit code（純 evidence；僅 headless backend）
+    ├── worker-error           # 僅確定性基礎設施故障：故障類別（見 Verdict 語意）
     ├── git-status.txt / diff.patch   # ground truth
     └── gate/
         ├── <AC-id>.json       # per-AC verdict + exit code + output tail
@@ -93,10 +95,21 @@ untracked，**不會**出現在 diff.patch，要靠 `??` 行發現後另行讀�
   等你 Stage 2 裁決，不參與 gate 判定）
 - `RETRY` — 有 FAIL 且 loop_budget 未耗盡；CLI 自動帶「machine 事實
   摘要」（AC id + cmd + exit code，無 worker prose）重派，你不介入
-- `ESCALATE` — budget 耗盡。交給人診斷（讀 evidence 樹），
+- `ESCALATE` — budget 耗盡，或發生 ERROR。交給人診斷（讀 evidence 樹），
   **不是**由你直接重試 — 你帶著 planning 確認偏誤
-- `HARD_STOP` / `ERROR` — 判定函式已支援，目前無 producer
-  （現行 AC 執行只產生 PASS / FAIL / SKIPPED_FOR_LLM）
+- `ERROR` — worker 根本沒起來或沒跑完，且**重派一定不會過**：headless
+  exit 125（timeout 自身失敗）/ 126（CLI 不可執行）/ 127（CLI 不存在），
+  以及 `backend: agentpager` 的 daemon 不在、`cwd` 無 proj-map entry。
+  gate 讀 `attempt-NN/worker-error` 產生，類別記在
+  `verdict.json.worker_error`，終態直接 ESCALATE（不吃 loop_budget），
+  且**即使 cmd-AC 全 PASS 也一樣**（worker 沒跑，AC 過只代表現實剛好符合）。
+  **不含** timeout（124）、一般非零 rc、agentpager 的 seat 被占與 launch
+  檔寫入失敗——那些可能在下一次 attempt 自癒，維持在 FAIL 路徑。
+  診斷：`final.json.worker_rc`（`backend: agentpager` 恆為 null，改看
+  `agentpager-wait-rc`）＋ `escalation.reason`（`gate` / `worker_error`），
+  不必翻 trace。看到 `exit-127` 先確認該 executor CLI 是否在 PATH 上——
+  worker CLI 自己回 127 也會落進這一格
+- `HARD_STOP` — 破壞性操作（判定函式已支援，目前無 producer）
 
 ## 鏈結（gated chain）
 

--- a/tests/test-dispatch-proj.sh
+++ b/tests/test-dispatch-proj.sh
@@ -16,7 +16,7 @@ bad() { FAIL=$((FAIL+1)); printf 'FAIL: %s\n' "$1"; }
 MAP="$(mktemp "$SCRIPT_DIR/tmp.projmap.XXXXXX")"
 cat > "$MAP" <<'EOF'
 # ccs proj map (key = abspath, mirrors lead whitelist keys)
-demo = /pool2/chenhsun/tools/ccs-dashboard
+demo = /home/x/work/demo
 other = /home/x/work/other
 EOF
 export CCS_DISPATCH_PROJ_MAP="$MAP"
@@ -24,11 +24,11 @@ cleanup() { rm -f "$MAP"; }
 trap cleanup EXIT
 
 test_exact_match() {
-  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard)"
+  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /home/x/work/demo)"
   [ "$got" = "demo" ] && ok "exact path -> key" || bad "exact (got: '$got')"
 }
 test_trailing_slash() {
-  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard/)"
+  local got; got="$(_ccs_dispatch_resolve_proj_from_dir /home/x/work/demo/)"
   [ "$got" = "demo" ] && ok "trailing slash normalized" || bad "trailing slash (got: '$got')"
 }
 test_second_entry() {
@@ -41,7 +41,7 @@ test_no_match() {
 }
 test_missing_map() {
   ( export CCS_DISPATCH_PROJ_MAP=/no/such/map
-    _ccs_dispatch_resolve_proj_from_dir /pool2/chenhsun/tools/ccs-dashboard >/dev/null 2>&1 ) \
+    _ccs_dispatch_resolve_proj_from_dir /home/x/work/demo >/dev/null 2>&1 ) \
     && bad "missing map should fail" || ok "missing map -> rc!=0"
 }
 

--- a/tests/test-gate-agentpager.sh
+++ b/tests/test-gate-agentpager.sh
@@ -234,6 +234,12 @@ assert_eq "daemon-down term ESCALATE" "ESCALATE" "$term3"
 assert_eq "daemon-down rc 10" "10" "$rc3"
 assert_eq "fast-fail error recorded" "yes" \
   "$([ -f "$hop3/attempt-01/agentpager-error.txt" ] && echo yes || echo no)"
+# issue #106: the worker never started, so this escalates on attempt 1 rather
+# than spending the retry budget on infrastructure. Asserting the terminal word
+# alone would not have caught that change of meaning.
+assert_eq "daemon-down spends no retry" "1" "$(jq -r '.attempts' "$hop3/final.json")"
+assert_eq "daemon-down blames the worker" "worker_error" \
+  "$(jq -r '.escalation.reason' "$hop3/final.json")"
 
 unset -f _ccs_dispatch_agentpager_session_alive _ccs_dispatch_agentpager_stop_file \
          _ccs_dispatch_agentpager_launch_file _ccs_dispatch_agentpager_available

--- a/tests/test-gate-worker-error.sh
+++ b/tests/test-gate-worker-error.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# tests/test-gate-worker-error.sh — worker infra failure is evidence, and the
+# deterministic subset of it produces the gate's ERROR verdict (issue #106).
+#
+# Two separable claims:
+#   1. every executor records its exit code (evidence only, no verdict change)
+#   2. only DETERMINISTIC failures (a retry provably cannot pass) write
+#      attempt-NN/worker-error, which the gate turns into ERROR -> ESCALATE
+#      without spending a retry on infrastructure
+# A timeout (124) and a plain non-zero (1) stay on the FAIL -> RETRY path on
+# purpose: those can self-heal on attempt 2, and the fix must not trade that
+# away. Absence of worker-error is fail-open (identical to today's behaviour).
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-gate-worker-error-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-gate-worker-error"; rm -rf "$WORK"
+mkdir -p "$WORK/repo" "$WORK/bin"; _TEST_DIRS+=("$WORK")
+
+# Fake CLIs on PATH (precedent: test-dispatch-executor-cli.sh). The exit code
+# comes from FAKE_CLI_EXIT so a "crash" is deterministic: 125/126/127 stand in
+# for timeout-itself-failed / not-executable / not-found, which in the real
+# world are produced by `timeout` and the shell rather than by the CLI.
+for c in claude gemini; do
+  cat > "$WORK/bin/$c" <<'FAKE'
+#!/usr/bin/env bash
+echo "$0 $*" >> "$FAKE_CLI_LOG"
+exit "${FAKE_CLI_EXIT:-0}"
+FAKE
+  chmod +x "$WORK/bin/$c"
+done
+export PATH="$WORK/bin:$PATH"
+export FAKE_CLI_LOG="$WORK/argv.log"
+
+CWD="$WORK/repo"; (cd "$CWD" && git init -q)
+RUN="$WORK/run"; mkdir -p "$RUN"
+
+# spawn <attempt> <exit_code> [executor] -> attempt dir path. FAKE_CLI_EXIT is
+# exported (the stub is a child process) and scoped by the command substitution.
+spawn() {
+  local attempt="$1" code="$2" executor="${3:-claude}"
+  export FAKE_CLI_EXIT="$code"
+  _ccs_dispatch_run_worker "$CWD" "do X" "$RUN" "$attempt" 60 "$executor"
+  printf '%s\n' "$RUN/attempt-$(printf '%02d' "$attempt")"
+}
+
+echo "=== every executor records its exit code (evidence) ==="
+: > "$FAKE_CLI_LOG"
+ad="$(spawn 1 0 claude)"
+assert_contains "the stub actually ran (rc 0 proves nothing on its own)" \
+  "$(cat "$FAKE_CLI_LOG")" "/bin/claude -p do X"
+assert_eq "claude rc 0 recorded" "0" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+assert_eq "clean run writes no worker-error" "absent" \
+  "$([ -e "$ad/worker-error" ] && echo present || echo absent)"
+
+: > "$FAKE_CLI_LOG"
+ad="$(spawn 2 0 gemini)"
+assert_contains "the gemini stub actually ran" \
+  "$(cat "$FAKE_CLI_LOG")" "/bin/gemini -p do X"
+assert_eq "gemini rc 0 recorded" "0" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+
+echo "=== non-deterministic failures stay on the FAIL -> RETRY path ==="
+ad="$(spawn 3 1 claude)"
+assert_eq "rc 1 recorded" "1" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+assert_eq "rc 1 writes no worker-error" "absent" \
+  "$([ -e "$ad/worker-error" ] && echo present || echo absent)"
+
+ad="$(spawn 4 124 claude)"
+assert_eq "timeout rc 124 recorded" "124" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+assert_eq "timeout writes no worker-error (can self-heal)" "absent" \
+  "$([ -e "$ad/worker-error" ] && echo present || echo absent)"
+
+echo "=== deterministic failures write worker-error ==="
+ad="$(spawn 5 125 claude)"
+assert_eq "125 -> exit-125" "exit-125" "$(cat "$ad/worker-error" 2>/dev/null)"
+ad="$(spawn 6 126 claude)"
+assert_eq "126 -> exit-126" "exit-126" "$(cat "$ad/worker-error" 2>/dev/null)"
+ad="$(spawn 7 127 gemini)"
+assert_eq "127 -> exit-127" "exit-127" "$(cat "$ad/worker-error" 2>/dev/null)"
+assert_eq "127 rc also recorded" "127" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+
+echo "=== gate turns worker-error into ERROR -> ESCALATE, not RETRY ==="
+task='{"id":"t","goal":"g","acceptance_criteria":[
+  {"id":"AC1","text":"missing","verify":{"cmd":"grep -q greet greeter.py"}}]}'
+
+att="$WORK/att-err"; mkdir -p "$att"; printf 'exit-127\n' > "$att/worker-error"
+v="$(_ccs_dispatch_gate_run "$CWD" "$task" "$att" 1 1)"
+assert_eq "attempt 1 of budget 1 escalates" "ESCALATE" "$v"
+assert_eq "verdict.json agrees" "ESCALATE" "$(jq -r '.verdict' "$att/gate/verdict.json")"
+assert_eq "verdict records the kind" "exit-127" \
+  "$(jq -r '.worker_error' "$att/gate/verdict.json")"
+assert_eq "AC evidence still collected" "FAIL" "$(jq -r '.verdict' "$att/gate/AC1.json")"
+assert_eq "no synthetic AC file (would collide with a user AC id)" "absent" \
+  "$([ -e "$att/gate/_worker.json" ] && echo present || echo absent)"
+
+echo "=== fail-open: no worker-error -> unchanged RETRY ==="
+att2="$WORK/att-ok"; mkdir -p "$att2"
+v2="$(_ccs_dispatch_gate_run "$CWD" "$task" "$att2" 1 1)"
+assert_eq "same inputs without worker-error retry" "RETRY" "$v2"
+# has() rather than a null read: an absent field also prints "null", so the
+# value check alone cannot tell "written as null" from "never added".
+assert_eq "worker_error field is present" "true" \
+  "$(jq -r 'has("worker_error")' "$att2/gate/verdict.json")"
+assert_eq "worker_error is null" "null" \
+  "$(jq -r '.worker_error' "$att2/gate/verdict.json")"
+
+echo "=== ERROR outranks a passing AC set ==="
+echo "def greet(name): pass" > "$CWD/greeter.py"
+att3="$WORK/att-pass"; mkdir -p "$att3"; printf 'exit-126\n' > "$att3/worker-error"
+v3="$(_ccs_dispatch_gate_run "$CWD" "$task" "$att3" 1 1)"
+assert_eq "worker never ran -> escalate even though ACs pass" "ESCALATE" "$v3"
+rm -f "$CWD/greeter.py"
+
+echo "=== run loop: deterministic failure escalates without spending a retry ==="
+task_yaml="$WORK/task.yaml"
+cat > "$task_yaml" <<YAML
+id: we-x
+goal: "create greeter.py with greet()"
+scope:
+  cwd: "$CWD"
+execution_policy:
+  loop_budget: 1
+  timeout_sec: 60
+acceptance_criteria:
+  - id: AC1
+    text: "greet exists"
+    verify:
+      cmd: "grep -q 'def greet' greeter.py"
+YAML
+
+export FAKE_CLI_EXIT=127
+chain="$(_ccs_dispatch_run "$task_yaml")"; rc=$?
+hop="$chain/hop-01-we-x"
+assert_eq "exit 10 escalated" "10" "$rc"
+assert_eq "one attempt only" "1" "$(jq -r '.attempts' "$hop/final.json")"
+assert_eq "outcome escalated" "escalated" "$(jq -r '.outcome' "$hop/final.json")"
+assert_eq "final.json carries worker_rc" "127" "$(jq -r '.worker_rc' "$hop/final.json")"
+assert_eq "escalation blamed on the worker" "worker_error" \
+  "$(jq -r '.escalation.reason' "$hop/final.json")"
+
+echo "=== run loop: a plain failure still spends its retry and blames the gate ==="
+export FAKE_CLI_EXIT=1
+chain2="$(_ccs_dispatch_run "$task_yaml")"; rc2=$?
+hop2="$chain2/hop-01-we-x"
+assert_eq "exit 10 escalated" "10" "$rc2"
+assert_eq "two attempts" "2" "$(jq -r '.attempts' "$hop2/final.json")"
+assert_eq "final.json carries worker_rc" "1" "$(jq -r '.worker_rc' "$hop2/final.json")"
+assert_eq "escalation blamed on the gate" "gate" \
+  "$(jq -r '.escalation.reason' "$hop2/final.json")"
+
+echo "=== agentpager: deterministic infra failures are classified too ==="
+unset FAKE_CLI_EXIT
+_ccs_dispatch_agentpager_available() { return 1; }
+ad="$RUN/attempt-08"
+_ccs_dispatch_run_worker "$CWD" "do X" "$RUN" 8 60 claude "" agentpager
+assert_eq "daemon down classified" "agentpager-daemon-down" \
+  "$(cat "$ad/worker-error" 2>/dev/null)"
+assert_eq "human-readable note kept" "present" \
+  "$([ -s "$ad/agentpager-error.txt" ] && echo present || echo absent)"
+
+_ccs_dispatch_agentpager_available() { return 0; }
+_ccs_dispatch_resolve_proj_from_dir() { return 1; }
+_ccs_dispatch_run_worker "$CWD" "do X" "$RUN" 9 60 claude "" agentpager
+assert_eq "no proj-map entry classified" "agentpager-no-proj-map" \
+  "$(cat "$RUN/attempt-09/worker-error" 2>/dev/null)"
+
+_ccs_dispatch_resolve_proj_from_dir() { echo "ccs-dashboard"; return 0; }
+_ccs_dispatch_agentpager_session_alive() { return 0; }
+_ccs_dispatch_run_worker "$CWD" "do X" "$RUN" 10 60 claude "" agentpager
+assert_eq "seat busy is transient, not classified" "absent" \
+  "$([ -e "$RUN/attempt-10/worker-error" ] && echo present || echo absent)"
+
+test_summary

--- a/tests/test-resurrect.sh
+++ b/tests/test-resurrect.sh
@@ -49,7 +49,11 @@ older_st=$(printf '%s\n' "$out4" | awk -F'|' '$7=="older001"{print $4}')
 echo ""
 echo "=== e2e: ccs_collect.py → resurrection → non-archived status ==="
 
-TMPDIR_E2E=$(mktemp -d /pool2/chenhsun/tools/ccs-dashboard-fix-issue57/build/e2e-XXXXXX)
+# Repo-relative scratch (tmp/ is gitignored): the previous absolute path was
+# pinned to one machine's since-deleted worktree, so `mktemp -d` failed under
+# `set -e` and this file went red on every host.
+mkdir -p "$SCRIPT_DIR/tmp"
+TMPDIR_E2E=$(mktemp -d "$SCRIPT_DIR/tmp/e2e-XXXXXX")
 SID_E2E="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
 JDIR_E2E="$TMPDIR_E2E/projects/-tmp-ccs-e2e"
 mkdir -p "$JDIR_E2E"


### PR DESCRIPTION
## Summary

`ccs-dispatch-run` 的 gate loop 接住了 worker 的 exit code 卻丟掉——headless
（`executor: claude` / `gemini`）完全不落檔。結果是 worker crash、CLI 沒裝、
timeout 與「worker 跑了但什麼都沒做」在結構化證據層不可區分，而且基礎設施故障
照樣吃掉 `loop_budget`（`loop_budget: 1` 下等於故障即用盡預算）。

`_ccs_dispatch_gate_verdict` 其實早有 `ERROR -> ESCALATE` 分支，skill 文件自承
「判定函式已支援，目前無 producer」——設計上已經分「故障」與「沒做好」，實作卻
讓前者走了後者的路徑。本 PR 接上那個 producer，但**只收確定性故障**（重派一定
不會過的那一子集），可能自癒的失敗維持原路徑。

## Changes

- **證據層（零行為變更）**：`executor-exit-code` 從 wingman 專屬的 `if` 移到
  headless 共用路徑，三個 executor 一致落檔；`final.json` 增 `worker_rc`，
  `escalation.reason` 由單一 `gate` 分成 `gate` / `worker_error`。
- **verdict 層**：新增 `attempt-NN/worker-error`（單行故障類別），只在確定性
  故障時寫出——headless exit `125`（timeout 自身失敗）/ `126`（不可執行）/
  `127`（不存在），以及 `backend: agentpager` 的 daemon-down 與 no-proj-map。
  `_ccs_dispatch_gate_run` 讀它，於 verdict 輸入陣列 append 一筆合成
  `{ac_id:"_worker", track:"infra", verdict:"ERROR"}`，**純判定函式一行未改**。
- **刻意不收**：`124`（timeout）、一般非零 rc、agentpager 的 seat 被占與 launch
  檔寫入失敗——四者都可能在下一次 attempt 自癒，收成 ERROR 會把 transient 故障
  變成不重派，比現況差。
- **fail-open**：沒有 `worker-error` 檔時行為與改動前逐字相同。
- 文件：`docs/commands.md`、`skills/ccs-dispatch-run/SKILL.md`、
  `docs/internal/architecture-invariants.md`（I4 corollary + Rule 措辭收斂）、
  `docs/internal/state-file-lifecycle.md`、`CHANGELOG.md`。
- **另一筆獨立 commit（`test:`）**：清掉兩份測試 fixture 裡的個人絕對路徑。
  `test-resurrect.sh` 把 e2e 暫存目錄釘在一個早已刪除的 worktree 絕對路徑，
  `mktemp -d` 在 `set -e` 下失敗，全套測試因此在**任何機器上**都紅一項；
  `test-dispatch-proj.sh` 則把作者的真實專案路徑當 proj-map fixture。兩者都是
  public repo 裡的個人 path。改為 repo-relative 的 gitignored `tmp/` 與
  placeholder 路徑（沿用該檔第二筆 entry 既有的形狀）。

兩個實作決定值得單獨說：

1. **verdict 的輸入是 `worker-error`，不是 exit code。** 若讓 gate 自行判讀 rc，
   agentpager 那幾條沒有 process rc 的路徑就得養第二套規則；分類邏輯留在**產生
   現場**，gate 只認一個訊號。`executor-exit-code` 因此維持純 evidence。
2. **合成 ERROR 記錄不落 `gate/<id>.json`。** AC id 的合法字元集是
   `[A-Za-z0-9_.-]+`，任何檔名都可能與使用者自取的 AC id 撞名互相覆寫；改為只進
   判定函式的輸入陣列，原因記在 `verdict.json.worker_error`。

## Test plan (reviewer checklist)

- [x] 新增 `tests/test-gate-worker-error.sh`：evidence 落檔對稱性、125/126/127
      分類、124 與 rc=1 刻意不分類、gate ERROR -> ESCALATE、fail-open 回歸、
      ERROR 蓋過全 PASS 的 AC、`final.json` 兩個新欄位、agentpager 三條路徑
- [x] `tests/test-gate-agentpager.sh` 補 end-to-end 斷言（daemon-down 只花 1 個
      attempt、`escalation.reason` 為 `worker_error`）
- [x] 既有 gate / dispatch 測試全數回歸（fail-open 路徑由它們直接護航）
- [x] `set -u` 下 `loop_budget` 為負數時不再 unbound abort
- [x] 全套 `tests/run-all.sh`
- [x] `tests/test-resurrect.sh` 與 `tests/test-dispatch-proj.sh` 去個人化後各自綠，
      且不留暫存目錄
- [x] 公開 repo 脫敏（無個人 path / 內網 hostname / IP / credential），含對
      **既有 tracked 檔案**全域重掃

## Test results (author 已驗)

```
tests/test-gate-worker-error.sh   35 passed, 0 failed
tests/test-gate-agentpager.sh     26 passed, 0 failed
tests/test-resurrect.sh            7 passed, 0 failed   （master 上無法執行）
tests/test-dispatch-proj.sh        5 passed, 0 failed
tests/run-all.sh                  Total: 51  Passed: 51  Failed: 0  Skipped: 1
```

全套首次全綠——先前長期存在的那一項失敗是 fixture 路徑問題，已在本 PR 的
`test:` commit 一併修掉。

`set -u` regression case（`loop_budget: -1`）實測：`rc=10`、`final.json` 正常
產出 `{"outcome":"escalated","attempts":1,"worker_rc":null,"escalation":{"reason":"gate"}}`。

## Reviewer summary

兩輪獨立 review（fresh context、非作者，兩個不同面向：correctness/robustness 與
spec/invariant 合規），**blocking 0 / 0**，non-blocking 合計 13 則，report 全文
見 PR comment。**review 之後另加了 `test:` 那筆 commit（去個人化），該 commit
未經過獨立 review**——它只改兩份測試 fixture 的路徑字串，不觸及受測邏輯。correctness reviewer 另做了 mutation test（把 `ccs-dispatch.sh`
換回 master 版重跑新測試，32 條中 18 條轉紅）佐證測試不是假綠。

已在本 PR 內修掉的 non-blocking：

- `local ad` 只宣告未賦值 → `loop_budget` 異常時 `set -u` 下 unbound abort
  （**本次引入的回歸**，master 同輸入是乾淨的 rc=10）
- `run_one` 用 `-f`、`gate_run` 用「存在且非空」的判定分歧 → 改為從
  `gate/verdict.json.worker_error` 讀回，讓 gate 的紀錄成為唯一來源
- 文件「所有 executor 都落 `executor-exit-code`」在 `backend: agentpager` 下
  不成立（該 backend `worker_rc` 恆為 null）→ 三處措辭改為依 backend 標註
- 「ERROR 蓋過全 PASS 的 AC」原本只寫在測試與 gitignored design doc → 補進
  user-facing 文件
- agentpager 實際有第四條 early return（launch 檔寫入失敗）→ 歸 transient 並
  在文件明寫（原本三份文件都是窮舉式寫法，會讓讀者誤以為已完整分類）
- I4 的 Rule 原句「backend never changes the verdict / retry logic」與新增的
  corollary 有張力 → Rule 收斂成「backend 不得影響**驗收**裁決，只能報告工作
  根本沒發生」
- 測試斷言收緊：`has("worker_error")`（不存在的欄位也印 `null`）、加 argv log
  斷言證明 stub 真的被呼叫
- `CHANGELOG.md` 條目（本 repo 慣例是 feature branch 的 doc commit 就寫進
  `[Unreleased]`，不留到 version bump）

Drift Log（與 design doc 的偏離，全文蒸餾）：

- **D1** `escalation.reason` 的判定來源從 evidence 檔改成 gate verdict——非
  scope 變更，反而讓「gate 是唯一裁決來源」更緊，無新行為。
- **D2** design doc 說 agentpager 有三條 early return，實際四條——把第四條歸
  transient 並在文件明寫，不改 code（launch 寫檔失敗可能是暫時性的，符合本
  sprint「只收確定性故障」的既定判準，不需回 Phase 0 重新界定）。

**我沒能驗證的**：真實由 `timeout` / shell 產生的 125/126/127（測試以 stub 直接
`exit N` 模擬該 rc，驗的是分類邏輯而非 shell 語意）；agentpager 真實 daemon-down
的 E2E（既有 agentpager 測試同樣以 seam mock）。

## Carry-forward Minor items

- **免費 infra retry**：真正的「故障不吃預算」完整解是讓 infra 失敗不計入
  `loop_budget`、額外給一次重派。要動迴圈上界且與 I4 有張力，需另行設計。
- **`worker_rc` 在 `backend: agentpager` 恆為 null**：可考慮 fallback 讀
  `agentpager-wait-rc`，但那會讓「exit code」語意跨兩種來源，本 PR 選擇不做。
- ~~`tests/test-resurrect.sh` 硬寫個人絕對路徑~~ — 已在本 PR 一併處理（見
  Changes 最後一項）；同一次掃描另抓到 `tests/test-dispatch-proj.sh` 有同類
  問題，一併修。

## Related

- Closes #106

---
**Provenance**
- Model: Claude Opus 5 (1M context) · effort high
- Channel: agent-pager Path B (telegram slot 2)
