### PR TITLE
fix(dispatch): 把 attempt evidence 錨在 hop 的 base commit（issue #109）

### DIFF
--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -377,6 +377,15 @@ _ccs_dispatch_chain_alloc_dir() {
 _ccs_dispatch_capture_evidence() { # $1=cwd $2=hop_dir $3=attempt_dir
   local cwd="$1" hop_dir="$2" ad="$3" base=""
   [ -s "$hop_dir/base-commit" ] && base="$(head -n1 "$hop_dir/base-commit")"
+  # Re-verify rather than trust the recorded value: a worker is free to gc,
+  # re-init or switch away, and an unresolvable revision would make git diff
+  # fail into an empty patch -- silently indistinguishable from "no changes".
+  # Degrading to the bare diff at least still shows unstaged work.
+  if [ -n "$base" ] \
+     && ! (cd "$cwd" 2>/dev/null \
+           && git rev-parse --verify "$base^{commit}" >/dev/null 2>&1); then
+    base=""
+  fi
   (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
   if [ -n "$base" ]; then
     (cd "$cwd" && git diff "$base") > "$ad/diff.patch" 2>/dev/null || true
@@ -484,7 +493,13 @@ _ccs_dispatch_run_one() {
   # diff must still show what attempt 1 changed, since a retry inherits the
   # working tree its predecessor left behind. Empty when cwd has no commit to
   # anchor to -- capture_evidence degrades explicitly on that.
-  (cd "$cwd" && git rev-parse HEAD 2>/dev/null || true) > "$hop_dir/base-commit"
+  # --verify, not a bare `git rev-parse HEAD`: in a repo with no commit yet the
+  # bare form prints the literal string "HEAD" on stdout (only the fatal goes to
+  # stderr), which would then be handed to git diff as a revision, fail, and be
+  # swallowed into an empty diff -- the exact vacuous evidence this fixes.
+  # --verify prints nothing there, so capture_evidence takes its fallback.
+  (cd "$cwd" 2>/dev/null && git rev-parse --verify HEAD 2>/dev/null || true) \
+    > "$hop_dir/base-commit"
 
   local attempt=1 verdict outcome="escalated" rc=10 term="ESCALATE"
   # ad is read after the loop; seed it so a budget that makes the loop body

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -363,6 +363,33 @@ _ccs_dispatch_chain_alloc_dir() {
   echo "$dir"
 }
 
+# Ground-truth evidence for one attempt: git status plus a diff anchored at the
+# hop's base commit (written by run_one before attempt 1).
+#
+# The anchor is the whole point. A bare `git diff` compares the working tree
+# against the INDEX, so a worker that runs `git add` empties it, and one that
+# commits empties `git diff HEAD` too -- leaving "the worker did nothing" and
+# "the worker did the work and staged it" identical in the only material Stage 2
+# is allowed to read. Nothing stops a worker from staging: it runs auto-approved
+# and the protocol never forbids it. The AC transcription rules already say
+# base-anchor instead of bare `git diff` for AC; this seam is the same trap in
+# the evidence path (issue #109).
+_ccs_dispatch_capture_evidence() { # $1=cwd $2=hop_dir $3=attempt_dir
+  local cwd="$1" hop_dir="$2" ad="$3" base=""
+  [ -s "$hop_dir/base-commit" ] && base="$(head -n1 "$hop_dir/base-commit")"
+  (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
+  if [ -n "$base" ]; then
+    (cd "$cwd" && git diff "$base") > "$ad/diff.patch" 2>/dev/null || true
+  else
+    # No usable base (cwd is not a git repo, or a repo with no commit yet).
+    # Keep the old behaviour rather than inventing a substitute: this seam is
+    # fail-soft by design elsewhere too, and a diff that silently means
+    # something different would be worse than a known limit. git-status.txt
+    # still names the touched paths.
+    (cd "$cwd" && git diff) > "$ad/diff.patch" 2>/dev/null || true
+  fi
+}
+
 # SPAWN SEAM. Real impl runs the executor synchronously (headless claude -p) in
 # <cwd> and captures evidence into attempt-NN/. Tests override this to simulate
 # worker edits. Scope C drives synchronous headless execution; the agentpager
@@ -419,8 +446,7 @@ _ccs_dispatch_run_worker() {
   if [ "$executor" = "wingman" ]; then
     cp "$cwd/.wingman/result.md" "$ad/wingman-result.md" 2>/dev/null || true
   fi
-  (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
-  (cd "$cwd" && git diff) > "$ad/diff.patch" 2>/dev/null || true
+  _ccs_dispatch_capture_evidence "$cwd" "$run_dir" "$ad"
   return 0
 }
 
@@ -454,6 +480,11 @@ _ccs_dispatch_run_one() {
 
   mkdir -p "$hop_dir"
   cp "$task_yaml" "$hop_dir/task.yaml"   # freeze (§1)
+  # Evidence anchor, recorded ONCE per hop rather than per attempt: attempt 2's
+  # diff must still show what attempt 1 changed, since a retry inherits the
+  # working tree its predecessor left behind. Empty when cwd has no commit to
+  # anchor to -- capture_evidence degrades explicitly on that.
+  (cd "$cwd" && git rev-parse HEAD 2>/dev/null || true) > "$hop_dir/base-commit"
 
   local attempt=1 verdict outcome="escalated" rc=10 term="ESCALATE"
   # ad is read after the loop; seed it so a budget that makes the loop body
@@ -1693,8 +1724,7 @@ _ccs_dispatch_run_worker_agentpager() {
   printf '%s\n' "$wrc" > "$ad/agentpager-wait-rc"
 
   # Ground-truth evidence (mirrors the headless seam).
-  (cd "$cwd" && git status --porcelain) > "$ad/git-status.txt" 2>/dev/null || true
-  (cd "$cwd" && git diff) > "$ad/diff.patch" 2>/dev/null || true
+  _ccs_dispatch_capture_evidence "$cwd" "$run_dir" "$ad"
   return 0
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -748,7 +748,7 @@ ${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/runs/<first-task-id>-cha
       prompt.md          # 實際送 worker 的 prompt
       executor-output.md # worker 原始輸出
       git-status.txt     # gate 當下 git status --porcelain
-      diff.patch         # git diff <base-commit>：錨在派工前的 commit，worker `git add` / `git commit` 都不會把它清空（base-commit 為空時退回裸 git diff）
+      diff.patch         # git diff <base-commit>：錨在派工前的 commit，worker `git add` / `git commit` 都不會把它清空（base-commit 為空、或該 revision 已不存在時退回裸 git diff——此時 staged 改動看不到，以 git-status.txt 為主）
       wingman-result.md  # 僅 wingman executor：scope.cwd/.wingman/result.md 凍結副本
       executor-exit-code # 僅 headless backend（claude / gemini / wingman 皆落）：worker process exit code（純 evidence，不參與 verdict）。backend: agentpager 沒有 process rc，對應證據是 agentpager-wait-rc
       worker-error       # 僅確定性基礎設施故障：故障類別單行（exit-125|126|127 / agentpager-daemon-down / agentpager-no-proj-map）；gate 據此發 ERROR

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -743,11 +743,12 @@ ${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/runs/<first-task-id>-cha
   chain.json             # 鏈結執行摘要（包含 hops 陣列、stopped_at_hop、stop_reason、outcome 與 depth 欄位）
   hop-01-<task-id-1>/
     task.yaml            # 凍結副本
+    base-commit          # 派工前的 scope.cwd HEAD（每 hop 記一次，diff 的錨點；非 git repo 或無 commit 時為空）
     attempt-01/
       prompt.md          # 實際送 worker 的 prompt
       executor-output.md # worker 原始輸出
       git-status.txt     # gate 當下 git status --porcelain
-      diff.patch         # git diff
+      diff.patch         # git diff <base-commit>：錨在派工前的 commit，worker `git add` / `git commit` 都不會把它清空（base-commit 為空時退回裸 git diff）
       wingman-result.md  # 僅 wingman executor：scope.cwd/.wingman/result.md 凍結副本
       executor-exit-code # 僅 headless backend（claude / gemini / wingman 皆落）：worker process exit code（純 evidence，不參與 verdict）。backend: agentpager 沒有 process rc，對應證據是 agentpager-wait-rc
       worker-error       # 僅確定性基礎設施故障：故障類別單行（exit-125|126|127 / agentpager-daemon-down / agentpager-no-proj-map）；gate 據此發 ERROR

--- a/docs/internal/state-file-lifecycle.md
+++ b/docs/internal/state-file-lifecycle.md
@@ -125,6 +125,13 @@ against `base-commit`, not against the index: a worker is free to stage or
 commit its own edits, and a bare `git diff` would then be empty — making "did
 nothing" and "did the work and staged it" identical in the evidence tree.
 
+Two limits of the anchor. It is per-hop, so in a chain whose earlier hop left
+its edits uncommitted, a later hop's `diff.patch` also carries them (the bare
+`git diff` behaved the same way; this is not new). And when no anchor can be
+resolved — `cwd` is not a git repo, has no commit yet, or the recorded revision
+no longer exists — capture falls back to the bare `git diff`, where a staged
+edit is again invisible and `git-status.txt` is the reliable material.
+
 `worker-error` exists only when the worker demonstrably never ran to
 completion and a retry cannot change that (`exit-125` / `exit-126` /
 `exit-127`, `agentpager-daemon-down`, `agentpager-no-proj-map`). Failures

--- a/docs/internal/state-file-lifecycle.md
+++ b/docs/internal/state-file-lifecycle.md
@@ -106,6 +106,7 @@ runs/<first_id>-chain-NN/
 ├── chain.json                     # chain-level summary (hops[], stop_reason, outcome, depth)
 └── hop-NN-<task_id>/
     ├── task.yaml                  # frozen at dispatch (AC immutable — §1 of the gate)
+    ├── base-commit                # cwd HEAD before attempt 1 — the diff anchor
     ├── attempt-NN/
     │   ├── prompt.md              # attempt 1 = goal; ≥2 = §6 feedback + goal
     │   ├── executor-output.md     # worker stdout+stderr
@@ -119,7 +120,10 @@ runs/<first_id>-chain-NN/
 
 `task.yaml` is frozen on entry — acceptance criteria must not change
 mid-run. The gate re-derives ground truth (`git-status.txt` / `diff.patch`)
-independently of the worker's self-report (see I4).
+independently of the worker's self-report (see I4). `diff.patch` is taken
+against `base-commit`, not against the index: a worker is free to stage or
+commit its own edits, and a bare `git diff` would then be empty — making "did
+nothing" and "did the work and staged it" identical in the evidence tree.
 
 `worker-error` exists only when the worker demonstrably never ran to
 completion and a retry cannot change that (`exit-125` / `exit-126` /

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -87,7 +87,9 @@ hop-NN-<task-id>/
 只讀 `diff.patch` + `git-status.txt`（`diff.patch` 錨在 hop 的
 `base-commit`，所以 worker 自行 `git add` / `git commit` 也看得到改動；但
 worker 新增的檔案是 untracked，**不會**出現在 diff.patch，要靠 `??` 行
-發現後另行讀檔）
+發現後另行讀檔。**`base-commit` 為空時**——`cwd` 非 git repo、或 repo 尚無
+commit——退回裸 `git diff`，此時 staged 改動看不到，判讀請以
+`git-status.txt` 為主）
 + `gate/verdict.json` + guidance-AC 清單，**不要重讀 worker trace**
 （fresh-context 紀律；executor-output.md 只在鑑識時看）。你裁決的是 script 抓不到的：是不是對的解、設計
 好不好、guidance-AC 過不過。

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -69,6 +69,7 @@ ccs-dispatch-run <task.yaml>
 chain.json                     # 鏈終態：hops[]、stop_reason、outcome
 hop-NN-<task-id>/
 ├── task.yaml                  # dispatch 當下凍結的驗收條件
+├── base-commit                # 派工前的 cwd HEAD，diff.patch 的錨點
 ├── final.json                 # 本 hop 終態：outcome / attempts / worker_rc
 └── attempt-NN/
     ├── prompt.md              # worker 收到的完整 prompt
@@ -83,8 +84,10 @@ hop-NN-<task-id>/
 
 ### 4. Judgment review（Stage 2）
 
-只讀 `diff.patch` + `git-status.txt`（worker 新增的檔案是
-untracked，**不會**出現在 diff.patch，要靠 `??` 行發現後另行讀檔）
+只讀 `diff.patch` + `git-status.txt`（`diff.patch` 錨在 hop 的
+`base-commit`，所以 worker 自行 `git add` / `git commit` 也看得到改動；但
+worker 新增的檔案是 untracked，**不會**出現在 diff.patch，要靠 `??` 行
+發現後另行讀檔）
 + `gate/verdict.json` + guidance-AC 清單，**不要重讀 worker trace**
 （fresh-context 紀律；executor-output.md 只在鑑識時看）。你裁決的是 script 抓不到的：是不是對的解、設計
 好不好、guidance-AC 過不過。

--- a/tests/test-dispatch-evidence-base.sh
+++ b/tests/test-dispatch-evidence-base.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-evidence-base.sh — attempt evidence is anchored at the
+# hop's base commit, so a worker cannot empty it by staging (issue #109).
+#
+# What the old bare `git diff` cost: Stage 2 is allowed to read only
+# diff.patch / git-status.txt / verdict.json, and a worker that ran `git add`
+# left diff.patch empty -- indistinguishable from a worker that did nothing.
+# The worker runs auto-approved and nothing forbids it from staging or
+# committing, so this cannot be left to worker discipline.
+#
+# The negative control matters as much as the positive cases: an evidence path
+# that is non-empty no matter what the worker did would pass every assertion
+# below except that one, while telling Stage 2 nothing.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-evidence-base-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-evidence-base"; rm -rf "$WORK"
+mkdir -p "$WORK/repo" "$WORK/bin"; _TEST_DIRS+=("$WORK")
+
+# Fake claude on PATH (precedent: test-gate-worker-error.sh). FAKE_CLI_MODE
+# selects what the "worker" does to the repo, which is the whole variable under
+# test -- the real executor's behaviour here is unconstrained.
+cat > "$WORK/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+cd "$FAKE_REPO" || exit 1
+case "${FAKE_CLI_MODE:-none}" in
+  edit)     printf 'worker line\n' >> tracked.txt ;;
+  stage)    printf 'worker line\n' >> tracked.txt; git add tracked.txt ;;
+  commit)   printf 'worker line\n' >> tracked.txt; git add tracked.txt
+            git -c user.email=w@t -c user.name=w commit -qm "worker commit" ;;
+  new)      printf 'brand new\n' > untracked.txt ;;
+  none)     : ;;
+esac
+exit 0
+FAKE
+chmod +x "$WORK/bin/claude"
+export PATH="$WORK/bin:$PATH"
+
+CWD="$WORK/repo"; export FAKE_REPO="$CWD"
+(cd "$CWD" && git init -q \
+  && printf 'base line\n' > tracked.txt \
+  && git add tracked.txt \
+  && git -c user.email=t@t -c user.name=t commit -qm base)
+BASE="$(cd "$CWD" && git rev-parse HEAD)"
+
+HOP="$WORK/hop"; mkdir -p "$HOP"
+printf '%s\n' "$BASE" > "$HOP/base-commit"
+
+# spawn <attempt> <mode> -> attempt dir. Restores the repo to the base commit
+# first, so each case starts from the same world.
+spawn() {
+  local attempt="$1" mode="$2"
+  (cd "$CWD" && git reset -q --hard "$BASE" && git clean -qfd)
+  export FAKE_CLI_MODE="$mode"
+  _ccs_dispatch_run_worker "$CWD" "do X" "$HOP" "$attempt" 60 claude
+  printf '%s\n' "$HOP/attempt-$(printf '%02d' "$attempt")"
+}
+
+echo "=== a staged edit stays visible in evidence (the reported bug) ==="
+ad="$(spawn 1 stage)"
+assert_eq "the stub really staged (otherwise this proves nothing)" "yes" \
+  "$( (cd "$CWD" && git diff --quiet) && echo yes || echo no )"
+assert_contains "staged edit appears in diff.patch" \
+  "$(cat "$ad/diff.patch")" "worker line"
+
+echo "=== a committed edit stays visible (only base-anchoring passes this) ==="
+ad="$(spawn 2 commit)"
+assert_eq "the stub really committed" "yes" \
+  "$( (cd "$CWD" && git diff HEAD --quiet) && echo yes || echo no )"
+assert_contains "committed edit appears in diff.patch" \
+  "$(cat "$ad/diff.patch")" "worker line"
+
+echo "=== an unstaged edit still works (no regression) ==="
+ad="$(spawn 3 edit)"
+assert_contains "unstaged edit appears in diff.patch" \
+  "$(cat "$ad/diff.patch")" "worker line"
+
+echo "=== negative control: a worker that did nothing leaves it empty ==="
+ad="$(spawn 4 none)"
+assert_eq "diff.patch empty when the repo is untouched" "0" \
+  "$(wc -c < "$ad/diff.patch" | tr -d ' ')"
+assert_eq "git-status.txt empty too" "0" \
+  "$(wc -c < "$ad/git-status.txt" | tr -d ' ')"
+
+echo "=== a new file is untracked: status names it, diff cannot ==="
+ad="$(spawn 5 new)"
+assert_contains "untracked file visible in git-status.txt" \
+  "$(cat "$ad/git-status.txt")" "?? untracked.txt"
+assert_eq "diff.patch still empty for an untracked-only change" "0" \
+  "$(wc -c < "$ad/diff.patch" | tr -d ' ')"
+
+echo "=== no usable base: degrade to the old behaviour, do not crash ==="
+NOBASE="$WORK/hop-nobase"; mkdir -p "$NOBASE"
+(cd "$CWD" && git reset -q --hard "$BASE" && git clean -qfd)
+export FAKE_CLI_MODE=edit
+_ccs_dispatch_run_worker "$CWD" "do X" "$NOBASE" 1 60 claude
+ad="$NOBASE/attempt-01"
+assert_contains "unstaged edit still captured without base-commit" \
+  "$(cat "$ad/diff.patch")" "worker line"
+assert_eq "evidence files exist rather than aborting" "yes" \
+  "$([ -f "$ad/git-status.txt" ] && echo yes || echo no)"
+
+echo "=== integration: run_one records the base before the first attempt ==="
+# Without this the helper above would read a base-commit nobody writes, and the
+# fix would be dead code in production while every unit case still passed.
+cat > "$WORK/task.yaml" <<YAML
+id: ev
+goal: "touch a file"
+scope: { cwd: "$CWD" }
+acceptance_criteria:
+  - id: AC1
+    desc: "file changed"
+    verify: { cmd: "git diff --quiet tracked.txt || true" }
+YAML
+(cd "$CWD" && git reset -q --hard "$BASE" && git clean -qfd)
+SEEN_BASE=""
+_ccs_dispatch_run_worker() {  # seam override: observe what run_one left us
+  local hop="$3"
+  SEEN_BASE="$(head -n1 "$hop/base-commit" 2>/dev/null)"
+  mkdir -p "$hop/attempt-$(printf '%02d' "$4")"
+  return 0
+}
+task_json="$(_ccs_dispatch_gate_load_task "$WORK/task.yaml")"
+_ccs_dispatch_run_one "$task_json" "$WORK/task.yaml" "$WORK/hop-int" >/dev/null
+assert_eq "run_one writes the hop's base commit before spawning" "$BASE" \
+  "$SEEN_BASE"
+
+test_summary

--- a/tests/test-dispatch-evidence-base.sh
+++ b/tests/test-dispatch-evidence-base.sh
@@ -104,6 +104,35 @@ assert_contains "unstaged edit still captured without base-commit" \
 assert_eq "evidence files exist rather than aborting" "yes" \
   "$([ -f "$ad/git-status.txt" ] && echo yes || echo no)"
 
+echo "=== a repo with no commit yet: still shows the work (found by review) ==="
+# `git rev-parse HEAD` prints the literal string "HEAD" on stdout in a repo with
+# no commit -- only the fatal goes to stderr. Recording that as the base fed an
+# invalid revision to git diff, which failed into an empty patch: the very
+# vacuous evidence this change exists to remove, and a regression against the
+# bare `git diff` it replaced. Hence --verify, whose stdout is empty here.
+FRESH="$WORK/fresh"; mkdir -p "$FRESH"
+# tracked.txt, staged but never committed: the stub appends to that name, and a
+# bare `git diff` only shows a path git already knows about.
+(cd "$FRESH" && git init -q && printf 'base line\n' > tracked.txt \
+  && git add tracked.txt)
+FHOP="$WORK/hop-fresh"; mkdir -p "$FHOP"
+printf '' > "$FHOP/base-commit"
+FAKE_REPO="$FRESH" FAKE_CLI_MODE=edit \
+  _ccs_dispatch_run_worker "$FRESH" "do X" "$FHOP" 1 60 claude
+assert_contains "staged-but-uncommitted repo still yields a diff" \
+  "$(cat "$FHOP/attempt-01/diff.patch")" "worker line"
+
+echo "=== an unresolvable base degrades instead of emptying the diff ==="
+# A worker may gc, re-init or switch away; a stale sha would make git diff fail
+# into an empty patch. Re-verifying turns that into the no-base fallback.
+GONE="$WORK/hop-gone"; mkdir -p "$GONE"
+printf '%s\n' "0000000000000000000000000000000000000000" > "$GONE/base-commit"
+(cd "$CWD" && git reset -q --hard "$BASE" && git clean -qfd)
+export FAKE_CLI_MODE=edit
+_ccs_dispatch_run_worker "$CWD" "do X" "$GONE" 1 60 claude
+assert_contains "unresolvable base falls back to the bare diff" \
+  "$(cat "$GONE/attempt-01/diff.patch")" "worker line"
+
 echo "=== integration: run_one records the base before the first attempt ==="
 # Without this the helper above would read a base-commit nobody writes, and the
 # fix would be dead code in production while every unit case still passed.
@@ -127,6 +156,25 @@ _ccs_dispatch_run_worker() {  # seam override: observe what run_one left us
 task_json="$(_ccs_dispatch_gate_load_task "$WORK/task.yaml")"
 _ccs_dispatch_run_one "$task_json" "$WORK/task.yaml" "$WORK/hop-int" >/dev/null
 assert_eq "run_one writes the hop's base commit before spawning" "$BASE" \
+  "$SEEN_BASE"
+
+# Same seam, no-commit repo: this is what pins --verify. A bare `git rev-parse
+# HEAD` records the literal "HEAD" here, and every unit case above would still
+# pass while production wrote an unusable anchor.
+cat > "$WORK/task-fresh.yaml" <<YAML
+id: evf
+goal: "touch a file"
+scope: { cwd: "$FRESH" }
+acceptance_criteria:
+  - id: AC1
+    desc: "no-op"
+    verify: { cmd: "true" }
+YAML
+SEEN_BASE="unset"
+task_json="$(_ccs_dispatch_gate_load_task "$WORK/task-fresh.yaml")"
+_ccs_dispatch_run_one "$task_json" "$WORK/task-fresh.yaml" \
+  "$WORK/hop-int-fresh" >/dev/null
+assert_eq "run_one records an empty base in a no-commit repo, not \"HEAD\"" "" \
   "$SEEN_BASE"
 
 test_summary


### PR DESCRIPTION
## Summary

`ccs-dispatch.sh` 兩處收 attempt evidence 的呼叫點都用裸 `git diff`（比 working
tree vs index）。worker 只要對自己的改動下過 `git add`，`diff.patch` 就是空檔；
再 `git commit`，`git diff HEAD` 也一起乾淨。Stage 2 只准讀 `diff.patch` /
`git-status.txt` / `verdict.json`，於是「worker 什麼都沒做」與「做完並 staged」
在唯一可讀的材料裡不可區分。worker 以 auto-approve 跑、協定從未禁止它 stage，
靠 worker 自律無效。

順帶消掉一個自相矛盾：`skills/ccs-dispatch-run/references/task-yaml.md` 的 AC
撰寫紀律剛明文禁止 AC 用裸 `git diff`（PR #108），實作端自己還在用。

## Changes

- `fix(dispatch): anchor attempt evidence at the hop's base commit` — 新 helper
  `_ccs_dispatch_capture_evidence`（headless 與 agentpager 兩個 seam 共用）；
  `_ccs_dispatch_run_one` **每 hop 記一次** `base-commit`（非每 attempt——重派
  繼承前一輪的 working tree，attempt-2 的 evidence 必須含 attempt-1 的改動）；
  新測試 `tests/test-dispatch-evidence-base.sh`。
- `docs(dispatch): record the evidence diff anchor in the layout docs` — evidence
  layout 三處同步（`docs/commands.md`、`docs/internal/state-file-lifecycle.md`、
  已分發的 `skills/ccs-dispatch-run/SKILL.md` 的 Stage 2 段）。
- `fix(dispatch): verify the anchor instead of trusting rev-parse output` —
  回應獨立 review 的 blocking，見下方 Reviewer summary。

## Test plan (reviewer checklist)

- [x] worker `git add` 後 evidence `diff.patch` 非空
- [x] worker `git commit` 後 evidence 仍非空（只有 base-anchored 過得了）
- [x] 負向對照：worker 什麼都沒做 → `diff.patch` 空（區分得出「沒做」與「做了
      但被 stage」）
- [x] 新建檔案：`git-status.txt` 看得到 `??`，`diff.patch` 仍空（已知限制，
      文件已明寫）
- [x] 無可用 base（非 git repo / 無 commit / 錨已不存在）→ 退回裸 `git diff`，
      不崩、不產出誤導的空 diff
- [x] `run_one` 真的在第一次 attempt 前寫 `base-commit`（否則修法在生產路徑
      等於死碼）
- [x] 全套 `tests/run-all.sh` 無回歸

## Test results (author 已驗)

**Unit tests：** `bash tests/test-dispatch-evidence-base.sh` → 15 passed, 0
failed。`bash tests/run-all.sh` → **Total 52 / Passed 52 / Failed 0 / Skipped 1**
（review 修完後重跑一次，結果相同）。

**E2E tests：** N/A — 本 repo 無 E2E harness；evidence seam 的等價驗證是上面那
支測試，它用 fake CLI on PATH 走真的 `_ccs_dispatch_run_worker`（沿用
`test-gate-worker-error.sh` 的 harness），不是 mock 掉 seam 本身。

**Smoke tests：** N/A（shell 函式層變更，無裝置面）。改以 **mutation 實測**
代替：由 plan 作者 / 驗收者執行，非實作者自證。

- 改回裸 `git diff` → staged / committed 兩條紅
- 改用 `git diff HEAD`（較弱的修法）→ 只有 committed 那條紅
- 拿掉 `run_one` 的 `base-commit` 寫入 → 只有 integration 那條紅（unit 仍綠，
  因為 unit 自帶 `base-commit`，隔離正確）
- 讓 `diff.patch` 恆含改動字樣 → 兩條負向對照紅
- `run_one` 改回裸 `git rev-parse HEAD` → 新增的 no-commit 那條紅
- 拿掉讀取時的錨再驗證 → 錨失效那條紅

## Reviewer summary

獨立 review（fresh context、非作者）**verdict: REQUEST-CHANGES**，抓到 1 blocking
＋ 5 non-blocking。完整 report 貼為本 PR 的 comment。

**Blocking（已修）**：「無 commit 的 repo」那條 fallback 永遠走不到。
`git rev-parse HEAD` 在還沒有任何 commit 的 repo 會把**字面 `HEAD` 印到
stdout**（只有 fatal 走 stderr）→ `base-commit` 非空 → `git diff HEAD` rc=128
被 `2>/dev/null || true` 吞掉 → `diff.patch` 空。該 case **相對 master 是行為
退步**（裸 `git diff` 看得到改動）。修法 `git rev-parse --verify HEAD`，並在
讀取時再驗證一次錨是否解得開（涵蓋 worker gc / re-init 的一般形）。

**測試本身也被 review 打中**：原先兩條新 case 自己寫 `base-commit`，因此只測到
`capture_evidence`、測不到 `run_one` 用哪種 `rev-parse` 形式——mutation 才讓這個
假覆蓋現形。已改成走 `run_one` 的 seam override 斷言。

**我沒能驗證的**：agentpager 那個呼叫點（`ccs-dispatch.sh` 第二處 seam）**無測試
覆蓋**，其 reachability 是靠讀 code 確認（`run_worker` → agentpager 分支 → 同一
helper），不是靠測試。風險評估為低（同一 helper 的複製呼叫），但這是本 PR 唯一
只有靜態依據的斷言。

**我單方面決定的**：(a) 錨失效時只退回裸 diff、**不**落錯誤訊號檔（見
carry-forward 第 1 項）；(b) untracked 檔不進 diff 的限制不修——`git add -N` 會
污染 worker 的 index，代價大於收益，改以文件明寫。

## Carry-forward Minor items

- 錨解析失敗（gc / re-init / 錯 sha）目前靜默退回裸 diff，evidence 樹裡沒有
  「錨失效」訊號。建議落 `diff-error.txt`（git rc 或 stderr）——會新增 evidence
  面，需同步三份文件，故另案。
- agentpager seam 的 evidence 收集零測試覆蓋（全 repo 沒有其他測試斷言 evidence
  檔內容）。
- `verify.cmd` 執行時沒有 export 任何 base 相關變數，所以 `task-yaml.md` 教 AC
  作者自己 `BASE=$(git rev-parse HEAD)` 與 `run_one` 記的 `base-commit` 是兩套
  獨立紀錄。把 base 餵成 env 給 `verify.cmd` 能讓兩者收斂。
- 三種 inline 標籤寫法在跨 repo 之間不一致（`inline`／`inline desktop`／
  `inline (desktop Path A)`）——契約 §0 明說路徑名稱 repo-specific，故不違約。

## Related

- Issue: #109
- 前置 / 起源：PR #108 的獨立 review 在查證新增條文時發現，非實跑遭遇
- Scope decision：本 repo `tmp/backlog.md` § 0（不進版控）

---

**Provenance**
- Model: Claude Opus 5 (1M context) · effort high
- Channel: Claude Code(agent-pager Path B,telegram slot 1)
