### PR TITLE
feat(dispatch): grok gated executor and headless env scrub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ diff 命中以下任一面 → 必跑 Change Impact Analysis 並貼為 PR commen
   消費）、`ccs-health.sh` 的 `_ccs_health_badge_md` / `_ccs_health_events` /
   `_ccs_health_score`（被 `ccs-overview.sh` 消費）。
 - **後端 / executor 分流點**：`ccs-dispatch.sh` 的 backend 選擇
-  （`headless` ↔ `agentpager`）與 executor 分派（`claude` / `gemini` / `wingman`）。
+  （`headless` ↔ `agentpager`）與 executor 分派（`claude` / `gemini` / `wingman` / `grok`）。
 - **task.yaml schema**（對外契約）：`_ccs_dispatch_gate_load_task` 的 jq 驗證。
   使用者的 task 檔與已分發的 `skills/ccs-dispatch-run` 共同依賴它，加一個必填欄位
   會讓既有 task.yaml 全部 validation 失敗（對應文件
@@ -133,9 +133,10 @@ diff 命中以下任一面 → 必跑 Change Impact Analysis 並貼為 PR commen
 本 repo 有四條變體軸，填該欄時逐條比對，不適用者明寫「無」：
 
 - **Provider**：Claude `[C]` ↔ Gemini `[G]` 的 session 收集與解析（ADR-002 duck-typing）
-- **Executor**：`claude` / `gemini` / `wingman`（wingman 無 model 旗標、僅作
+- **Executor**：`claude` / `gemini` / `wingman` / `grok`（wingman 無 model 旗標、僅作
   provenance，且 FAIL 直接 escalate 不 retry；`backend=agentpager` 與
-  `executor=wingman` 互斥，schema 層直接擋）
+  `executor=wingman` 互斥，schema 層直接擋。grok 有 `-m`，retry 同
+  claude/gemini；`backend=agentpager` + grok 合法）
 - **Backend**：`headless` ↔ `agentpager`。**兩個分流點行為不同，須分開比對**——
   別套用單一的「同步 / 非同步」標籤，那在兩邊都不成立：
   - **gate-run**（task.yaml 的 `.backend`）：兩者皆同步，agentpager 走前景阻塞

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -99,7 +99,7 @@ _ccs_dispatch_gate_load_task() {
     and ((.next == null) or (.next | type == "string" and (length > 0)))
     and ((.executor == null) or
          (.executor | type == "string"
-          and (. == "claude" or . == "gemini" or . == "wingman")))
+          and (. == "claude" or . == "gemini" or . == "wingman" or . == "grok")))
     and ((.model == null) or (.model | type == "string" and (length > 0)))
     and (if .executor == "wingman"
          then (.plan | type == "string" and (length > 0))
@@ -434,21 +434,25 @@ _ccs_dispatch_run_worker() {
   fi
   local ad="$run_dir/attempt-$(printf '%02d' "$attempt")"
   mkdir -p "$ad"
-  # claude/gemini need auto-approve: headless has no tty, so a permission
+  # claude/gemini/grok need auto-approve: headless has no tty, so a permission
   # prompt hangs until the wall-clock timeout (claude -p without a permission
   # mode stalls on the first edit tool and produces zero output/changes). The
   # deterministic gate re-runs every verify.cmd against ground truth, so an
   # auto-approved false-success is caught (see
   # docs/case-studies/gemini-yolo-overconfidence.md). claude is the default.
-  # wingman is file-driven (plan.md in, .wingman/result.md out) and ignores
-  # the prompt; --exit-status maps overall_status to the exit code, which is
-  # recorded as evidence only -- the gate stays the sole verdict source.
+  # grok --output-format plain keeps evidence as prose (the CLI has no `text`
+  # value; a typo is clap-rejected). wingman is file-driven (plan.md in,
+  # .wingman/result.md out) and ignores the prompt; --exit-status maps
+  # overall_status to the exit code, which is recorded as evidence only -- the
+  # gate stays the sole verdict source.
   # A declared model is pinned per CLI (the flags differ and are not
   # interchangeable); omitting it keeps the CLI's own saved default. wingman is
   # file-driven and has no model flag, so it ignores the field.
   local cmd
   case "$executor" in
     gemini)  cmd=(gemini -p "$prompt" --approval-mode yolo)
+             [ -n "$model" ] && cmd+=(-m "$model") ;;
+    grok)    cmd=(grok -p "$prompt" --always-approve --output-format plain)
              [ -n "$model" ] && cmd+=(-m "$model") ;;
     wingman) cmd=(wingman execute --plan "$plan_abs" --exit-status) ;;
     *)       cmd=(claude -p "$prompt" --permission-mode bypassPermissions)

--- a/ccs-dispatch.sh
+++ b/ccs-dispatch.sh
@@ -399,6 +399,22 @@ _ccs_dispatch_capture_evidence() { # $1=cwd $2=hop_dir $3=attempt_dir
   fi
 }
 
+# Run <cmd...> under timeout with the AGENT_PAGER_* namespace stripped from the
+# child. Headless workers inherit the orchestrator's env today, so a
+# pager-launched parent leaks NOTIFY/BOT_SLOT/SESSION_TREE into the CLI; the
+# child's hooks then relay as the parent slot (issue #114). `env -u` is
+# child-only — the caller keeps wake/notify/seat. An empty namespace is a
+# passthrough (`env cmd`). timeout stays the outermost wrapper so it still
+# reaps both env and the CLI.
+_ccs_dispatch_timeout_scrubbed() {
+  local timeout_sec="$1"; shift
+  local scrub=() v
+  while IFS= read -r v; do
+    [ -n "$v" ] && scrub+=(-u "$v")
+  done < <(compgen -v AGENT_PAGER_ 2>/dev/null || true)
+  timeout "$timeout_sec" env "${scrub[@]}" "$@"
+}
+
 # SPAWN SEAM. Real impl runs the executor synchronously (headless claude -p) in
 # <cwd> and captures evidence into attempt-NN/. Tests override this to simulate
 # worker edits. Scope C drives synchronous headless execution; the agentpager
@@ -439,7 +455,7 @@ _ccs_dispatch_run_worker() {
              [ -n "$model" ] && cmd+=(--model "$model") ;;
   esac
   local wrc=0
-  (cd "$cwd" && timeout "$timeout_sec" "${cmd[@]}") \
+  (cd "$cwd" && _ccs_dispatch_timeout_scrubbed "$timeout_sec" "${cmd[@]}") \
     > "$ad/executor-output.md" 2>&1 || wrc=$?
   # Every executor records its rc: a crashed worker, a missing CLI and a
   # worker that ran and did nothing are otherwise indistinguishable in the
@@ -1777,21 +1793,25 @@ _ccs_dispatch_spawn_headless() {
   if [ "$mode" = "sync" ]; then
     local rc=0
     (cd "$project_dir" && \
-      timeout "$timeout_secs" claude -p "$(cat "$prompt_file")") \
+      _ccs_dispatch_timeout_scrubbed "$timeout_secs" \
+        claude -p "$(cat "$prompt_file")") \
       > "$dispatch_dir/results/${job_id}.raw" \
       2> "$dispatch_dir/results/${job_id}.err" \
       || rc=$?
     _ccs_dispatch_finish "$job_id" "$rc"
     return $rc
   else
+    # Source first so the wrapper can call the same scrub helper as the
+    # sync path. Finish still runs in this wrapper (not under env -u), so
+    # wake/notify keep the orchestrator's AGENT_PAGER_* .
     nohup bash -c '
+      source "$6/ccs-dashboard.sh"
       prompt=$(cat "$1")
       cd "$2" && \
-      timeout "$3" claude -p "$prompt" \
+      _ccs_dispatch_timeout_scrubbed "$3" claude -p "$prompt" \
         > "$4/results/$5.raw" \
         2> "$4/results/$5.err"
       rc=$?
-      source "$6/ccs-dashboard.sh"
       _ccs_dispatch_finish "$5" $rc
     ' _ \
       "$prompt_file" \

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -651,7 +651,7 @@ hops:
   以 spec 位置為心智模型寫相對路徑會 silently 錯位。
 - out dir 預設 `<spec 所在目錄>/chain`，可 `--out` 覆寫。
 - 每份產出立即以 gate 自身的 task loader 驗證（≥1 AC、≥1 `verify.cmd`、
-  executor ∈ {claude,gemini,wingman}、AC id 唯一）。任一 hop 不合法 → 不產出任何檔、非零 exit。
+  executor ∈ {claude,gemini,wingman,grok}、AC id 唯一）。任一 hop 不合法 → 不產出任何檔、非零 exit。
 - 成功時 entry path（`hop-01-*`）印到 stdout，可直接組合：
   `ccs-dispatch-run "$(ccs-dispatch-plan spec.yaml)"`。
 
@@ -726,8 +726,8 @@ id: task-x                      # slug，也是 run-id 前綴
 goal: "新增 greeter 並被 CLI 呼叫"
 scope:
   cwd: "/abs/path/to/project"   # worker 執行與 gate 驗收的目錄
-executor: gemini                # 可選：claude(預設) | gemini | wingman。claude/gemini 皆 auto-approve 跑 headless（claude `--permission-mode bypassPermissions`、gemini `--approval-mode yolo`）— 無 tty 下權限 prompt 會卡到 timeout；gate 為信任邊界，見 §8.4
-backend: agentpager             # 可選：headless(預設) | agentpager。agentpager 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 worker 的 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）。executor 映射為互動 worker CLI（claude|gemini）；`agentpager` + `executor: wingman` 不合法（wingman 非可互動 launch 的 CLI）。見下方「backend: agentpager」
+executor: gemini                # 可選：claude(預設) | gemini | wingman | grok。claude/gemini/grok 皆 auto-approve 跑 headless（claude `--permission-mode bypassPermissions`、gemini `--approval-mode yolo`、grok `--always-approve --output-format plain`）— 無 tty 下權限 prompt 會卡到 timeout；gate 為信任邊界，見 §8.4
+backend: agentpager             # 可選：headless(預設) | agentpager。agentpager 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 worker 的 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）。executor 映射為互動 worker CLI（claude|gemini|grok）；`agentpager` + `executor: wingman` 不合法（wingman 非可互動 launch 的 CLI）。見下方「backend: agentpager」
 model: "local-chat-35b"         # 可選：本次執行的 model。headless 帶 -m/--model、agentpager 寫進 launch 檔的 model: 欄；缺省 = 沿用 CLI 自己的預設。wingman 無 model 旗標，僅作 provenance。同時供收尾 X-Executor trailer 的 <model> 段
 plan: "plan.md"                 # 僅 executor: wingman（互為充要）：wingman plan.md 路徑，相對本檔所在目錄解析（同 next:）；由主 session 依 wingman plan-template 撰寫
 next: "task-y.yaml"             # 可選：下一個要自動執行與驗收的任務路徑（相對於此 yaml）
@@ -760,7 +760,7 @@ ${XDG_DATA_HOME:-~/.local/share}/ccs-dashboard/dispatch/runs/<first-task-id>-cha
       git-status.txt     # gate 當下 git status --porcelain
       diff.patch         # git diff <base-commit>：錨在派工前的 commit，worker `git add` / `git commit` 都不會把它清空（base-commit 為空、或該 revision 已不存在時退回裸 git diff——此時 staged 改動看不到，以 git-status.txt 為主）
       wingman-result.md  # 僅 wingman executor：scope.cwd/.wingman/result.md 凍結副本
-      executor-exit-code # 僅 headless backend（claude / gemini / wingman 皆落）：worker process exit code（純 evidence，不參與 verdict）。backend: agentpager 沒有 process rc，對應證據是 agentpager-wait-rc
+      executor-exit-code # 僅 headless backend（claude / gemini / wingman / grok 皆落）：worker process exit code（純 evidence，不參與 verdict）。backend: agentpager 沒有 process rc，對應證據是 agentpager-wait-rc
       worker-error       # 僅確定性基礎設施故障：故障類別單行（exit-125|126|127 / agentpager-daemon-down / agentpager-no-proj-map）；gate 據此發 ERROR
       launch-file.txt    # 僅 backend: agentpager：寫給 agent-pager 的 inbound launch 檔路徑
       handoff.md         # 僅 backend: agentpager：worker per-attempt 完成訊號 handoff 副本
@@ -784,7 +784,7 @@ CCS_DISPATCH_GATE_CMD_TAIL_CHARS=2000  # per-AC stdout/stderr 擷取尾端字元
 
 > **安全註記（§8.4）：** AC `verify.cmd` 會執行 worker 產出的 code（`pytest`、`python -c` 等，驗證本質使然），僅靠 `execution_policy.timeout_sec` 設界。只對「你本就願意在本機執行」的 worker 開跑；不加 network / write-path 限制（單人本地 MVP）。
 
-**backend: agentpager（互動 worker 進 gate）：** 預設 `backend: headless` 走同步 headless CLI；`backend: agentpager` 讓 gate worker 改跑在 agent-pager 互動 local channel（tmux、可監看/中途接管），把「gate 驗收 + 重派」與「可觀察互動 worker」合流（issue #91）。實作為**前景阻塞式 spawn+wait**：寫 inbound launch → 等 worker 寫 per-attempt handoff 檔（`tmp/handoff-<hop>-a<NN>.md`）為完成訊號 → 收回單一 per-user seat → 回來後 gate 照常對現實跑 `verify.cmd`（handoff 內容不採信，gate 仍是唯一裁決來源）。**重派＝Option B**：gate 判 RETRY 時，attempt 迴圈重新前景 spawn 一個 fresh 互動 hop、把上輪 machine 事實 feedback 前綴進 prompt（與 headless 對稱；不同於 `wingman` 的不重派）。**bounded wait**：先有 startup grace 等 worker session 出現（`CCS_DISPATCH_AGENTPAGER_STARTUP`，預設 60s），再以 `execution_policy.timeout_sec` 綁定 completion 等待——逾時未見 handoff 即收回 seat、當作未完成（gate 隨即 FAIL）。故最壞上界約 startup + timeout。gate 路徑本質 autonomous，與 jobs/`--chain` 互動路徑的「no wall-clock kill（D2）」互不相干。`executor` 映射為互動 worker CLI（claude|gemini）；`agentpager` + `wingman` 不合法（wingman 非可互動 launch）。auth 註記：互動 gemini worker 的 `GOOGLE_CLOUD_PROJECT` 由 agent-pager runner daemon 的 process env 繼承（worker 經 `bash -c` 起、不 source `.bashrc`），非結構性保證；持久修復屬 agent-pager 側。
+**backend: agentpager（互動 worker 進 gate）：** 預設 `backend: headless` 走同步 headless CLI；`backend: agentpager` 讓 gate worker 改跑在 agent-pager 互動 local channel（tmux、可監看/中途接管），把「gate 驗收 + 重派」與「可觀察互動 worker」合流（issue #91）。實作為**前景阻塞式 spawn+wait**：寫 inbound launch → 等 worker 寫 per-attempt handoff 檔（`tmp/handoff-<hop>-a<NN>.md`）為完成訊號 → 收回單一 per-user seat → 回來後 gate 照常對現實跑 `verify.cmd`（handoff 內容不採信，gate 仍是唯一裁決來源）。**重派＝Option B**：gate 判 RETRY 時，attempt 迴圈重新前景 spawn 一個 fresh 互動 hop、把上輪 machine 事實 feedback 前綴進 prompt（與 headless 對稱；不同於 `wingman` 的不重派）。**bounded wait**：先有 startup grace 等 worker session 出現（`CCS_DISPATCH_AGENTPAGER_STARTUP`，預設 60s），再以 `execution_policy.timeout_sec` 綁定 completion 等待——逾時未見 handoff 即收回 seat、當作未完成（gate 隨即 FAIL）。故最壞上界約 startup + timeout。gate 路徑本質 autonomous，與 jobs/`--chain` 互動路徑的「no wall-clock kill（D2）」互不相干。`executor` 映射為互動 worker CLI（claude|gemini|grok）；`agentpager` + `wingman` 不合法（wingman 非可互動 launch）。auth 註記：互動 gemini worker 的 `GOOGLE_CLOUD_PROJECT` 由 agent-pager runner daemon 的 process env 繼承（worker 經 `bash -c` 起、不 source `.bashrc`），非結構性保證；持久修復屬 agent-pager 側。
 
 **Scope C 限制（後續 sprint 補）：** 無 tier ladder（重派用同一 executor）、無 pager escalation ladder、不接 `--chain`（gated chain 續鏈為獨立層）、無 Stage-2 judgment review 自動化、guidance-AC 一律 SKIPPED_FOR_LLM。evidence 目前全留（未來加 TTL）。orchestrator-wake（worker 完成回灌派工 session）為獨立 followup。
 

--- a/skills/ccs-dispatch-run/SKILL.md
+++ b/skills/ccs-dispatch-run/SKILL.md
@@ -125,10 +125,11 @@ PASS 後自動跟 `next:`（相對於當前 task.yaml 所在目錄解析）。
 ## 邊界（現行實作 = Scope C）
 
 - gate + 單次重派；無 tier ladder（重派同 executor）
-- executor 為 `claude`（預設）/ `gemini` / `wingman`；claude 與
-  gemini 以 auto-approve 跑 headless（claude
+- executor 為 `claude`（預設）/ `gemini` / `wingman` / `grok`；claude、
+  gemini 與 grok 以 auto-approve 跑 headless（claude
   `--permission-mode bypassPermissions`、gemini
-  `--approval-mode yolo`）— **gate 為信任邊界**：worker 全權限執行
+  `--approval-mode yolo`、grok `--always-approve --output-format plain`）—
+  **gate 為信任邊界**：worker 全權限執行
   於 `scope.cwd`，假成功由 gate 重驗現實攔下；task 應只來自你自己
   的規劃，勿餵不受信任的 goal
 - `executor: wingman`（本地 LLM，免 quota）為檔案驅動：task 需帶

--- a/skills/ccs-dispatch-run/references/task-yaml.md
+++ b/skills/ccs-dispatch-run/references/task-yaml.md
@@ -11,9 +11,9 @@
 | `id` | Yes | 非空字串；同時是 run 目錄名前綴 |
 | `goal` | Yes | 非空字串；worker 收到的任務描述全文 |
 | `scope.cwd` | No | worker 執行與 gate 驗收目錄；預設 `.`（呼叫時的 cwd）；建議寫絕對路徑 |
-| `executor` | No | `claude`（預設）\| `gemini` \| `wingman`；頂層字串欄位。claude/gemini 以 auto-approve 跑 headless（gate 為信任邊界，見 SKILL.md § 邊界）；wingman 為本地 LLM 檔案驅動，需 `plan:` |
-| `backend` | No | `headless`（預設）\| `agentpager`；頂層字串欄位。`agentpager` 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）；bounded wait（逾 `timeout_sec` 收回 seat）。`executor` 映射為互動 worker CLI（claude\|gemini）；`agentpager` + `wingman` 不合法 |
-| `model` | No | 頂層字串欄位；派工者宣告本次執行用的 model。**會實際生效**：headless 帶 `-m`（gemini）/ `--model`（claude），`backend: agentpager` 則寫進 launch 檔的 `model:` 欄（由 agent-pager 的 registry 解析 alias）。缺省 = 沿用該 CLI 自己記住的預設。`executor: wingman` 為檔案驅動、無 model 旗標，該欄僅作 provenance。同時供收尾 auto-suggest 的 `X-Executor` trailer 填 `<model>` 段（缺省時退化為 executor-only） |
+| `executor` | No | `claude`（預設）\| `gemini` \| `wingman` \| `grok`；頂層字串欄位。claude/gemini/grok 以 auto-approve 跑 headless（gate 為信任邊界，見 SKILL.md § 邊界）；wingman 為本地 LLM 檔案驅動，需 `plan:` |
+| `backend` | No | `headless`（預設）\| `agentpager`；頂層字串欄位。`agentpager` 讓 gate worker 跑在 agent-pager 互動 local channel（tmux、可監看/接管），gate 以前景阻塞式 spawn+wait 等 per-attempt handoff 檔為完成訊號，回來後照常對現實驗收（gate 仍是唯一裁決來源）；bounded wait（逾 `timeout_sec` 收回 seat）。`executor` 映射為互動 worker CLI（claude\|gemini\|grok）；`agentpager` + `wingman` 不合法 |
+| `model` | No | 頂層字串欄位；派工者宣告本次執行用的 model。**會實際生效**：headless 帶 `-m`（gemini / grok）/ `--model`（claude），`backend: agentpager` 則寫進 launch 檔的 `model:` 欄（由 agent-pager 的 registry 解析 alias）。缺省 = 沿用該 CLI 自己記住的預設。`executor: wingman` 為檔案驅動、無 model 旗標，該欄僅作 provenance。同時供收尾 auto-suggest 的 `X-Executor` trailer 填 `<model>` 段（缺省時退化為 executor-only） |
 | `plan` | 僅 wingman | 與 `executor: wingman` 互為充要（缺一驗證失敗）；wingman plan.md 路徑，相對**本檔所在目錄**解析（同 `next:`），執行時轉絕對路徑傳給 `wingman execute --plan`。plan 依 wingman plan-template 紀律由派工者撰寫 |
 | `next` | No | 下一個 task.yaml 路徑；相對路徑以**本檔所在目錄**解析。**與 worker handoff frontmatter 的同名欄位不同型別**：那邊的 `next:` 是散文一行，在 `ccs-dispatch --chain`（非同步鏈）會被原樣拼進下一 hop 的 prompt。**`ccs-dispatch-run` 的 gated chain 只讀本檔的 `next:`，不讀 worker handoff**。在 handoff 寫路徑不會報錯，只會讓非同步鏈的下一個 worker 收到一行沒有語境的路徑 |
 | `execution_policy.loop_budget` | No | 重派上限；預設 1（共 2 attempts）；0 = 不重派。`executor: wingman` 一律視同 0（重派摘要走 prompt 前綴，wingman 吃不到；feedback 迴圈為 followup） |

--- a/tests/test-dispatch-env-scrub.sh
+++ b/tests/test-dispatch-env-scrub.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# tests/test-dispatch-env-scrub.sh — headless CLI child must not inherit
+# AGENT_PAGER_* from the orchestrator (issue #114). Evidence only goes to
+# the attempt / results tree; the child must not run pager hooks as the
+# parent slot.
+#
+# Two production sites share one helper: gate-run headless
+# (_ccs_dispatch_run_worker) and job-spawn (_ccs_dispatch_spawn_headless
+# sync). The async nohup path uses the same helper; test-dispatch.sh
+# covers that it still completes.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export XDG_DATA_HOME="$SCRIPT_DIR/tmp/test-dispatch-env-scrub-xdg"
+rm -rf "$XDG_DATA_HOME"; mkdir -p "$XDG_DATA_HOME"
+source "$SCRIPT_DIR/tests/fixture-helper.sh"
+source "$SCRIPT_DIR/ccs-dashboard.sh"
+
+WORK="$SCRIPT_DIR/tmp/test-dispatch-env-scrub"
+rm -rf "$WORK"; mkdir -p "$WORK/bin" "$WORK/repo" "$WORK/env"
+_TEST_DIRS+=("$WORK")
+(cd "$WORK/repo" && git init -q)
+
+# Fake CLI dumps the pager namespace + a marker, then exits 0.
+# FAKE_ENV_LOG is per-case so parallel-looking sequential cases do not mix.
+cat > "$WORK/bin/claude" <<'FAKE'
+#!/usr/bin/env bash
+{
+  printenv CCS_SCRUB_MARKER
+  printenv | grep '^AGENT_PAGER_' || true
+} > "${FAKE_ENV_LOG:?}"
+exit 0
+FAKE
+chmod +x "$WORK/bin/claude"
+cp "$WORK/bin/claude" "$WORK/bin/gemini"
+chmod +x "$WORK/bin/gemini"
+export PATH="$WORK/bin:$PATH"
+
+export AGENT_PAGER_NOTIFY=1
+export AGENT_PAGER_BOT_SLOT=9
+export AGENT_PAGER_SESSION_TREE=/x
+export CCS_SCRUB_MARKER=keep
+
+assert_parent_intact() {
+  assert_eq "parent keeps NOTIFY" "1" "${AGENT_PAGER_NOTIFY}"
+  assert_eq "parent keeps BOT_SLOT" "9" "${AGENT_PAGER_BOT_SLOT}"
+  assert_eq "parent keeps SESSION_TREE" "/x" "${AGENT_PAGER_SESSION_TREE}"
+}
+
+assert_child_scrubbed() {
+  local log="$1" label="$2"
+  local body
+  body="$(cat "$log" 2>/dev/null || true)"
+  assert_contains "$label: log is non-empty (marker is the lower bound)" \
+    "$body" "keep"
+  assert_eq "$label: child has no AGENT_PAGER_*" "" \
+    "$(printf '%s\n' "$body" | grep '^AGENT_PAGER_' || true)"
+}
+
+echo "=== gate-run headless child does not inherit AGENT_PAGER_* ==="
+export FAKE_ENV_LOG="$WORK/env/gate-run.log"
+: > "$FAKE_ENV_LOG"
+RUN="$WORK/run-gate"; rm -rf "$RUN"; mkdir -p "$RUN"
+_ccs_dispatch_run_worker "$WORK/repo" "do X" "$RUN" 1 60 claude
+assert_child_scrubbed "$FAKE_ENV_LOG" "gate-run"
+assert_parent_intact
+
+echo "=== job-spawn sync child does not inherit AGENT_PAGER_* ==="
+export FAKE_ENV_LOG="$WORK/env/job-sync.log"
+: > "$FAKE_ENV_LOG"
+_ccs_dispatch_spawn_headless "d-scrub-sync" "$WORK/repo" "do Y" 60 sync >/dev/null
+assert_child_scrubbed "$FAKE_ENV_LOG" "job-sync"
+assert_parent_intact
+
+echo "=== empty AGENT_PAGER_* namespace still spawns ==="
+export FAKE_ENV_LOG="$WORK/env/empty.log"
+: > "$FAKE_ENV_LOG"
+(
+  while IFS= read -r v; do unset "$v"; done < <(compgen -v AGENT_PAGER_ || true)
+  RUN="$WORK/run-empty"; rm -rf "$RUN"; mkdir -p "$RUN"
+  _ccs_dispatch_run_worker "$WORK/repo" "do Z" "$RUN" 1 60 claude
+)
+body="$(cat "$FAKE_ENV_LOG" 2>/dev/null || true)"
+assert_contains "empty-ns: CLI still ran" "$body" "keep"
+assert_eq "empty-ns: child has no AGENT_PAGER_*" "" \
+  "$(printf '%s\n' "$body" | grep '^AGENT_PAGER_' || true)"
+assert_parent_intact
+
+test_summary

--- a/tests/test-dispatch-executor-cli.sh
+++ b/tests/test-dispatch-executor-cli.sh
@@ -10,9 +10,9 @@ source "$SCRIPT_DIR/ccs-dashboard.sh"
 WORK="$SCRIPT_DIR/tmp/test-dispatch-executor-cli"
 rm -rf "$WORK"; mkdir -p "$WORK"; _TEST_DIRS+=("$WORK")
 
-# argv-recording shims for both CLIs, earlier on PATH than the real ones
+# argv-recording shims, earlier on PATH than the real ones
 BIN="$WORK/bin"; mkdir -p "$BIN"
-for c in claude gemini; do
+for c in claude gemini grok; do
   cat > "$BIN/$c" <<EOF
 #!/usr/bin/env bash
 echo "$c \$*" >> "$WORK/argv.log"
@@ -59,4 +59,28 @@ assert_not_contains "gemini keeps its own default" "$log_nom" " -m "
 : > "$WORK/argv.log"
 _ccs_dispatch_run_worker "$CWD" "do W" "$RUN" 1 60 claude
 assert_not_contains "claude keeps its own default" "$(cat "$WORK/argv.log")" "--model"
+
+echo "=== grok executor spawns grok -p ... --always-approve --output-format plain ==="
+: > "$WORK/argv.log"
+_ccs_dispatch_run_worker "$CWD" "do G" "$RUN" 1 60 grok
+log_gk="$(cat "$WORK/argv.log")"
+assert_contains "grok binary invoked" "$log_gk" "grok -p do G"
+assert_contains "grok always-approve" "$log_gk" "--always-approve"
+assert_contains "grok output-format plain" "$log_gk" "--output-format plain"
+assert_not_contains "grok did not call claude" "$log_gk" "claude -p"
+assert_not_contains "grok did not call gemini" "$log_gk" "gemini -p"
+
+echo "=== grok model pin / omit ==="
+: > "$WORK/argv.log"
+_ccs_dispatch_run_worker "$CWD" "do G" "$RUN" 1 60 grok "" headless "grok-4.6"
+assert_contains "grok gets -m" "$(cat "$WORK/argv.log")" "-m grok-4.6"
+: > "$WORK/argv.log"
+_ccs_dispatch_run_worker "$CWD" "do G" "$RUN" 1 60 grok
+# Exact argv, not " -m ": an empty `cmd+=(-m "$model")` logs a trailing
+# `-m` with no following space, which the substring miss would still pass.
+assert_eq "grok omit model exact argv" \
+  "grok -p do G --always-approve --output-format plain" \
+  "$(cat "$WORK/argv.log")"
+
+test_summary
 

--- a/tests/test-dispatch-executor-thread.sh
+++ b/tests/test-dispatch-executor-thread.sh
@@ -44,3 +44,10 @@ echo "=== omitted executor threads claude to worker ==="
 : > "$WORK/seen-executor.log"; rm -f "$CWD/done.txt"
 _ccs_dispatch_run "$(mk n.yaml '')" >/dev/null
 assert_eq "worker saw claude" "claude" "$(head -1 "$WORK/seen-executor.log")"
+
+echo "=== grok task threads grok to worker ==="
+: > "$WORK/seen-executor.log"; rm -f "$CWD/done.txt"
+_ccs_dispatch_run "$(mk k.yaml 'executor: grok')" >/dev/null
+assert_eq "worker saw grok" "grok" "$(head -1 "$WORK/seen-executor.log")"
+
+test_summary

--- a/tests/test-gate-agentpager.sh
+++ b/tests/test-gate-agentpager.sh
@@ -75,6 +75,20 @@ YAML
 _ccs_dispatch_gate_load_task "$WORK/apwing.yaml" >/dev/null 2>&1
 assert_eq "agentpager+wingman rejected" "1" "$?"
 
+echo "=== schema accepts backend: agentpager + executor: grok ==="
+cat > "$WORK/apgrok.yaml" <<YAML
+id: t
+goal: g
+backend: agentpager
+executor: grok
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    verify: { cmd: "true" }
+YAML
+_ccs_dispatch_gate_load_task "$WORK/apgrok.yaml" >/dev/null 2>&1
+assert_eq "agentpager+grok accepted" "0" "$?"
+
 # ── foreground wait helper ──────────────────────────────────────────────────
 echo "=== wait_and_collect: handoff appears -> rc 0, seat reclaimed, output collected ==="
 SEAT="$WORK/seat"; : > "$SEAT"
@@ -186,6 +200,35 @@ task_json="$(_ccs_dispatch_gate_load_task "$WORK/nomodel.yaml")"
 term="$(_ccs_dispatch_run_one "$task_json" "$WORK/nomodel.yaml" "$WORK/hop-nomodel")"
 assert_eq "no-model PASS term" "PASS" "$term"
 assert_eq "launch writer gets empty model" "" "$(head -1 "$MODELLOG")"
+
+echo "=== integration: executor grok reaches the launch file as cli ==="
+cat > "$WORK/grok.yaml" <<YAML
+id: gk
+goal: "make g"
+backend: agentpager
+executor: grok
+scope: { cwd: "$WORK/repo" }
+acceptance_criteria:
+  - id: AC1
+    text: "g exists"
+    verify: { cmd: "test -f g.txt" }
+YAML
+CLILOG="$WORK/clilog"
+: > "$CLILOG"; rm -f "$WORK/seat" "$WORK/repo/g.txt"; rm -f "$WORK/repo/tmp"/handoff-*.md
+_ccs_dispatch_agentpager_available() { return 0; }
+_ccs_dispatch_resolve_proj_from_dir() { echo "testproj"; }
+_ccs_dispatch_agentpager_session_alive() { [ -f "$WORK/seat" ]; }
+_ccs_dispatch_agentpager_stop_file() { rm -f "$WORK/seat"; echo "$WORK/stop"; }
+_ccs_dispatch_agentpager_launch_file() {
+  local sig="$1"; local cli="${6:-}"
+  mkdir -p "$WORK/repo/tmp"; : > "$WORK/seat"; : > "$WORK/repo/g.txt"
+  printf -- '---\nsummary: s\noutcome: done\n---\n' > "$WORK/repo/tmp/handoff-${sig}.md"
+  printf '%s\n' "$cli" >> "$CLILOG"; echo "$WORK/inbound-${sig}"
+}
+task_json="$(_ccs_dispatch_gate_load_task "$WORK/grok.yaml")"
+term="$(_ccs_dispatch_run_one "$task_json" "$WORK/grok.yaml" "$WORK/hop-grok")"
+assert_eq "grok PASS term" "PASS" "$term"
+assert_eq "launch writer gets cli=grok" "grok" "$(head -1 "$CLILOG")"
 
 echo "=== integration: attempt1 FAIL -> retry -> attempt2 PASS (Option B) ==="
 cat > "$WORK/retry.yaml" <<YAML

--- a/tests/test-gate-executor.sh
+++ b/tests/test-gate-executor.sh
@@ -26,6 +26,11 @@ js="$(_ccs_dispatch_gate_load_task "$(mk g.yaml 'executor: gemini')")"; rc=$?
 assert_eq "gemini rc 0" "0" "$rc"
 assert_eq "gemini parsed" "gemini" "$(echo "$js" | jq -r '.executor')"
 
+echo "=== executor: grok loads OK ==="
+js_g="$(_ccs_dispatch_gate_load_task "$(mk grok.yaml 'executor: grok')")"; rc_g=$?
+assert_eq "grok rc 0" "0" "$rc_g"
+assert_eq "grok parsed" "grok" "$(echo "$js_g" | jq -r '.executor')"
+
 echo "=== executor: claude loads OK ==="
 _ccs_dispatch_gate_load_task "$(mk c.yaml 'executor: claude')" >/dev/null 2>&1
 assert_eq "claude rc 0" "0" "$?"
@@ -48,3 +53,5 @@ assert_eq "wingman without plan -> rc 1" "1" "$?"
 echo "=== non-string executor -> rc 1 ==="
 _ccs_dispatch_gate_load_task "$(mk numeric.yaml 'executor: 123')" >/dev/null 2>&1
 assert_eq "numeric -> rc 1" "1" "$?"
+
+test_summary

--- a/tests/test-gate-worker-error.sh
+++ b/tests/test-gate-worker-error.sh
@@ -24,7 +24,7 @@ mkdir -p "$WORK/repo" "$WORK/bin"; _TEST_DIRS+=("$WORK")
 # comes from FAKE_CLI_EXIT so a "crash" is deterministic: 125/126/127 stand in
 # for timeout-itself-failed / not-executable / not-found, which in the real
 # world are produced by `timeout` and the shell rather than by the CLI.
-for c in claude gemini; do
+for c in claude gemini grok; do
   cat > "$WORK/bin/$c" <<'FAKE'
 #!/usr/bin/env bash
 echo "$0 $*" >> "$FAKE_CLI_LOG"
@@ -61,6 +61,12 @@ ad="$(spawn 2 0 gemini)"
 assert_contains "the gemini stub actually ran" \
   "$(cat "$FAKE_CLI_LOG")" "/bin/gemini -p do X"
 assert_eq "gemini rc 0 recorded" "0" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
+
+: > "$FAKE_CLI_LOG"
+ad="$(spawn 8 0 grok)"
+assert_contains "the grok stub actually ran" \
+  "$(cat "$FAKE_CLI_LOG")" "/bin/grok -p do X"
+assert_eq "grok rc 0 recorded" "0" "$(cat "$ad/executor-exit-code" 2>/dev/null)"
 
 echo "=== non-deterministic failures stay on the FAIL -> RETRY path ==="
 ad="$(spawn 3 1 claude)"


### PR DESCRIPTION
## Summary

gated dispatch 現在接受 `executor: grok`，並在所有 headless CLI child 清掉 orchestrator 的 `AGENT_PAGER_*`，避免 pager-launched 派工把 worker hooks 跑成父 slot 身分。grok 走獨立配額的 frontier worker；既有 task 不寫 grok 時行為不變。

## Changes

- headless spawn 抽出 `_ccs_dispatch_timeout_scrubbed`：`timeout` 包 `env -u` 整個 `AGENT_PAGER_*` namespace，只打 CLI child。gate-run 與 job-spawn（sync + nohup）共用；nohup wrapper 的 finish/wake 仍見 orchestrator env。
- task schema 白名單加 `grok`；spawn 臂為 `grok -p --always-approve --output-format plain`，有 `model` 才帶 `-m`。retry 同 claude/gemini。`backend: agentpager` + grok 合法；`ccs-dispatch --cli grok` 未改。
- 文件值集合對齊：`task-yaml.md`、`SKILL.md`、`docs/commands.md` gated 段、`AGENTS.md` CIA executor 清單與變體軸。

11 files, +227 / −26（`git diff --stat origin/master...HEAD`）。

## Test plan

- [x] schema 接受 `executor: grok`，未知值（`codex` / `gemeni`）仍拒絕
- [x] grok spawn 的 argv 含 `-p` / `--always-approve` / `--output-format plain`；有 model 才有 `-m`；省略 model 的整串 argv 不含 `-m`
- [x] task `executor: grok` 傳到 worker 第 6 參
- [x] `backend: agentpager` + grok 合法，launch 檔拿到 `cli=grok`；agentpager + wingman 仍拒絕
- [x] headless child 看不到 `AGENT_PAGER_*`，父行程仍在，無關 marker 仍繼承；gate-run 與 job-spawn sync 都蓋到
- [x] 空 `AGENT_PAGER_*` namespace 仍能 spawn
- [x] `ccs-dispatch --cli` help / case 仍只有 claude|gemini
- [x] `tests/run-all.sh` 全綠（既有 skip 除外）
- [ ] live grok CLI 當 gated worker（本 PR 刻意不燒配額）
- [ ] live `backend: agentpager` + grok daemon

## Test results

**Unit tests：**
`bash tests/run-all.sh` → Total: 53  Passed: 53  Failed: 0  Skipped: 1（`test-crash-detect.sh` live data，既有 skip）。

針對本變更另跑：`test-dispatch-env-scrub.sh`、`test-gate-executor.sh`、`test-dispatch-executor-cli.sh`、`test-dispatch-executor-thread.sh`、`test-gate-worker-error.sh`、`test-gate-agentpager.sh`、`test-dispatch.sh`（含 async E2E）。

Mutation（orchestrator）：拿掉 helper 的 `-u` → gate-run 與 job-sync 兩條紅；job-spawn 改回裸 `timeout` → 只有 job-sync 紅；jq 拿掉 grok → schema 紅；拿掉 `--output-format plain` → argv 紅；無條件空 `-m` → exact-argv 紅。

**E2E tests：**
N/A — 無獨立 E2E harness。`test-dispatch.sh` async 路徑有跑過（job 能 completed）；未 live spawn 真 grok。

**Smoke tests：**
N/A — 本機 CLI source，無 device / daemon 部署。grok 旗標對過本機 `grok --help`（`-p` / `-m` / `--always-approve` / `--output-format plain`）。

## Reviewer summary

Fresh-context（non-author）verdict：**approve-with-nits**，blocking 0。

N2（省略 model 的 `" -m "` 子字串偏弱）已收成 exact argv，折進 grok commit。N1（async nohup 沒有 child env dump）與 N3（grok retry 只間接測到）不擋 merge，見 Carry-forward。

Worklog Drift Log：no drift。

完整 report 貼為本 PR 的 review comment。

## Carry-forward

- async nohup child 的 `AGENT_PAGER_*` dump（N1）：production 字串有呼叫 helper，但 helper 名打錯時 async E2E 仍可能綠。
- grok FAIL→RETRY 的 integration case（N3）：程式只對 wingman clamp `loop_budget`；grok 路徑目前靠「不是 wingman」間接成立。
- `ccs-dispatch --cli grok`（非 gated job spawn）刻意不做。
- live grok dogfood：落地後另挑機械 + 硬 oracle 任務。

## Related

- Closes #114
- Closes #115
- Design / plan：worktree gitignored `internal/`（不進版控）

---
**Provenance**
- Model: Grok grok-4.6 · effort high
- Channel: Grok Build TUI(agent-pager Path B,telegram slot 3)