### PR TITLE
docs(dispatch): add three AC transcription rules to task.yaml contract

### DIFF
--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -40,7 +40,41 @@
 - **負向 AC 碰撞檢查**（wingman plan-passthrough 尤其）：`! grep`
   類 AC 凍結前，對 plan 內給定的代碼**含註解字面**跑同一
   predicate——基線驗證擋不住 plan 自帶的字面碰撞，gate 會 FAIL
-  在正確的實作上
+  在正確的實作上。（下面「負向 AC 只掃 diff 新增行」那條同時緩解本條：
+  掃描範圍縮到新增行後，plan 內既有字面不再命中）
+- **AC 逐字寫在 YAML block scalar，不要先經 markdown table**：table 需要
+  把 pipe 逃脫成 `\|`，而 ERE 的 `\|` 是**字面 pipe、不是 alternation**
+  （實測 `grep -nE '/a/\|/b/'` 對 `/a/x` 回 rc=1，只對含完整字面字串
+  `/a/|/b/` 的行才回 rc=0）——逃脫過的 AC 通常永遠不 match，變成永遠
+  PASS 的橡皮圖章
+- **「沒動到 X」類 AC 錨在派工前的 base commit**，不要用裸 `git diff`：
+  後者比的是 working tree vs index，worker 只要 `git add` 就回 rc=0
+  （實測：改檔後 `git diff --quiet` rc=1、`git add` 之後 rc=0，而同一
+  時點 `git diff HEAD --quiet` 仍 rc=1）→ 該 AC vacuously PASS，而這類
+  AC 往往正是唯一擋住 worker 改動既存檔案的機制。**`git diff HEAD` 與
+  `git status --porcelain` 只擋到這一步**——worker 再 commit 一次，兩者
+  一起變乾淨（實測皆回「無差異」）。派工前記下
+  `BASE=$(git rev-parse HEAD)`，AC 用 `git diff "$BASE" -- <path>`，
+  或另加一條 `test "$(git rev-parse HEAD)" = "<base-sha>"`
+- **負向 AC 只掃 diff 的新增行，不要掃整份檔案**：規則文件常把要禁的
+  pattern 當示例寫在自己內文裡，整檔掃描於是恆紅；而恆紅 AC 對 cheap
+  worker 是「把那條規則刪掉」的誘因。寫法：
+
+  ```
+  ! git diff "$BASE" -U0 --no-color -- <path> \
+    | grep -E '^\+' | grep -vE '^\+\+\+ ' | grep -E '<pattern>' >/dev/null
+  ```
+
+  三個細節都是實測踩出來的：`--no-color`（目標 repo 若設
+  `color.ui = always`，diff 行帶 ANSI escape，`^\+` 全部不匹配 → 整條
+  靜默 PASS）、用 `grep -vE '^\+\+\+ '` 濾檔頭而非 `^\+[^+]`（後者會漏掉
+  內容本身以 `+` 開頭的新增行）、末段 `grep … >/dev/null` 而非 `grep -q`
+  （`-q` 提早退出使上游收 SIGPIPE，在有 `pipefail` 的 shell 下整條反轉成
+  PASS）。**涵蓋範圍：只涵蓋 tracked 檔案的修改**——worker **新建**的檔案
+  不在 `git diff` 裡（實測回 PASS），要納入須先
+  `git add -N -- <path>`，或對該檔改掃整檔。凍結前對一個**故意含
+  pattern** 的暫時 diff 跑一次，確認會 FAIL——路徑打錯或檔案不存在時
+  diff 為空，這條會恆 PASS 而不報錯
 - integration 類：驗「元件被呼叫」不只「檔案存在」
   （例：`grep -q 'from .greeter import' src/cli.py`）
 - 涉及 credential 的 task：加一條


### PR DESCRIPTION
## Summary

在 `skills/ccs-dispatch-run/references/task-yaml.md` 的 §「AC 撰寫紀律」補三條轉寫規則。
起因是一次 gated dispatch 實跑：三個 hop 的 AC 由我（orchestrator）自己寫，事後盤點發現
四個缺陷，其中三個的形狀相同——**AC 綠燈，但它其實什麼都沒驗到**。這三條就是把那三個
形狀寫成可照抄的規則。

治的不是 worker 的能力，是**寫 AC 的人**：gate 的價值上限等於 AC 的品質，而 AC 是
orchestrator 寫的。

## Changes

- `docs(dispatch)`: §「AC 撰寫紀律」新增三條——AC 逐字寫 YAML block scalar（不經
  markdown table 逃脫 pipe）／「沒動到 X」類錨在派工前的 base commit（不用裸 `git diff`）
  ／負向 AC 只掃 diff 的新增行（附強化過的一行式與其涵蓋範圍限制）。既有「負向 AC 碰撞
  檢查」那條補一句與第三條的交叉引用。

## Test plan (reviewer checklist)

- [x] 三條規則的技術斷言逐條實跑（非引述文件）
- [x] 推薦的一行式對 positive / negative control 都正確
- [x] 一行式在四種失效情境下的行為已確認並寫進條文（新建檔／worker commit／
      `color.ui=always`／`pipefail`）
- [x] `docs/sync-checklist.md` 四張清單逐張比對（本次一張都沒命中）
- [x] public repo 脫敏：diff 新增行 + commit message 皆無個人路徑／內網位址／credential／
      內部 issue 編號
- [x] 與該節既有五條無重複、無衝突

## Test results (author 已驗)

**Unit tests：** N/A — 純文件變更，未動任何 `.sh` / `.py`。`tests/` 未觸及。

**E2E tests：** N/A — 同上。

**Smoke tests：** 條文裡每一條斷言都在一次性 git sandbox 裡實跑過，八種情境：

```
negative control（diff 無 pattern）           rc=0 PASS ✔
positive control（diff 含 pattern）           rc=1 FAIL ✔
內容以 '+' 開頭的新增行                        rc=1 FAIL ✔（`^\+[^+]` 會漏，已改）
color.ui = always                             rc=1 FAIL ✔（缺 --no-color 會靜默 PASS）
worker commit 後（$BASE 形式）                 rc=1 FAIL ✔
worker commit 後（HEAD 形式）                  rc=0        ← 這正是要避免的假 PASS
untracked 新檔（git add -N 之前）              rc=0        ← 涵蓋範圍限制，已寫進條文
untracked 新檔（git add -N 之後）              rc=1 FAIL ✔
set -o pipefail + grep … >/dev/null           rc=1 FAIL ✔（改用 grep -q 會反轉）
```

另：`grep -nE '/a/\|/b/'` 對 `/a/x` rc=1、對含完整字面 `/a/|/b/` 的行 rc=0；未逃脫的
`-E '/a/|/b/'` 對 `/a/x` rc=0（GNU grep 3.4）。`git diff --quiet` 在 `git add` 前 rc=1、
之後 rc=0，同一時點 `git diff HEAD --quiet` 仍 rc=1。

## Reviewer summary

獨立 review（fresh context、非作者）verdict = **REQUEST CHANGES：2 blocking + 7
non-blocking**，全文貼為本 PR 的 comment。兩條 blocking 都已修並重新驗證：

- **B1 — 推薦的一行式對 worker 新建的檔案是 vacuous PASS。** untracked 檔案不在
  `git diff HEAD` 裡，而 gate 端不做 `git add -N`、worker 也沒被要求 stage，所以
  「worker 新建檔案 + 負向 AC 掃該檔」這個常見組合會直接綠燈。**修法**：條文明寫涵蓋
  範圍僅限 tracked 檔案的修改，並給出 `git add -N` 的補法。
- **B2 — worker 只要 commit 一次，兩種推薦寫法同時失效。** 規則二原本推薦
  `git diff HEAD` / `git status --porcelain`，但 worker 以 auto-approve 跑、沒有任何
  機制阻止它 commit，commit 後兩者一起變乾淨，退回完全相同的假 PASS。**修法**：改為
  錨在派工前記下的 `BASE=$(git rev-parse HEAD)`，並提供 HEAD 比對的替代 AC。

已一併採納的 non-blocking：`--no-color`（目標 repo 設 `color.ui = always` 會讓 `^\+`
全不匹配而靜默 PASS）、改用 `grep -vE '^\+\+\+ '` 濾檔頭（`^\+[^+]` 會漏掉內容以 `+`
開頭的新增行）、末段改 `grep … >/dev/null`（`grep -q` 的 SIGPIPE 在 `pipefail` 下反轉
整條）、補「凍結前對故意含 pattern 的暫時 diff 跑一次」（路徑打錯時 diff 為空 → 恆
PASS）、與既有「負向 AC 碰撞檢查」補交叉引用、規則一措辭改為「完整字面字串」。

**reviewer 同意的一個取捨**：本次**不加** mutation 相關規則。該節既有「若安裝了
`plan-quality` skill，依其完整要求」已是指標；且 `plan-quality` §3(b) 明訂 mutation 的
執行者是 plan 作者／驗收者、**不寫成實作者的 AC**——在 dispatch 場景 worker 就是實作者，
把 mutation 寫成 `verify.cmd` 會實質違反該條，不只是雙 SoT 的風格問題。

**Worklog Drift Log 蒸餾**：一則 D1——原 plan 要求「三條規則 ＋ mutation 一句指回」，
實際只做三條，理由如上（驗收條件本來就寫「mutation 不在此重述」）。

## Carry-forward Minor items

- **實作與新規則自相矛盾（pre-existing，reviewer 發現）**：`ccs-dispatch.sh` 收 evidence
  的 `diff.patch` 用的正是裸 `git diff`——worker 一 `git add`，這份 evidence 就是空的。
  不在本 PR 範圍，建議開 follow-up issue 改成 `git diff HEAD`（或 base-anchored）。
- **兩份契約文件互指但有懸空格**：`plan-quality` 的委派清單列了「timeout 來自基線實測」
  與「worker 自檢層 vs gate 裁決層不混同」，這兩條在本檔並不存在。後續補齊或修正該
  skill 的措辭。
- 三條規則的**機器化候選**（觀察後再議）：載入器已在讀 `.verify.cmd`，第 2、3 條原則上
  可做靜態偵測（裸 `git diff`、負向 `grep -r` 掃非 diff 目標）。

## Related

- 對向契約：個人 `plan-quality` skill 的 AC 鑑別力兩條（同一輪的另一半，已 merge）
- 觸發來源：一次三 hop 的 gated dispatch 實跑（AC 缺陷盤點）

---
**Provenance**
- Model: Claude Opus 5 (1M context) · effort high
- Channel: Claude Code(agent-pager Path B, telegram slot 1)
